### PR TITLE
one more line for cache

### DIFF
--- a/kg_microbe/utils/download_utils.py
+++ b/kg_microbe/utils/download_utils.py
@@ -339,6 +339,7 @@ def get_uniprot_values_organism(organism_ids,
     if os.path.exists(empty_org_file):
         df = pd.read_csv(empty_org_file)
         empty_orgs = df[empty_org_file_header].tolist()
+        empty_orgs = list(map(str, empty_orgs))
 
     elif not os.path.exists(empty_org_file):
         empty_orgs = []


### PR DESCRIPTION
From Brook: Fixed local_name of uniprot items and fixed issue of not taking into account past organism IDs marked as empty from uniprot query in empty_organism_queries.tsv.