### PR TITLE
removed space from CAS-RN ID

### DIFF
--- a/kg_microbe/transform_utils/bacdive/tmp/bacdive_mappings.tsv
+++ b/kg_microbe/transform_utils/bacdive/tmp/bacdive_mappings.tsv
@@ -24,11 +24,11 @@ CHEBI:16551	D-trehalose (trehalose)	kegg.compound:C01083	CAS-RN:99-20-7			API_20
 						API_20A:GRAM	Gram
 						API_20A:COCC	"Morphology coccus=+"" rod=""-"""""
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_rID32A:URE	Urease/urea hydrolysis
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_rID32A:ADH (Arg)	Arginine dihydrolase
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_rID32A:ADH (Arg)	Arginine dihydrolase
 CHEBI:54684	4-Nitrophenyl-alpha-D-galactoside		CAS-RN:7493-95-0	EC:3.2.1.22	alpha-galactosidase	API_rID32A:alpha GAL	alpha-Galactosidase
 CHEBI:355715	4-Nitrophenyl-beta-D-galactoside	kegg.compound:C04452	CAS-RN:3150-24-1	EC:3.2.1.23	beta-galactosidase	API_rID32A:beta GAL	beta-Galactosidase
 CHEBI:90128	4-Nitrophenyl 6-O-phosphono-beta-D-galactosid					API_rID32A:beta GP	beta-Galactosidase 6-phosphate
-	4-Nitrophenyl alpha-D-glucopyranoside 		CAS-RN:3767-28-0 	EC:3.2.1.20	alpha-glucosidase	API_rID32A:alpha GLU	alpha-Glucosidase
+	4-Nitrophenyl alpha-D-glucopyranoside 		CAS-RN:3767-28-0	EC:3.2.1.20	alpha-glucosidase	API_rID32A:alpha GLU	alpha-Glucosidase
 	4-Nitrophenyl beta-D-glucopyranoside		CAS-RN:2492-87-7	EC:3.2.1.21	beta-glucosidase	API_rID32A:beta GLU	beta-Glucosidase
 	4-Nitrophenyl alpha-L-arabinofuranoside 		CAS-RN:6892-58-6	EC:3.2.1.55	non-reducing end alpha-L-arabinofuranosidase	API_rID32A:alpha ARA	alpha-Arabinosidase
 	4-Nitrophenyl beta-D-glucuronide 		CAS-RN:10344-94-2	EC:3.2.1.31	beta-glucuronidase	API_rID32A:beta GUR	beta-Glucuronidase
@@ -39,7 +39,7 @@ CHEBI:16015	L-glutamic acid	kegg.compound:C00025	CAS-RN:56-86-0	EC:4.1.1.15	Glut
 	4-Nitrophenyl alpha-L-fucopyranoside 		CAS-RN:10231-84-2	EC:3.2.1.51	alpha-L-fucosidase	API_rID32A:alpha FUC	alpha-Fucosidase
 CHEBI:63043	Potassium nitrate		CAS-RN:7757-79-1			API_rID32A:NIT	Reduction of nitrate
 CHEBI:16828	L-tryptophan	kegg.compound:C00078	CAS-RN:73-22-3	EC:4.1.99.1	tryptophanase	API_rID32A:IND	Indole production
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.1	alkaline phosphatase	API_rID32A:PAL	Alkaline phosphatase
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.1	alkaline phosphatase	API_rID32A:PAL	Alkaline phosphatase
 	L-arginine beta-naphthylamide hydrochloride		CAS-RN:18905-73-2			API_rID32A:ArgA	L-arginine arylamidase
 	L-proline beta-naphthylamide		CAS-RN:97216-16-5	EC:3.4.11.5	prolyl aminopeptidase	API_rID32A:ProA	Proline arylamidase
 	Leu-Gly beta-naphthylamide		CAS-RN:100930-00-5	EC:3.4.11.1	leucyl aminopeptidase	API_rID32A:LGA	Leucyl glycin arylamidase
@@ -54,14 +54,14 @@ CHEBI:16828	L-tryptophan	kegg.compound:C00078	CAS-RN:73-22-3	EC:4.1.99.1	tryptop
 	L-serine beta-naphthylamide		CAS-RN:888-74-4			API_rID32A:SerA	Serine arylamidase
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_CAM:URE	Urease/urea hydrolysis
 CHEBI:63043	Potassium nitrate		CAS-RN:7757-79-1			API_CAM:NIT	Reduction of nitrate
-	5-bromo-4-chloro-3-indolyl acetate 		CAS-RN:3252-36-6 			API_CAM:EST	Esterase
+	5-bromo-4-chloro-3-indolyl acetate 		CAS-RN:3252-36-6			API_CAM:EST	Esterase
 CHEBI:18089	Hippuric acid (N-benzoylglycine)	kegg.compound:C01586	CAS-RN:495-69-2			API_CAM:HIP	Hippuric acid
 	gamma-L-glutamyl-4-methoxy-2-naphthylamine		CAS-RN:24723-50-0	EC:2.3.2.2	gamma-glutamyltransferase	API_CAM:GGT	gamma-Glutamyl transferase
 CHEBI:78019	2,3,5-triphenyltetrazolium chloride	kegg.compound:C11305	CAS-RN:298-96-4			API_CAM:TTC	Reduction of Triphenyl tetrazolium chloride
 	L-pyroglutamic acid 2-naphthylamide 		CAS-RN:22155-91-5	EC:3.4.19.3	pyroglutamyl-peptidase I	API_CAM:PYRA	Pyrrolidonyl arylamidase
-	L-arginine-4-methoxy beta-naphthylamide		CAS-RN:61876-75-3 			API_CAM:ArgA	L-arginine arylamidase
-	L-aspartic acid beta-naphthylamide 		CAS-RN:635-91-6 			API_CAM:AspA	L-aspartic acid arylamidase
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.1	alkaline phosphatase	API_CAM:PAL	Alkaline phosphatase
+	L-arginine-4-methoxy beta-naphthylamide		CAS-RN:61876-75-3			API_CAM:ArgA	L-arginine arylamidase
+	L-aspartic acid beta-naphthylamide 		CAS-RN:635-91-6			API_CAM:AspA	L-aspartic acid arylamidase
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.1	alkaline phosphatase	API_CAM:PAL	Alkaline phosphatase
 						API_CAM:H2S	H2S production
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_CAM:GLU	Assimilation of D-glucose
 CHEBI:63675	Sodium succinate	kegg.compound:C00042 	CAS-RN:150-90-3			API_CAM:SUT	Assimilation of succinate
@@ -76,26 +76,26 @@ CHEBI:48923	Erythromycin					API_CAM:ERO	Erythromycin resistance (+) sensitivity
 CHEBI:90426	L-cystyl-2-naphthylamide		CAS-RN:65322-97-6		Cystine arylamidase	API_zym:Cystine arylamidase	
 	N-benzoyl-DL-arginine-2-naphthylamide		CAS-RN:0913-04-02	EC:3.4.21.4	Trypsin	API_zym:Trypsin	
 	N-glutaryl-phenylalanine-2-naphthylamide			EC:3.4.21.1	alpha-Chymotrypsin	API_zym:alpha- Chymotrypsin	
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.2	Acid phosphatase	API_zym:Acid phosphatase	
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.2	Acid phosphatase	API_zym:Acid phosphatase	
 	Naphthol-AS-BI-phosphate		CAS-RN:1919-91-1		Naphthol-AS-BI-phosphohydrolase	API_zym:Naphthol-AS-BI-phosphohydrolase	
 	6-Br-2-naphthyl-alphaD-galactpyranoside		CAS-RN:25997-59-5	EC:3.2.1.22	alpha-Galactosidase	API_zym:alpha- Galactosidase	
 	2-naphthyl-betaD-galactpyranoside		CAS-RN:312693-81-5	EC:3.2.1.23	beta-Galactosidase	API_zym:beta- Galactosidase	
-	Naphthol-AS-BI-betaD-glucuronide		CAS-RN:37-87-6 	EC:3.2.1.31	beta-Glucuronidase	API_zym:beta- Glucuronidase	
+	Naphthol-AS-BI-betaD-glucuronide		CAS-RN:37-87-6	EC:3.2.1.31	beta-Glucuronidase	API_zym:beta- Glucuronidase	
 	2-naphthyl-alphaD-glucopyranoside		CAS-RN:25320-79-0	EC:3.2.1.20	alpha-Glucosidase	API_zym:alpha- Glucosidase	
-	6-Br-2-naphthyl-betaD-glucopyranoside		CAS-RN: 15548-61-5 	EC:3.2.1.21	beta-Glucosidase	API_zym:beta- Glucosidase	
+	6-Br-2-naphthyl-betaD-glucopyranoside		CAS-RN:15548-61-5	EC:3.2.1.21	beta-Glucosidase	API_zym:beta- Glucosidase	
 	1-naphthyl-N-acetyl-betaD-glucosaminide		CAS-RN:10329-98-3	EC:3.2.1.52	N-acetyl-beta-glucosaminidase	API_zym:N-acetyl-beta- glucosaminidase	
 	6-Br-2-naphthyl-alphaD-mannopyranoside		CAS-RN:15548-61-5	EC:3.2.1.24	alpha-Mannosidase	API_zym:alpha- Mannosidase	
 	2-naphthyl-alphaL-fucopyranoside			EC:3.2.1.51	alpha-Fucosidase	API_zym:alpha- Fucosidase	
 	L-leucyl-2-naphthylamide		CAS-RN:732-85-4		Leucine arylamidase	API_zym:Leucine arylamidase	
-	L-valyl-2-naphthylamide		CAS-RN:729-24-8 		Valine arylamidase	API_zym:Valine arylamidase	
+	L-valyl-2-naphthylamide		CAS-RN:729-24-8		Valine arylamidase	API_zym:Valine arylamidase	
 	2-naphthyl myristate		CAS-RN:7262-80-8	EC:3.1.1.3	Lipase (C 14)	API_zym:Lipase (C 14)	
 	2-naphtyl caprylate		CAS-RN:10251-17-9		Esterase Lipase (C 8)	API_zym:Esterase Lipase (C 8)	
 	2-naphthyl butyrate		CAS-RN:5856-33-7	EC:3.1.1.1	Esterase (C 4)	API_zym:Esterase (C 4)	
 					Control	API_zym:Control	
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.1	Alkaline phosphatase	API_zym:Alkaline phosphatase	
-CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8 	EC:4.1.1.17	ornithine decarboxylase	API_ID32E:ODC	Ornithine decarboxylase
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_ID32E:ADH (Arg)	Arginine dihydrolase
-CHEBI:18019	L-lysine	kegg.compound:C00047	CAS-RN:56-87-1 	EC:4.1.1.18	Lysine decarboxylase	API_ID32E:LDC (Lys)	Lysine decarboxylase
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.1	Alkaline phosphatase	API_zym:Alkaline phosphatase	
+CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8	EC:4.1.1.17	ornithine decarboxylase	API_ID32E:ODC	Ornithine decarboxylase
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_ID32E:ADH (Arg)	Arginine dihydrolase
+CHEBI:18019	L-lysine	kegg.compound:C00047	CAS-RN:56-87-1	EC:4.1.1.18	Lysine decarboxylase	API_ID32E:LDC (Lys)	Lysine decarboxylase
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_ID32E:URE	Urease/urea hydrolysis
 CHEBI:18403	L-arabitol (L-arabinitol)	kegg.compound:C00532	CAS-RN:7643-75-6			API_ID32E:LARL	Acid from L-arabitol
 CHEBI:18024	D-galacturonic acid	kegg.compound:C00333	CAS-RN:685-73-4			API_ID32E:GAT	Acid from D-galacturonic acid
@@ -107,47 +107,47 @@ CHEBI:16899	D-mannitol	kegg.compound:C00392	CAS-RN:69-65-8			API_ID32E:MAN	Acid 
 CHEBI:17306	D-maltose (maltose)	kegg.compound:C00208	CAS-RN:69-79-4			API_ID32E:MAL	Acid from maltose
 CHEBI:15963	D-adonitol (D-ribitol)	kegg.compound:C00474	CAS-RN:488-81-3			API_ID32E:ADO	Acid from D-adonitol
 CHEBI:18394	Palatinose (6-O-alpha-D-glucopyranosyl-D-fruc	kegg.compound:C01742	CAS-RN:13718-94-0			API_ID32E:PLE	Acid from palatinose
-	4-Nitrophenyl beta-D-glucuronide 		CAS-RN:10344-94-2 	EC:3.2.1.31	beta-glucuronidase	API_ID32E:beta GUR	beta-Glucuronidase
+	4-Nitrophenyl beta-D-glucuronide 		CAS-RN:10344-94-2	EC:3.2.1.31	beta-glucuronidase	API_ID32E:beta GUR	beta-Glucuronidase
 CHEBI:62983	Sodium malonate	kegg.compound:C00383	CAS-RN:141-95-7			API_ID32E:MNT	Malonate
 CHEBI:16828	L-tryptophan	kegg.compound:C00078	CAS-RN:73-22-3	EC:4.1.99.1	tryptophanase	API_ID32E:IND	Indole production
-CHEBI:355715	5-Bromo-4-chloro-3-indolyl N-acetyl-beta-D-gl	kegg.compound:C04452	CAS-RN:4264-82-8 			API_ID32E:beta NAG	N-Acetyl-beta-Glucosaminidase
+CHEBI:355715	5-Bromo-4-chloro-3-indolyl N-acetyl-beta-D-gl	kegg.compound:C04452	CAS-RN:4264-82-8			API_ID32E:beta NAG	N-Acetyl-beta-Glucosaminidase
 CHEBI:355715	4-Nitrophenyl-beta-D-galactoside	kegg.compound:C04452	CAS-RN:3150-24-1	EC:3.2.1.23	beta-galactosidase	API_ID32E:beta GAL	beta-Galactosidase
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_ID32E:GLU	Acid from D-glucose
 CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_ID32E:SAC	Acid from sucrose
 CHEBI:30849	L-arabinose	kegg.compound:C00259	CAS-RN:147-81-9			API_ID32E:LARA	Acid from L-arabinose
-CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4 			API_ID32E:DARL	Acid from D-arabitol
-CHEBI:54684	4-Nitrophenyl alpha-D-glucopyranoside 		CAS-RN:3767-28-0 	EC:3.2.1.20	alpha-glucosidase	API_ID32E:alpha GLU	alpha-Glucosidase
+CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4			API_ID32E:DARL	Acid from D-arabitol
+CHEBI:54684	4-Nitrophenyl alpha-D-glucopyranoside 		CAS-RN:3767-28-0	EC:3.2.1.20	alpha-glucosidase	API_ID32E:alpha GLU	alpha-Glucosidase
 CHEBI:54684	4-Nitrophenyl-alpha-D-galactoside	kegg.compound:C01083	CAS-RN:7493-95-0	EC:3.2.1.22	alpha-galactosidase	API_ID32E:alpha GAL	alpha-Galactosidase
 CHEBI:16551	D-trehalose (trehalose)	kegg.compound:C01083	CAS-RN:99-20-7			API_ID32E:TRE	Acid from trehalose
 CHEBI:62345	L-rhamnose	kegg.compound:C00507	CAS-RN:73-34-7			API_ID32E:RHA	Acid from L-rhamnose
 CHEBI:17268	Inositol (myo-inositol)	kegg.compound:C00137	CAS-RN:87-89-8			API_ID32E:INO	Acid from inositol
 CHEBI:17057	D-cellobiose (cellobiose)	kegg.compound:C00185	CAS-RN:528-50-7			API_ID32E:CEL	Acid from cellobiose
 CHEBI:17924	D-sorbitol (D-glucitol)	kegg.compound:C00794	CAS-RN:50-70-4			API_ID32E:SOR	Acid from sorbitol
-	4-Nitrophenyl alpha-D-maltoside 		CAS-RN:17400-77-0 			API_ID32E:alphaMAL	alpha-Maltosidase
+	4-Nitrophenyl alpha-D-maltoside 		CAS-RN:17400-77-0			API_ID32E:alphaMAL	alpha-Maltosidase
 	L-aspartic acid 4-nitroanilide					API_ID32E:AspA	L-aspartic acid arylamidase
 CHEBI:50144	sodium pyruvate		CAS-RN:113-24-6			API_20STR:VP	Acetoin production (Voges Proskauer test)
 CHEBI:18089	Hippuric acid (N-benzoylglycine)	kegg.compound:C01586	CAS-RN:495-69-2			API_20STR:HIP	Hippuric acid hydrolysis
 CHEBI:4853	Esculin ferric citrate	kegg.compound:C09264	CAS-RN:531-75-9	EC:3.2.1.21	beta-glucosidase	API_20STR:ESC	Esculin hydrolysis/beta-glucosidase
 	L-pyroglutamic acid 2-naphthylamide 		CAS-RN:22155-91-5	EC:3.4.19.3	pyroglutamyl-peptidase I	API_20STR:PYRA	Pyrrolidonyl arylamidase
 	6-Bromo-2-naphthyl-alpha-D-galactopyranoside		CAS-RN:25997-59-5	EC:3.2.1.22	alpha-galactosidase	API_20STR:alpha GAL	alpha-Galactosidase
-	Naphthol AS-BI beta-D-glucuronide		CAS-RN:37-87-6 	EC:3.2.1.31	beta-glucuronidase	API_20STR:beta GUR	beta-Glucuronidase
+	Naphthol AS-BI beta-D-glucuronide		CAS-RN:37-87-6	EC:3.2.1.31	beta-glucuronidase	API_20STR:beta GUR	beta-Glucuronidase
 	2-Naphthyl-beta-D-galactopyranoside		CAS-RN:312693-81-5	EC:3.2.1.62	glycosylceramidase	API_20STR:beta GAL	beta-Galactosidase
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.1	alkaline phosphatase	API_20STR:PAL	Alkaline phosphatase
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.1	alkaline phosphatase	API_20STR:PAL	Alkaline phosphatase
 	L-leucine beta-naphthylamide		CAS-RN:732-85-4	EC:3.3.2.6	leukotriene-A4 hydrolase	API_20STR:LAP	Leucine arylamidase
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_20STR:ADH	Arginine dihydrolase
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_20STR:ADH	Arginine dihydrolase
 CHEBI:16988	D-ribose	kegg.compound:C00121	CAS-RN:50-69-1			API_20STR:RIB	Acid from D-ribose
 CHEBI:30849	L-arabinose	kegg.compound:C00259	CAS-RN:147-81-9			API_20STR:ARA	Acid from L-arabinose
 CHEBI:16899	D-mannitol	kegg.compound:C00392	CAS-RN:69-65-8			API_20STR:MAN	Acid from D-mannitol
 CHEBI:17924	D-sorbitol (D-glucitol)	kegg.compound:C00794	CAS-RN:50-70-4			API_20STR:SOR	Acid from D-sorbitol
 CHEBI:17716	D-lactose (lactose)	kegg.compound:C00243	CAS-RN:63-42-3			API_20STR:LAC	Acid from lactose
 CHEBI:16551	D-trehalose (trehalose)	kegg.compound:C01083	CAS-RN:99-20-7			API_20STR:TRE	Acid from trehalose
-CHEBI:15443	Inulin	kegg.compound:C03323	CAS-RN:9005-80-5 			API_20STR:INU	Acid from inulin
+CHEBI:15443	Inulin	kegg.compound:C03323	CAS-RN:9005-80-5			API_20STR:INU	Acid from inulin
 CHEBI:16634	D-raffinose (raffinose)	kegg.compound:C00492	CAS-RN:512-69-6			API_20STR:RAF	Acid from raffinose
 CHEBI:28017	Amidon (starch)	kegg.compound:C00369	CAS-RN:9005-25-8			API_20STR:AMD	Acid from starch
 CHEBI:28087	Glycogen	kegg.compound:C00182	CAS-RN:9005-79-2			API_20STR:GLYG	Acid from glycogen
 						API_20STR:beta HEM	beta hemolysis present
-	Naphthol AS-BI beta-D-glucuronide		CAS-RN:37-87-6 	EC:3.2.1.31	beta-glucuronidase	API_coryne:beta GUR	beta-Glucuronidase
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.1	alkaline phosphatase	API_coryne:PAL	Alkaline phosphatase
+	Naphthol AS-BI beta-D-glucuronide		CAS-RN:37-87-6	EC:3.2.1.31	beta-glucuronidase	API_coryne:beta GUR	beta-Glucuronidase
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.1	alkaline phosphatase	API_coryne:PAL	Alkaline phosphatase
 	L-pyroglutamic acid 2-naphthylamide 		CAS-RN:22155-91-5	EC:3.4.19.3	pyroglutamyl-peptidase I	API_coryne:PYRA	Pyrrolidonyl arylamidase
 CHEBI:45285	Pyrazinecarboxamide	kegg.compound:C01956	CAS-RN:98-96-4	EC:3.5.1.B15	pyrazinamidase	API_coryne:PYZ	Pyrazinamidase
 CHEBI:63043	Potassium nitrate		CAS-RN:7757-79-1			API_coryne:NIT	Reduction of nitrate
@@ -168,11 +168,11 @@ CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_cor
 CHEBI:28087	Glycogen	kegg.compound:C00182	CAS-RN:9005-79-2			API_coryne:GLYG	Fermentation of glycogen
 				EC:1.11.1.6	catalase	API_coryne:CAT	Catalase
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_ID32STA:URE	Urease/urea hydrolysis
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_ID32STA:ADH (Arg)	Arginine dihydrolase
-CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8 	EC:4.1.1.17	ornithine decarboxylase	API_ID32STA:ODC	Ornithine decarboxylase
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_ID32STA:ADH (Arg)	Arginine dihydrolase
+CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8	EC:4.1.1.17	ornithine decarboxylase	API_ID32STA:ODC	Ornithine decarboxylase
 CHEBI:4853	Esculin ferric citrate	kegg.compound:C09264	CAS-RN:531-75-9	EC:3.2.1.21	beta-glucosidase	API_ID32STA:ESC	Esculin hydrolysis
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_ID32STA:GLU	Fermentation of D-glucose
-CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7 			API_ID32STA:FRU	Fermentation of D-fructose
+CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7			API_ID32STA:FRU	Fermentation of D-fructose
 CHEBI:16024	D-mannose	kegg.compound:C00159	CAS-RN:3458-28-4			API_ID32STA:MNE	Fermentation of D-mannose
 CHEBI:17306	D-maltose (maltose)	kegg.compound:C00208	CAS-RN:69-79-4			API_ID32STA:MAL	Fermentation of maltose
 CHEBI:17716	D-lactose (lactose)	kegg.compound:C00243	CAS-RN:63-42-3			API_ID32STA:LAC	Fermentation of lactose
@@ -183,34 +183,34 @@ CHEBI:16988	D-ribose	kegg.compound:C00121	CAS-RN:50-69-1			API_ID32STA:RIB	Ferme
 CHEBI:17057	D-cellobiose (cellobiose)	kegg.compound:C00185	CAS-RN:528-50-7			API_ID32STA:CEL	Fermentation of cellobiose
 CHEBI:63043	Potassium nitrate		CAS-RN:7757-79-1			API_ID32STA:NIT	Reduction of nitrate
 CHEBI:50144	sodium pyruvate		CAS-RN:113-24-6			API_ID32STA:VP	Acetoin production (Voges Proskauer test)
-	2-Naphthyl-beta-D-galactopyranoside		CAS-RN:312693-81-5 	EC:3.2.1.23	beta-galactosidase	API_ID32STA:beta GAL	beta-Galactosidase
-	L-arginine beta-naphthylamide hydrochloride		CAS-RN:18905-73-2 			API_ID32STA:ArgA	L-arginine arylamidase
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.1	alkaline phosphatase	API_ID32STA:PAL	Alkaline phosphatase
-	L-pyroglutamic acid 2-naphthylamide 		CAS-RN:22155-91-5 	EC:3.4.19.3	pyroglutamyl-peptidase I	API_ID32STA:PyrA	Pyrrolidonyl arylamidase
+	2-Naphthyl-beta-D-galactopyranoside		CAS-RN:312693-81-5	EC:3.2.1.23	beta-galactosidase	API_ID32STA:beta GAL	beta-Galactosidase
+	L-arginine beta-naphthylamide hydrochloride		CAS-RN:18905-73-2			API_ID32STA:ArgA	L-arginine arylamidase
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.1	alkaline phosphatase	API_ID32STA:PAL	Alkaline phosphatase
+	L-pyroglutamic acid 2-naphthylamide 		CAS-RN:22155-91-5	EC:3.4.19.3	pyroglutamyl-peptidase I	API_ID32STA:PyrA	Pyrrolidonyl arylamidase
 CHEBI:28368	Novobiocin	kegg.compound:C05080	CAS-RN:303-81-1			API_ID32STA:NOVO	Novobiocin resistance
 CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_ID32STA:SAC	Fermentation of sucrose
-CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6 			API_ID32STA:NAG	Fermentation of N-acetyl-glucosamine
+CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6			API_ID32STA:NAG	Fermentation of N-acetyl-glucosamine
 CHEBI:32528	D-turanose (turanose)	kegg.compound:C19636	CAS-RN:547-25-1			API_ID32STA:TUR	Fermentation of turanose
 CHEBI:30849	L-arabinose	kegg.compound:C00259	CAS-RN:147-81-9			API_ID32STA:ARA	Fermentation of arabinose
-	4-Nitrophenyl beta-D-glucuronide 		CAS-RN:10344-94-2 	EC:3.2.1.31	beta-glucuronidase	API_ID32STA:beta GUR	beta-Glucuronidase
+	4-Nitrophenyl beta-D-glucuronide 		CAS-RN:10344-94-2	EC:3.2.1.31	beta-glucuronidase	API_ID32STA:beta GUR	beta-Glucuronidase
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_STA:GLU	Acid from D-glucose
-CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7 			API_STA:FRU	Acid from D-fructose
+CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7			API_STA:FRU	Acid from D-fructose
 CHEBI:16024	D-mannose	kegg.compound:C00159	CAS-RN:3458-28-4			API_STA:MNE	Acid from D-mannose
 CHEBI:17306	D-maltose (maltose)	kegg.compound:C00208	CAS-RN:69-79-4			API_STA:MAL	Acid from maltose
 CHEBI:17716	D-lactose (lactose)	kegg.compound:C00243	CAS-RN:63-42-3			API_STA:LAC	Acid from lactose
 CHEBI:16551	D-trehalose (trehalose)	kegg.compound:C01083	CAS-RN:99-20-7			API_STA:TRE	Acid from trehalose
 CHEBI:16899	D-mannitol	kegg.compound:C00392	CAS-RN:69-65-8			API_STA:MAN	Acid from D-mannitol
 CHEBI:17151	Xylitol	kegg.compound:C00503	CAS-RN:149-32-6			API_STA:XLT	Acid from xylitol
-CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9 			API_STA:MEL	Acid from melibiose
+CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9			API_STA:MEL	Acid from melibiose
 CHEBI:63043	Potassium nitrate		CAS-RN:7757-79-1			API_STA:NIT	Reduction of nitrate
-	2-naphthyl phosphate		CAS-RN:14463-68-4 	EC:3.1.3.1	alkaline phosphatase	API_STA:PAL	Alkaline phosphatase
+	2-naphthyl phosphate		CAS-RN:14463-68-4	EC:3.1.3.1	alkaline phosphatase	API_STA:PAL	Alkaline phosphatase
 CHEBI:50144	sodium pyruvate		CAS-RN:113-24-6			API_STA:VP	Acetoin production (Voges Proskauer test)
 CHEBI:16634	D-raffinose (raffinose)	kegg.compound:C00492	CAS-RN:512-69-6			API_STA:RAF	Acid from raffinose
 CHEBI:65327	D-xylose	kegg.compound:C00181	CAS-RN:58-86-6			API_STA:XYL	Acid from D-xylose
 CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_STA:SAC	Acid from sucrose
 CHEBI:320061	Methyl alpha-D-glucopyranoside		CAS-RN:709-50-2			API_STA:MDG	Acid from methyl-alpha-D-glucopyranoside
-CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6 			API_STA:NAG	Acid from N-acetyl-glucosamine
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_STA:ADH	Arginine dihydrolase
+CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6			API_STA:NAG	Acid from N-acetyl-glucosamine
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_STA:ADH	Arginine dihydrolase
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_STA:URE	Urease/urea hydrolysis
 				EC:3.4.24.75	Lysostaphin	API_STA:LSTR	Resistance to lysostaphin (EC 3.4.24.75)
 						API_STA:Control	
@@ -226,7 +226,7 @@ CHEBI:15963	D-adonitol (D-ribitol)	kegg.compound:C00474	CAS-RN:488-81-3			API_50
 CHEBI:74863	Methyl beta-D-xylopyranoside		CAS-RN:0612-05-05			API_50CHas:MDX	Assimilation of methyl beta-D-xylopyranoside
 CHEBI:12936	D-galactose	kegg.compound:C00124	CAS-RN:59-23-4			API_50CHas:GAL	Assimilation of D-galactose
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_50CHas:GLU	Assimilation of D-glucose
-CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7 			API_50CHas:FRU	Assimilation of D-fructose
+CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7			API_50CHas:FRU	Assimilation of D-fructose
 CHEBI:16024	D-mannose	kegg.compound:C00159	CAS-RN:3458-28-4			API_50CHas:MNE	Assimilation of D-mannose
 CHEBI:17266	L-sorbose	kegg.compound:C00247	CAS-RN:87-79-6			API_50CHas:SBE	Assimilation of L-sorbose
 CHEBI:62345	L-rhamnose	kegg.compound:C00507	CAS-RN:73-34-7			API_50CHas:RHA	Assimilation of L-rhamnose
@@ -236,35 +236,35 @@ CHEBI:16899	D-mannitol	kegg.compound:C00392	CAS-RN:69-65-8			API_50CHas:MAN	Assi
 CHEBI:17924	D-sorbitol (D-glucitol)	kegg.compound:C00794	CAS-RN:50-70-4			API_50CHas:SOR	Assimilation of sorbitol
 CHEBI:43943	Methyl alpha-D-mannopyranoside (methyl alpha-		CAS-RN:25281-48-5			API_50CHas:MDM	Assimilation of methyl alpha-D-mannopyranoside
 CHEBI:320061	Methyl alpha-D-glucopyranoside		CAS-RN:709-50-2			API_50CHas:MDG	Assimilation of  methyl alpha-D-glucopyranoside
-CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6 			API_50CHas:NAG	Assimilation of N-acetyl-glucosamine
-CHEBI:27613	Amygdalin	kegg.compound:C08325	CAS-RN:29883-15-6 			API_50CHas:AMY	Assimilation of amygdalin
+CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6			API_50CHas:NAG	Assimilation of N-acetyl-glucosamine
+CHEBI:27613	Amygdalin	kegg.compound:C08325	CAS-RN:29883-15-6			API_50CHas:AMY	Assimilation of amygdalin
 CHEBI:18305	Arbutin (hydroquinone O-beta-D-glucopyranosid	kegg.compound:C06186	CAS-RN:497-76-7			API_50CHas:ARB	Assimilation of arbutin
 CHEBI:4853	Esculin ferric citrate	kegg.compound:C09264	CAS-RN:531-75-9			API_50CHas:ESC	Assimilation of esculin
 CHEBI:17814	Salicin	kegg.compound:C01451	CAS-RN:138-52-3			API_50CHas:SAL	Assimilation of salicin
 CHEBI:17057	D-cellobiose (cellobiose)	kegg.compound:C00185	CAS-RN:528-50-7			API_50CHas:CEL	Assimilation of cellobiose
 CHEBI:17306	D-maltose (maltose)	kegg.compound:C00208	CAS-RN:69-79-4			API_50CHas:MAL	Assimilation of maltose
 CHEBI:17716	D-lactose (lactose)	kegg.compound:C00243	CAS-RN:63-42-3			API_50CHas:LAC	Assimilation of lactose
-CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9 			API_50CHas:MEL	Assimilation of melibiose
+CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9			API_50CHas:MEL	Assimilation of melibiose
 CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_50CHas:SAC	Assimilation of sucrose
 CHEBI:16551	D-trehalose (trehalose)	kegg.compound:C01083	CAS-RN:99-20-7			API_50CHas:TRE	Assimilation of trehalose
-CHEBI:15443	Inulin	kegg.compound:C03323	CAS-RN:9005-80-5 			API_50CHas:INU	Assimilation of inulin
+CHEBI:15443	Inulin	kegg.compound:C03323	CAS-RN:9005-80-5			API_50CHas:INU	Assimilation of inulin
 CHEBI:6731	D-melezitose (melezitose)	kegg.compound:C08243	CAS-RN:0597-12-06			API_50CHas:MLZ	Assimilation of melezitose
 CHEBI:16634	D-raffinose (raffinose)	kegg.compound:C00492	CAS-RN:512-69-6			API_50CHas:RAF	Assimilation of raffinose
 CHEBI:28017	Amidon (starch)	kegg.compound:C00369	CAS-RN:9005-25-8			API_50CHas:AMD	Assimilation of starch
 CHEBI:28087	Glycogen	kegg.compound:C00182	CAS-RN:9005-79-2			API_50CHas:GLYG	Assimilation of glycogen
 CHEBI:17151	Xylitol	kegg.compound:C00503	CAS-RN:149-32-6			API_50CHas:XLT	Assimilation of xylitol
-CHEBI:28066	Gentiobiose	kegg.compound:C08240	CAS-RN:554-91-6 			API_50CHas:GEN	Assimilation of gentiobiose
+CHEBI:28066	Gentiobiose	kegg.compound:C08240	CAS-RN:554-91-6			API_50CHas:GEN	Assimilation of gentiobiose
 CHEBI:32528	D-turanose (turanose)	kegg.compound:C19636	CAS-RN:547-25-1			API_50CHas:TUR	Assimilation of turanose
 CHEBI:62318	D-lyxose		CAS-RN:65-42-9			API_50CHas:LYX	Assimilation of D-lyxose
 CHEBI:16443	D-tagatose	kegg.compound:C00796	CAS-RN:87-81-1			API_50CHas:TAG	Assimilation of D-tagatose
 CHEBI:28847	D-fucose					API_50CHas:DFUC	Assimilation of D-fucose
 CHEBI:18287	L-Fucose		CAS-RN:2438-80-4			API_50CHas:LFUC	Assimilation of L-fucose
-CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4 			API_50CHas:DARL	Assimilation of D-arabitol
+CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4			API_50CHas:DARL	Assimilation of D-arabitol
 CHEBI:18403	L-arabitol (L-arabinitol)	kegg.compound:C00532	CAS-RN:7643-75-6			API_50CHas:LARL	Assimilation of L-arabitol
 CHEBI:33198	Gluconate (D-gluconic acid)	kegg.compound:C00257	CAS-RN:526-95-4			API_50CHas:GNT	Assimilation of gluconate
 CHEBI:16808	2-Ketogluconate (2-dehydro-D-gluconate)	kegg.compound:C06473	CAS-RN:669-90-9			API_50CHas:2KG	Assimilation of 2-Ketogluconate
 CHEBI:17426	5-Ketogluconate (5-dehydro-D-gluconate)	kegg.compound:C01062				API_50CHas:5KG	Assimilation of 5-Ketogluconate
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_rID32STR:ADH (Arg)	Arginine dihydrolase
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_rID32STR:ADH (Arg)	Arginine dihydrolase
 	Resorufin beta-D-glucopyranoside		CAS-RN:101490-85-1	EC:3.2.1.21	beta-glucosidase	API_rID32STR:beta GLU	beta-Glucosidase
 	Resorufin beta-D-galactopyranoside		CAS-RN:95079-19-9	EC:3.2.1.23	beta-galactosidase	API_rID32STR:beta GAR	beta-Galactosidase
 	Resorufin beta-D-glucuronide		CAS-RN:125440-91-7	EC:3.2.1.31	beta-glucuronidase	API_rID32STR:beta GUR	beta-Glucuronidase
@@ -278,19 +278,19 @@ CHEBI:16551	D-trehalose (trehalose)	kegg.compound:C01083	CAS-RN:99-20-7			API_rI
 CHEBI:16634	D-raffinose (raffinose)	kegg.compound:C00492	CAS-RN:512-69-6			API_rID32STR:RAF	Acid from raffinose
 CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_rID32STR:SAC	Acid from sucrose
 CHEBI:30849	L-arabinose	kegg.compound:C00259	CAS-RN:147-81-9			API_rID32STR:LARA	Acid from L-arabinose
-CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4 			API_rID32STR:DARL	Acid from D-arabitol
+CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4			API_rID32STR:DARL	Acid from D-arabitol
 CHEBI:40585	alpha-cyclodextrin		CAS-RN:10016-20-3			API_rID32STR:CDEX	Acid from alpha-cyclodextrin
 CHEBI:50144	sodium pyruvate		CAS-RN:113-24-6			API_rID32STR:VP	Acetoin production (Voges Proskauer test)
 	Ala-Phe-Pro beta-naphthylamide					API_rID32STR:APPA	Alanyl-Phenylalanyl-Proline arylamidase
-	2-Naphthyl-beta-D-galactopyranoside		CAS-RN:312693-81-5 	EC:3.2.1.23	beta-galactosidase	API_rID32STR:beta GAL	beta-Galactosidase
-	L-pyroglutamic acid 2-naphthylamide 		CAS-RN:22155-91-5 	EC:3.4.19.3	pyroglutamyl-peptidase I	API_rID32STR:PyrA	Pyrrolidonyl arylamidase
+	2-Naphthyl-beta-D-galactopyranoside		CAS-RN:312693-81-5	EC:3.2.1.23	beta-galactosidase	API_rID32STR:beta GAL	beta-Galactosidase
+	L-pyroglutamic acid 2-naphthylamide 		CAS-RN:22155-91-5	EC:3.4.19.3	pyroglutamyl-peptidase I	API_rID32STR:PyrA	Pyrrolidonyl arylamidase
 	6-Bromo-2-naphthyl-N-acetyl-beta-D-glucosamin					API_rID32STR:beta NAG	N-Acetyl-glucosaminidase
 	Gly-Trp beta-naphthylamide					API_rID32STR:GTA	Glycyl-tryptophan arylamidase
 CHEBI:18089	Hippuric acid (N-benzoylglycine)	kegg.compound:C01586	CAS-RN:495-69-2			API_rID32STR:HIP	Hydrolysis of hippuric acid
 CHEBI:28087	Glycogen	kegg.compound:C00182	CAS-RN:9005-79-2			API_rID32STR:GLYG	Acid from glycogen
 	Pullulan	kegg.compound:C00480	CAS-RN:2614080			API_rID32STR:PUL	Acid from pullulan
 CHEBI:17306	D-maltose (maltose)	kegg.compound:C00208	CAS-RN:69-79-4			API_rID32STR:MAL	Acid from maltose
-CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9 			API_rID32STR:MEL	Acid from melibiose
+CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9			API_rID32STR:MEL	Acid from melibiose
 CHEBI:6731	D-melezitose (melezitose)	kegg.compound:C08243	CAS-RN:0597-12-06			API_rID32STR:MLZ	Acid from melezitose
 CHEBI:320055	Methyl beta-D-glucopyranoside		CAS-RN:709-50-2			API_rID32STR:Mbeta DG	Acidification of methyl beta-D-glucopyranoside
 CHEBI:16443	D-tagatose	kegg.compound:C00798	CAS-RN:87-81-3			API_rID32STR:TAG	Acid from D-tagatose
@@ -298,10 +298,10 @@ CHEBI:16443	D-tagatose	kegg.compound:C00798	CAS-RN:87-81-3			API_rID32STR:TAG	Ac
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_rID32STR:URE	Urease/urea hydrolysis
 CHEBI:7963	Benzylpenicillin potassium		CAS-RN:113-98-4	EC:3.5.2.6	beta-lactamase	API_NH:PEN	Penicillinase production
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_NH:GLU	Acid from D-glucose
-CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7 			API_NH:FRU	Acid from D-fructose
+CHEBI:15824	D-fructose	kegg.compound:C00095	CAS-RN:57-48-7			API_NH:FRU	Acid from D-fructose
 CHEBI:17306	D-maltose (maltose)	kegg.compound:C00208	CAS-RN:69-79-4			API_NH:MAL	Acid from maltose
 CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_NH:SAC	Acid from sucrose
-CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8 	EC:4.1.1.17	ornithine decarboxylase	API_NH:ODC	Ornithine decarboxylase
+CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8	EC:4.1.1.17	ornithine decarboxylase	API_NH:ODC	Ornithine decarboxylase
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_NH:URE	Urease/urea hydrolysis
 	5-bromo-3-indolyl-decanoate		CAS-RN:133950-71-7	EC:3.1.1.3	triacylglycerol lipase	API_NH:LIP	Lipase
 CHEBI:1744	Para-nitrophenylphosphate (4-nitrophenyl phos	kegg.compound:C03360	CAS-RN:330-13-2	EC:3.1.3.1	alkaline phosphatase	API_NH:PAL	Alkaline phosphatase
@@ -311,8 +311,8 @@ CHEBI:355715	4-Nitrophenyl-beta-D-galactoside	kegg.compound:C04452	CAS-RN:3150-2
 CHEBI:16828	L-tryptophan	kegg.compound:C00078	CAS-RN:73-22-3	EC:4.1.99.1	tryptophanase	API_NH:IND	Indole production
 						API_LIST:DIM	Differentiation L. innocura(+)/ L.monoytogenes(-)
 CHEBI:4853	Esculin ferric citrate	kegg.compound:C09264	CAS-RN:531-75-9	EC:3.2.1.21	beta-glucosidase	API_LIST:ESC	Esculin hydrolysis
-	4-Nitrophenyl alpha-D-mannopyranoside 		CAS-RN:10357-27-4 	EC:3.2.1.24	alpha-mannosidase	API_LIST:alpha MAN	alpha-Mannosidase
-CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4 			API_LIST:DARL	Acid from D-arabitol
+	4-Nitrophenyl alpha-D-mannopyranoside 		CAS-RN:10357-27-4	EC:3.2.1.24	alpha-mannosidase	API_LIST:alpha MAN	alpha-Mannosidase
+CHEBI:18333	D-arabitol	kegg.compound:C01904	CAS-RN:488-82-4			API_LIST:DARL	Acid from D-arabitol
 CHEBI:65327	D-xylose	kegg.compound:C00181	CAS-RN:58-86-6			API_LIST:XYL	Acid from D-xylose
 CHEBI:62345	L-rhamnose	kegg.compound:C00507	CAS-RN:73-34-7			API_LIST:RHA	Acid from L-rhamnose
 CHEBI:320061	Methyl alpha-D-glucopyranoside		CAS-RN:709-50-2			API_LIST:MDG	Acid from methyl-alpha-D-glucopyranoside
@@ -321,9 +321,9 @@ CHEBI:29042	alpha-D-glucose 1-phosphate	kegg.compound:C00103	CAS-RN:59-56-3			AP
 CHEBI:16443	D-tagatose	kegg.compound:C00797	CAS-RN:87-81-2			API_LIST:TAG	Acid from D-tagatose
 						API_LIST:beta HEM	beta hemolysis present
 CHEBI:30769	Citric acid	kegg.compound:C00158	CAS-RN:77-92-9			API_20E:CIT	Citrate utilization
-CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8 	EC:4.1.1.17	ornithine decarboxylase	API_20E:ODC	Ornithine decarboxylase
-CHEBI:18019	L-lysine	kegg.compound:C00047	CAS-RN:56-87-1 	EC:4.1.1.18	Lysine decarboxylase	API_20E:LDC (Lys)	Lysine decarboxylase
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_20E:ADH (Arg)	Arginine dihydrolase
+CHEBI:15729	L-ornithine	kegg.compound:C00077	CAS-RN:70-26-8	EC:4.1.1.17	ornithine decarboxylase	API_20E:ODC	Ornithine decarboxylase
+CHEBI:18019	L-lysine	kegg.compound:C00047	CAS-RN:56-87-1	EC:4.1.1.18	Lysine decarboxylase	API_20E:LDC (Lys)	Lysine decarboxylase
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_20E:ADH (Arg)	Arginine dihydrolase
 CHEBI:90144	o-nitrophenyl-beta-D-galactopyranosid		CAS-RN:0369-07-03	EC:3.2.1.23	beta-galactosidase	API_20E:ONPG	beta-Galactosidase
 						API_20E:H2S	H2S production
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_20E:URE	Urease/urea hydrolysis
@@ -337,8 +337,8 @@ CHEBI:17268	Inositol (myo-inositol)	kegg.compound:C00137	CAS-RN:87-89-8			API_20
 CHEBI:17924	D-sorbitol (D-glucitol)	kegg.compound:C00794	CAS-RN:50-70-4			API_20E:Sor	Fermentation/oxidation of sorbitol
 CHEBI:62345	L-rhamnose	kegg.compound:C00507	CAS-RN:73-34-7			API_20E:RHA	Fermentation/oxidation of L-rhamnose
 CHEBI:17992	D-saccharose (sucrose)	kegg.compound:C00089	CAS-RN:57-50-1			API_20E:SAC	Fermentation/oxidation of sucrose
-CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9 			API_20E:MEL	Fermentation/oxidation of melibiose
-CHEBI:27613	Amygdalin	kegg.compound:C08325	CAS-RN:29883-15-6 			API_20E:AMY	Fermentation/oxidation of amygdalin
+CHEBI:28053	D-melibiose (melibiose)	kegg.compound:C05402	CAS-RN:585-99-9			API_20E:MEL	Fermentation/oxidation of melibiose
+CHEBI:27613	Amygdalin	kegg.compound:C08325	CAS-RN:29883-15-6			API_20E:AMY	Fermentation/oxidation of amygdalin
 CHEBI:30849	L-arabinose	kegg.compound:C00259	CAS-RN:147-81-9			API_20E:ARA	Fermentation/oxidation of L-arabinose
 CHEBI:26689	Oxygen			EC:EC 1.9.3.1	cytochrome-c oxidase	API_20E:OX	Cytochrome oxidase
 CHEBI:63043	Potassium nitrate		CAS-RN:7757-79-1			API_20E:NO2	Nitrite production
@@ -349,7 +349,7 @@ CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_20E:OF-O	Oxidati
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_20E:OF-F	Fermentation of D-glucose
 CHEBI:4853	Esculin ferric citrate	kegg.compound:C09264	CAS-RN:531-75-9	EC:3.2.1.21	beta-glucosidase	API_20NE:ESC	Esculin hydrolysis/beta-Glucosidase
 CHEBI:16199	Urea	kegg.compound:C00086	CAS-RN:57-13-6	EC:3.5.1.5	Urease	API_20NE:URE	Urease/urea hydrolysis
-CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3 	EC:3.5.3.6	arginine deiminase	API_20NE:ADH (Arg)	Arginine dihydrolase
+CHEBI:16467	L-arginine	kegg.compound:C00062	CAS-RN:74-79-3	EC:3.5.3.6	arginine deiminase	API_20NE:ADH (Arg)	Arginine dihydrolase
 CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_20NE:GLU_ Ferm	Fermentation of D-glucose
 CHEBI:16828	L-tryptophan	kegg.compound:C00078	CAS-RN:73-22-3	EC:4.1.99.1	tryptophanase	API_20NE:TRP	Indole production
 CHEBI:63043	Potassium nitrate		CAS-RN:7757-79-1			API_20NE:NO3	Reduction of nitrates
@@ -359,7 +359,7 @@ CHEBI:17634	D-glucose	kegg.compound:C00031	CAS-RN:50-99-7			API_20NE:GLU_ Assim	
 CHEBI:30849	L-arabinose	kegg.compound:C00259	CAS-RN:147-81-9			API_20NE:ARA	Assimilation of L-arabinose
 CHEBI:16024	D-mannose	kegg.compound:C00159	CAS-RN:3458-28-4			API_20NE:MNE	Assimilation of D-mannose
 CHEBI:16899	D-mannitol	kegg.compound:C00392	CAS-RN:69-65-8			API_20NE:MAN	Assimilation of D-mannitol
-CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6 			API_20NE:NAG	Assimilation of N-acetyl-glucosamine
+CHEBI:506227	N-acetyl-D-glucosamine	kegg.compound:C00140	CAS-RN:7512-17-6			API_20NE:NAG	Assimilation of N-acetyl-glucosamine
 CHEBI:17306	D-maltose (maltose)	kegg.compound:C00208	CAS-RN:69-79-4			API_20NE:MAL	Assimilation of maltose
 CHEBI:33198	Gluconate (D-gluconic acid)	kegg.compound:C00257	CAS-RN:526-95-4			API_20NE:GNT	Assimilation of gluconate
 CHEBI:30813	Capric acid (decanoic acid)	kegg.compound:C01571	CAS-RN:334-48-5			API_20NE:CAP	Assimilation of capric acid

--- a/notebooks/bacdive_mapping_resource.ipynb
+++ b/notebooks/bacdive_mapping_resource.ipynb
@@ -15,22 +15,7 @@
    "execution_count": 2,
    "id": "5442f7dd-e283-429d-b861-5e875e177101",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/j5/bzs7jjf12j998fm88l0ssg740000gp/T/ipykernel_15508/4075657387.py:1: DeprecationWarning: \n",
-      "Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),\n",
-      "(to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)\n",
-      "but was not found to be installed on your system.\n",
-      "If this would cause problems for you,\n",
-      "please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466\n",
-      "        \n",
-      "  import pandas as pd\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "from pathlib import Path\n",
@@ -69,7 +54,7 @@
     "    if 'kegg_comp' in row.index and pd.notnull(row['kegg_comp']):\n",
     "        ids_dict[\"KEGG_ID\"] = KEGG_CPD_PREFIX + str(row['kegg_comp'])\n",
     "    if 'CAS' in row.index and pd.notnull(row['CAS']):\n",
-    "        ids_dict[\"CAS_RN_ID\"] = CAS_RN_PREFIX + str(row['CAS'])\n",
+    "        ids_dict[\"CAS_RN_ID\"] = CAS_RN_PREFIX + str(row['CAS']).strip()\n",
     "    if 'EC_number' in row.index and pd.notnull(row['EC_number']):\n",
     "        ids_dict[\"EC_ID\"] = EC_PREFIX + str(row['EC_number'])\n",
     "    return pd.Series(ids_dict)\n",


### PR DESCRIPTION
There was a space between prefix and ID for some CAS-RN CURIEs. `.strip()` before concatenation in the notebook fixed this.