### PR TITLE
Updates to Rhea and EC ingest

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -139,12 +139,12 @@
   url: https://github.com/geneontology/unipathway/raw/master/upa.owl
   local_name: upa.owl
 
-# 
-# RHEA
-# 
--
-  url: https://w3id.org/biopragmatics/resources/rhea/rhea.json.gz
-  local_name: rhea.json.gz
+# # # Redundant to RheaMappingsTransform
+# # RHEA
+# # 
+# -
+#   url: https://w3id.org/biopragmatics/resources/rhea/rhea.json.gz
+#   local_name: rhea.json.gz
 
 # RHEA mappings
 - 

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -420,11 +420,11 @@ IS_OUTPUT_OF_PREDICATE = "biolink:is_output_of"
 HAS_INPUT_RELATION = "RO:0002233"
 HAS_OUTPUT_RELATION = "RO:0002234"
 PARTICIPATES_IN_PREDICATE = "biolink:participates_in"
-CAN_BE_CARRIED_OUT_BY_PREDICATE = "biolink:can_be_carried_out_by"
+# CAN_BE_CARRIED_OUT_BY_PREDICATE = "biolink:can_be_carried_out_by" # Replacing with enables
 RHEA_PREDICATE_MAPPER = {
     "has participant": HAS_PARTICIPANT_PREDICATE,
     "enabled by": ENABLED_BY_PREDICATE,
-    "reaction enabled by molecular function": CAN_BE_CARRIED_OUT_BY_PREDICATE,
+    "reaction enabled by molecular function": RHEA_TO_GO_EDGE, # CAN_BE_CARRIED_OUT_BY_PREDICATE,
     "has input": HAS_INPUT_PREDICATE,
     "has output": HAS_OUTPUT_PREDICATE,
 }

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -295,11 +295,11 @@ DEBIO_MAPPER = {
     RHEA_RIGHT_TO_LEFT_DIRECTION: "debio:0000008",
     RHEA_BIDIRECTIONAL_DIRECTION: "debio:0000009",
 }
-DEBIO_PREDICATE_MAPPER = {
-    RHEA_LEFT_TO_RIGHT_DIRECTION: "biolink:is_input_of",
-    RHEA_RIGHT_TO_LEFT_DIRECTION: "biolink:is_output_of",
-    RHEA_BIDIRECTIONAL_DIRECTION: "biolink:participates_in",
-}
+# DEBIO_PREDICATE_MAPPER = {
+#     RHEA_LEFT_TO_RIGHT_DIRECTION: "biolink:is_input_of",
+#     RHEA_RIGHT_TO_LEFT_DIRECTION: "biolink:is_output_of",
+#     RHEA_BIDIRECTIONAL_DIRECTION: "biolink:participates_in",
+# }
 RHEA_DIRECTION_CATEGORY = "biolink:Activity"
 
 # Traits
@@ -415,6 +415,11 @@ HAS_PARTICIPANT_PREDICATE = "biolink:has_participant"
 ENABLED_BY_PREDICATE = "biolink:enabled_by"
 HAS_INPUT_PREDICATE = "biolink:has_input"
 HAS_OUTPUT_PREDICATE = "biolink:has_output"
+IS_INPUT_OF_PREDICATE = "biolink:is_input_of"
+IS_OUTPUT_OF_PREDICATE = "biolink:is_output_of"
+HAS_INPUT_RELATION = "RO:0002233"
+HAS_OUTPUT_RELATION = "RO:0002234"
+PARTICIPATES_IN_PREDICATE = "biolink:participates_in"
 CAN_BE_CARRIED_OUT_BY_PREDICATE = "biolink:can_be_carried_out_by"
 RHEA_PREDICATE_MAPPER = {
     "has participant": HAS_PARTICIPANT_PREDICATE,
@@ -422,6 +427,28 @@ RHEA_PREDICATE_MAPPER = {
     "reaction enabled by molecular function": CAN_BE_CARRIED_OUT_BY_PREDICATE,
     "has input": HAS_INPUT_PREDICATE,
     "has output": HAS_OUTPUT_PREDICATE,
+}
+
+# RHEA Pyobo
+ENABLED_BY_RELATION = "RO:0002333"
+RHEA_PYOBO_RELATIONS_MAPPER = {
+    ENABLED_BY_RELATION: ENABLED_BY_PREDICATE,
+    RDFS_SUBCLASS_OF: SUBCLASS_PREDICATE,
+    HAS_INPUT_RELATION: HAS_INPUT_PREDICATE,
+    HAS_OUTPUT_RELATION: HAS_OUTPUT_PREDICATE,
+    HAS_PARTICIPANT: HAS_PARTICIPANT_PREDICATE,
+    # "debio:0000007" : SUPERCLASS_PREDICATE, # This is being ignored in RheaMapperTransform
+    # "debio:0000008" : SUPERCLASS_PREDICATE, # This is being ignored in RheaMapperTransform
+    # "debio:0000009" : SUPERCLASS_PREDICATE, # This is being ignored in RheaMapperTransform
+    "debio:0000047": RHEA_TO_GO_EDGE,
+}
+
+RHEA_PYOBO_PREFIXES_MAPPER = {
+    "chebi": CHEBI_PREFIX,
+    RHEA_KEY: RHEA_NEW_PREFIX,
+    EC_PYOBO_PREFIX: EC_PREFIX,
+    "uniprot": UNIPROT_PREFIX,
+    "go": GO_PREFIX,
 }
 
 # Columns desired for the Uniprot data (from .dat files)
@@ -455,8 +482,6 @@ UNIPATHWAYS_CATEGORIES_DICT = {
     UNIPATHWAYS_PATHWAY_PREFIX: PATHWAY_CATEGORY,
 }
 
-HAS_INPUT_RELATION = "RO:0002233"
-HAS_OUTPUT_RELATION = "RO:0002234"
 PART_OF_RELATION = "BFO:0000050"
 PART_OF_PREDICATE = "biolink:part_of"
 RELATED_TO_RELATION = "RO:0000052"
@@ -490,6 +515,7 @@ UNIPATHWAYS_INCLUDE_PAIRS = [
 SPECIAL_PREFIXES = {
     EC_PYOBO_PREFIX: EC_PREFIX.rstrip(":"),
     EC_OBO_PREFIX: EC_PREFIX,
+    UNIPROT_OBO_PREFIX: UNIPROT_PREFIX,
     RHEA_NEW_PREFIX.lower().rstrip(":"): RHEA_NEW_PREFIX.rstrip(":"),
     RHEA_OBO_PREFIX: RHEA_NEW_PREFIX,
     # UNIPROT_OBO_PREFIX: UNIPROT_PREFIX + ":",  # comment for now since we do not need obo-db-ingest for uniprot

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -424,7 +424,7 @@ PARTICIPATES_IN_PREDICATE = "biolink:participates_in"
 RHEA_PREDICATE_MAPPER = {
     "has participant": HAS_PARTICIPANT_PREDICATE,
     "enabled by": ENABLED_BY_PREDICATE,
-    "reaction enabled by molecular function": RHEA_TO_GO_EDGE, # CAN_BE_CARRIED_OUT_BY_PREDICATE,
+    "reaction enabled by molecular function": RHEA_TO_GO_EDGE,  # CAN_BE_CARRIED_OUT_BY_PREDICATE,
     "has input": HAS_INPUT_PREDICATE,
     "has output": HAS_OUTPUT_PREDICATE,
 }

--- a/kg_microbe/transform_utils/ontology/ontology_transform.py
+++ b/kg_microbe/transform_utils/ontology/ontology_transform.py
@@ -15,7 +15,9 @@ from kgx.cli.cli_utils import transform
 
 from kg_microbe.transform_utils.constants import (
     CATEGORY_COLUMN,
+    CHEBI_PREFIX,
     CHEBI_XREFS_FILEPATH,
+    EC_PREFIX,
     EXCLUSION_TERMS_FILE,
     ID_COLUMN,
     NCBITAXON_PREFIX,
@@ -356,7 +358,8 @@ class OntologyTransform(Transform):
                 new_ef_lines = [line for line in new_ef_lines if UNIPROT_PREFIX not in line]
             elif name == "rhea":
                 # Remove debio nodes that account for direction, since already there in inverse triples
-                rhea_exclusions = ["debio",UNIPROT_PREFIX]
+                # Note that CHEBI and EC predicates do not match Rhea pyobo, so removing them
+                rhea_exclusions = ["debio",UNIPROT_PREFIX,CHEBI_PREFIX,EC_PREFIX]
                 new_nf_lines = [line for line in new_nf_lines if not any(sub in line for sub in rhea_exclusions)]
                 new_ef_lines = [line for line in new_ef_lines if not any(sub in line for sub in rhea_exclusions)]
             # Rewrite nodes file

--- a/kg_microbe/transform_utils/ontology/ontology_transform.py
+++ b/kg_microbe/transform_utils/ontology/ontology_transform.py
@@ -356,8 +356,9 @@ class OntologyTransform(Transform):
                 new_ef_lines = [line for line in new_ef_lines if UNIPROT_PREFIX not in line]
             elif name == "rhea":
                 # Remove debio nodes that account for direction, since already there in inverse triples
-                new_nf_lines = [line for line in new_nf_lines if "debio" not in line]
-                new_ef_lines = [line for line in new_ef_lines if "debio" not in line]
+                rhea_exclusions = ["debio","uniprot"]
+                new_nf_lines = [line for line in new_nf_lines if not any(sub in line for sub in rhea_exclusions)]
+                new_ef_lines = [line for line in new_ef_lines if not any(sub in line for sub in rhea_exclusions)]
             # Rewrite nodes file
             with open(nodes_file, "w") as new_nf:
                 new_nf.write("\t".join(self.node_header) + "\n")

--- a/kg_microbe/transform_utils/ontology/ontology_transform.py
+++ b/kg_microbe/transform_utils/ontology/ontology_transform.py
@@ -359,9 +359,13 @@ class OntologyTransform(Transform):
             elif name == "rhea":
                 # Remove debio nodes that account for direction, since already there in inverse triples
                 # Note that CHEBI and EC predicates do not match Rhea pyobo, so removing them
-                rhea_exclusions = ["debio",UNIPROT_PREFIX,CHEBI_PREFIX,EC_PREFIX]
-                new_nf_lines = [line for line in new_nf_lines if not any(sub in line for sub in rhea_exclusions)]
-                new_ef_lines = [line for line in new_ef_lines if not any(sub in line for sub in rhea_exclusions)]
+                rhea_exclusions = ["debio", UNIPROT_PREFIX, CHEBI_PREFIX, EC_PREFIX]
+                new_nf_lines = [
+                    line for line in new_nf_lines if not any(sub in line for sub in rhea_exclusions)
+                ]
+                new_ef_lines = [
+                    line for line in new_ef_lines if not any(sub in line for sub in rhea_exclusions)
+                ]
             # Rewrite nodes file
             with open(nodes_file, "w") as new_nf:
                 new_nf.write("\t".join(self.node_header) + "\n")

--- a/kg_microbe/transform_utils/ontology/ontology_transform.py
+++ b/kg_microbe/transform_utils/ontology/ontology_transform.py
@@ -57,13 +57,13 @@ from kg_microbe.utils.unipathways_utils import (
 from ..transform import Transform
 
 ONTOLOGIES = {
-    # "ncbitaxon": "ncbitaxon.owl.gz",
-    # "chebi": "chebi.owl.gz",
-    # "envo": "envo.json",
-    # "go": "go.json",
-    "rhea": "rhea.json.gz",
-    # "ec": "ec.json",
-    # "upa": "upa.owl",
+    "ncbitaxon": "ncbitaxon.owl.gz",
+    "chebi": "chebi.owl.gz",
+    "envo": "envo.json",
+    "go": "go.json",
+    # "rhea": "rhea.json.gz", # Redundant to RheaMappingsTransform
+    "ec": "ec.json",
+    "upa": "upa.owl",
 }
 
 

--- a/kg_microbe/transform_utils/ontology/ontology_transform.py
+++ b/kg_microbe/transform_utils/ontology/ontology_transform.py
@@ -55,13 +55,13 @@ from kg_microbe.utils.unipathways_utils import (
 from ..transform import Transform
 
 ONTOLOGIES = {
-    # "ncbitaxon": "ncbitaxon.owl.gz",
-    # "chebi": "chebi.owl.gz",
-    # "envo": "envo.json",
-    # "go": "go.json",
+    "ncbitaxon": "ncbitaxon.owl.gz",
+    "chebi": "chebi.owl.gz",
+    "envo": "envo.json",
+    "go": "go.json",
     "rhea": "rhea.json.gz",
     "ec": "ec.json",
-    # "upa": "upa.owl",
+    "upa": "upa.owl",
 }
 
 

--- a/kg_microbe/transform_utils/ontology/ontology_transform.py
+++ b/kg_microbe/transform_utils/ontology/ontology_transform.py
@@ -55,13 +55,13 @@ from kg_microbe.utils.unipathways_utils import (
 from ..transform import Transform
 
 ONTOLOGIES = {
-    "ncbitaxon": "ncbitaxon.owl.gz",
-    "chebi": "chebi.owl.gz",
-    "envo": "envo.json",
-    "go": "go.json",
+    # "ncbitaxon": "ncbitaxon.owl.gz",
+    # "chebi": "chebi.owl.gz",
+    # "envo": "envo.json",
+    # "go": "go.json",
     "rhea": "rhea.json.gz",
-    "ec": "ec.json",
-    "upa": "upa.owl",
+    # "ec": "ec.json",
+    # "upa": "upa.owl",
 }
 
 
@@ -356,7 +356,7 @@ class OntologyTransform(Transform):
                 new_ef_lines = [line for line in new_ef_lines if UNIPROT_PREFIX not in line]
             elif name == "rhea":
                 # Remove debio nodes that account for direction, since already there in inverse triples
-                rhea_exclusions = ["debio","uniprot"]
+                rhea_exclusions = ["debio",UNIPROT_PREFIX]
                 new_nf_lines = [line for line in new_nf_lines if not any(sub in line for sub in rhea_exclusions)]
                 new_ef_lines = [line for line in new_ef_lines if not any(sub in line for sub in rhea_exclusions)]
             # Rewrite nodes file

--- a/kg_microbe/transform_utils/ontology/ontology_transform.py
+++ b/kg_microbe/transform_utils/ontology/ontology_transform.py
@@ -31,8 +31,10 @@ from kg_microbe.transform_utils.constants import (
     UNIPATHWAYS_INCLUDE_PAIRS,
     UNIPATHWAYS_PATHWAY_PREFIX,
     UNIPATHWAYS_REACTION_PREFIX,
+    UNIPROT_PREFIX,
     XREF_COLUMN,
 )
+from kg_microbe.utils.ontology_utils import replace_category_ontology
 from kg_microbe.utils.pandas_utils import (
     drop_duplicates,
     establish_transitive_relationship_multiple,
@@ -45,7 +47,7 @@ from kg_microbe.utils.unipathways_utils import (
     check_wanted_pairs,
     remove_unwanted_prefixes_from_edges,
     remove_unwanted_prefixes_from_node_xrefs,
-    replace_category,
+    replace_category_for_unipathways,
     replace_id_with_xref,
     replace_triples_with_labels,
 )
@@ -53,13 +55,13 @@ from kg_microbe.utils.unipathways_utils import (
 from ..transform import Transform
 
 ONTOLOGIES = {
-    "ncbitaxon": "ncbitaxon.owl.gz",
-    "chebi": "chebi.owl.gz",
-    "envo": "envo.json",
-    "go": "go.json",
+    # "ncbitaxon": "ncbitaxon.owl.gz",
+    # "chebi": "chebi.owl.gz",
+    # "envo": "envo.json",
+    # "go": "go.json",
     "rhea": "rhea.json.gz",
     "ec": "ec.json",
-    "upa": "upa.owl",
+    # "upa": "upa.owl",
 }
 
 
@@ -239,7 +241,9 @@ class OntologyTransform(Transform):
                         elif any(
                             substring in line for substring in [UNIPATHWAYS_PATHWAY_PREFIX]
                         ):  # ,UNIPATHWAYS_LINEAR_SUB_PATHWAY_PREFIX]):
-                            new_line = replace_category(line, id_index, category_index)
+                            new_line = replace_category_for_unipathways(
+                                line, id_index, category_index
+                            )
                             if len(new_line) > 0:
                                 add_lines.append(new_line + "\n")
                         # Not adding any other node types except what is specified
@@ -319,9 +323,51 @@ class OntologyTransform(Transform):
                 # Write a new edges tsv file with same edge header
                 for line in ef:
                     new_edge_lines.append(_replace_special_prefixes(line))
-            # Rewrite nodes file
+            # Rewrite edges file
             with open(edges_file, "w") as new_ef:
                 for line in new_edge_lines:
+                    new_ef.write(line)
+
+        if name == "ec" or name == "rhea":
+            with open(nodes_file, "r") as nf, open(edges_file, "r") as ef:
+                # Update prefixes in nodes file
+                new_nf_lines = []
+                for line in nf:
+                    if line.startswith("id"):
+                        # get the index for the term 'id'
+                        id_index = line.strip().split("\t").index(ID_COLUMN)
+                        # get the index for the term 'category'
+                        category_index = line.strip().split("\t").index(CATEGORY_COLUMN)
+                    else:
+                        line = _replace_special_prefixes(line)
+                        line = replace_category_ontology(line, id_index, category_index)
+                        new_nf_lines.append(line + "\n")
+                # Update prefixes in edges file
+                new_ef_lines = []
+                for line in ef:
+                    if line.startswith("id"):
+                        continue
+                    else:
+                        line = _replace_special_prefixes(line)
+                        new_ef_lines.append(line)
+            if name == "ec":
+                # Remove Uniprot nodes since accounted for elsewhere
+                new_nf_lines = [line for line in new_nf_lines if UNIPROT_PREFIX not in line]
+                new_ef_lines = [line for line in new_ef_lines if UNIPROT_PREFIX not in line]
+            elif name == "rhea":
+                # Remove debio nodes that account for direction, since already there in inverse triples
+                new_nf_lines = [line for line in new_nf_lines if "debio" not in line]
+                new_ef_lines = [line for line in new_ef_lines if "debio" not in line]
+            # Rewrite nodes file
+            with open(nodes_file, "w") as new_nf:
+                new_nf.write("\t".join(self.node_header) + "\n")
+                for line in new_nf_lines:
+                    new_nf.write(line)
+
+            # Rewrite edges file
+            with open(edges_file, "w") as new_ef:
+                new_ef.write("\t".join(self.edge_header) + "\n")
+                for line in new_ef_lines:
                     new_ef.write(line)
 
         else:

--- a/kg_microbe/transform_utils/rhea/rhea.py
+++ b/kg_microbe/transform_utils/rhea/rhea.py
@@ -1,9 +1,9 @@
 """Transform for Rhea."""
 
 import csv
+import os
 from collections import defaultdict
 from glob import glob
-import os
 from pathlib import Path
 from typing import Optional, Union
 
@@ -147,10 +147,14 @@ class RheaMappingsTransform(Transform):
 
         # Remove any rows other than Rhea-Rhea relations since those relationships accounted for elsewhere
         relation_types_to_remove_pyobo = [
-            UNIPROT_PREFIX, GO_PREFIX, EC_PREFIX
+            UNIPROT_PREFIX,
+            GO_PREFIX,
+            EC_PREFIX,
         ]  # [CHEBI_PREFIX, GO_PREFIX, UNIPROT_PREFIX, EC_PREFIX]
         rhea_relation = rhea_relation[
-            ~rhea_relation[RHEA_TARGET_ID_COLUMN].str.contains("|".join(relation_types_to_remove_pyobo))
+            ~rhea_relation[RHEA_TARGET_ID_COLUMN].str.contains(
+                "|".join(relation_types_to_remove_pyobo)
+            )
         ]
 
         rhea_relation = rhea_relation.drop(columns=["relation_ns", "relation_id", "target_ns"])
@@ -292,12 +296,19 @@ class RheaMappingsTransform(Transform):
                         for row in mapping_tsv_reader:
                             subject_info = RHEA_NEW_PREFIX + str(row[rhea_idx])
                             object = xref_prefix + str(row[xref_idx])
-                            relation = [k for k, v in RHEA_PYOBO_RELATIONS_MAPPER.items() if v == predicate][0] \
-                                if predicate in RHEA_PYOBO_RELATIONS_MAPPER.values() \
+                            relation = (
+                                [
+                                    k
+                                    for k, v in RHEA_PYOBO_RELATIONS_MAPPER.items()
+                                    if v == predicate
+                                ][0]
+                                if predicate in RHEA_PYOBO_RELATIONS_MAPPER.values()
                                 else None
+                            )
                             # Remove rows other than Rhea-Rhea relations, accounted for elsewhere
                             if not any(
-                                substring in object for substring in relation_types_to_remove_rhea2_files
+                                substring in object
+                                for substring in relation_types_to_remove_rhea2_files
                             ):
                                 nodes_file_writer.writerow(
                                     [object, category, None] + [None] * (len(self.node_header) - 3)

--- a/kg_microbe/transform_utils/rhea/rhea.py
+++ b/kg_microbe/transform_utils/rhea/rhea.py
@@ -17,7 +17,6 @@ from tqdm import tqdm
 
 from kg_microbe.transform_utils.constants import (
     CHEBI_PREFIX,
-    # CLOSE_MATCH,
     DEBIO_MAPPER,
     EC_CATEGORY,
     EC_PREFIX,

--- a/kg_microbe/transform_utils/rhea/rhea.py
+++ b/kg_microbe/transform_utils/rhea/rhea.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 
 from kg_microbe.transform_utils.constants import (
     CHEBI_PREFIX,
-    CLOSE_MATCH,
+    # CLOSE_MATCH,
     DEBIO_MAPPER,
     EC_CATEGORY,
     EC_PREFIX,
@@ -266,7 +266,7 @@ class RheaMappingsTransform(Transform):
             pattern = f"{self.input_base_dir}/rhea2*.tsv"
             matching_files = glob(pattern)
 
-            #relation = CLOSE_MATCH
+            # relation = CLOSE_MATCH
             with progress_class(
                 total=len(matching_files), desc="Processing Rhea mappings..."
             ) as progress:
@@ -293,7 +293,9 @@ class RheaMappingsTransform(Transform):
                         for row in mapping_tsv_reader:
                             subject_info = RHEA_NEW_PREFIX + str(row[rhea_idx])
                             object = xref_prefix + str(row[xref_idx])
-                            relation = [k for k, v in RHEA_PYOBO_RELATIONS_MAPPER.items() if v == predicate][0] if predicate in RHEA_PYOBO_RELATIONS_MAPPER.values() else None
+                            relation = [k for k, v in RHEA_PYOBO_RELATIONS_MAPPER.items() if v == predicate][0] \
+                                if predicate in RHEA_PYOBO_RELATIONS_MAPPER.values() \
+                                else None
                             # Remove rows other than Rhea-Rhea relations, accounted for elsewhere
                             if not any(
                                 substring in object for substring in relation_types_to_remove_rhea2_files

--- a/kg_microbe/transform_utils/rhea/rhea.py
+++ b/kg_microbe/transform_utils/rhea/rhea.py
@@ -208,7 +208,7 @@ class RheaMappingsTransform(Transform):
                 total=len(rhea_nodes.items()) + 1, desc="Processing RHEA mappings..."
             ) as progress:
                 for k, v in rhea_nodes.items():
-                    # Get reaction identifiers corresponding to different directions (n, n+1, n+2, n+3) and associated with 1 reaction definition
+                    # Associate reaction identifiers corresponding to different directions (n, n+1, n+2, n+3)
                     tmp_file_writer.writerow(
                         [RHEA_NEW_PREFIX + k, RHEA_CATEGORY, v, RHEA_UNDEFINED_DIRECTION]
                     )
@@ -290,7 +290,7 @@ class RheaMappingsTransform(Transform):
                         for row in mapping_tsv_reader:
                             subject_info = RHEA_NEW_PREFIX + str(row[rhea_idx])
                             object = xref_prefix + str(row[xref_idx])
-                            # Remove any rows other than Rhea-Rhea relations since those relationships accounted for elsewhere
+                            # Remove rows other than Rhea-Rhea relations, accounted for elsewhere
                             if not any(
                                 substring in object for substring in relation_types_to_remove
                             ):
@@ -353,7 +353,7 @@ class RheaMappingsTransform(Transform):
                                                 object_info[0].replace("uniprot:", UNIPROT_PREFIX),
                                             ) + object_info[1:]
 
-                                        # Remove any rows other than Rhea-Rhea relations since those relationships accounted for elsewhere
+                                        # Remove rows other than Rhea-Rhea relations, accounted for elsewhere
                                         if not any(
                                             substring in object_info[0]
                                             for substring in relation_types_to_remove

--- a/kg_microbe/transform_utils/rhea/rhea.py
+++ b/kg_microbe/transform_utils/rhea/rhea.py
@@ -31,13 +31,12 @@ from kg_microbe.transform_utils.constants import (
     PREDICATE_ID_COLUMN,
     PREDICATE_LABEL_COLUMN,
     PRIMARY_KNOWLEDGE_SOURCE_COLUMN,
+    PROTEIN_CATEGORY,
     RAW_DATA_DIR,
-    RDFS_SUBCLASS_OF,
     RELATION_COLUMN,
     RHEA_BIDIRECTIONAL_DIRECTION,
     RHEA_CATEGORY,
     RHEA_CATEGORY_COLUMN,
-    RHEA_DIRECTION_CATEGORY,
     RHEA_DIRECTION_COLUMN,
     RHEA_ID_COLUMN,
     RHEA_LEFT_TO_RIGHT_DIRECTION,
@@ -46,6 +45,8 @@ from kg_microbe.transform_utils.constants import (
     RHEA_NAME_COLUMN,
     RHEA_NEW_PREFIX,
     RHEA_PREDICATE_MAPPER,
+    RHEA_PYOBO_PREFIXES_MAPPER,
+    RHEA_PYOBO_RELATIONS_MAPPER,
     RHEA_RIGHT_TO_LEFT_DIRECTION,
     RHEA_SUBJECT_ID_COLUMN,
     RHEA_TARGET_ID_COLUMN,
@@ -54,11 +55,10 @@ from kg_microbe.transform_utils.constants import (
     RHEA_TO_GO_EDGE,
     RHEA_UNDEFINED_DIRECTION,
     SPECIAL_PREFIXES,
-    SUBCLASS_PREDICATE,
     SUBJECT_COLUMN,
     SUBJECT_LABEL_COLUMN,
     SUBSTRATE_CATEGORY,
-    SUPERCLASS_PREDICATE,
+    UNIPROT_PREFIX,
 )
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.dummy_tqdm import DummyTqdm
@@ -120,24 +120,37 @@ class RheaMappingsTransform(Transform):
         rhea_relation["relation_ns"] = rhea_relation["relation_ns"].apply(
             lambda x: self.converter.standardize_prefix(x)
         )
+        # Combines relation_ns with relation_id to get full curie
         rhea_relation[RELATION_COLUMN] = (
             rhea_relation["relation_ns"] + ":" + rhea_relation["relation_id"]
         )
-
         rhea_relation[RHEA_MAPPING_ID_COLUMN.lower()] = RHEA_NEW_PREFIX + rhea_relation[
             RHEA_MAPPING_ID_COLUMN.lower()
         ].astype(str)
-        rhea_relation[RHEA_TARGET_ID_COLUMN] = RHEA_NEW_PREFIX + rhea_relation[
-            RHEA_TARGET_ID_COLUMN
-        ].astype(str)
-
-        rhea_relation[PREDICATE_COLUMN] = rhea_relation[RELATION_COLUMN].apply(
-            lambda x: (
-                x.replace(RDFS_SUBCLASS_OF, SUBCLASS_PREDICATE)
-                if x == RDFS_SUBCLASS_OF
-                else SUPERCLASS_PREDICATE
-            )
+        # Update prefixes
+        rhea_relation["target_ns"] = rhea_relation["target_ns"].apply(
+            lambda x: (RHEA_PYOBO_PREFIXES_MAPPER[x])
         )
+        # Add correct prefix to target
+        rhea_relation[RHEA_TARGET_ID_COLUMN] = rhea_relation.agg(
+            lambda x: x["target_ns"] + str(x[RHEA_TARGET_ID_COLUMN]), axis=1
+        )
+
+        # Get corresponding prefixes if they exist, otherwise exclude (debio for now)
+        rhea_relation[PREDICATE_COLUMN] = rhea_relation[RELATION_COLUMN].apply(
+            lambda x: (RHEA_PYOBO_RELATIONS_MAPPER.get(x))
+        )
+        # Filter rows where the predicate column is not None (debio for now)
+        rhea_relation = rhea_relation[rhea_relation[PREDICATE_COLUMN].notna()]
+
+        # Remove any rows other than Rhea-Rhea relations since those relationships accounted for elsewhere
+        relation_types_to_remove = [
+            UNIPROT_PREFIX
+        ]  # [CHEBI_PREFIX, GO_PREFIX, UNIPROT_PREFIX, EC_PREFIX]
+        rhea_relation = rhea_relation[
+            ~rhea_relation[RHEA_TARGET_ID_COLUMN].str.contains("|".join(relation_types_to_remove))
+        ]
+
         rhea_relation = rhea_relation.drop(columns=["relation_ns", "relation_id", "target_ns"])
         rhea_relation = rhea_relation.rename(
             columns={
@@ -172,29 +185,30 @@ class RheaMappingsTransform(Transform):
             edges_file_writer.writerow(self.edge_header)
             edges_file_writer.writerows(rhea_relation.values.tolist())
 
-            # write direction for rhea nodes
-            nodes_file_writer.writerow(
-                [
-                    DEBIO_MAPPER.get(RHEA_LEFT_TO_RIGHT_DIRECTION),
-                    RHEA_DIRECTION_CATEGORY,
-                    RHEA_LEFT_TO_RIGHT_DIRECTION,
-                ]
-                + [None] * (len(self.node_header) - 3)
-            )
-            nodes_file_writer.writerow(
-                [
-                    DEBIO_MAPPER.get(RHEA_RIGHT_TO_LEFT_DIRECTION),
-                    RHEA_DIRECTION_CATEGORY,
-                    RHEA_RIGHT_TO_LEFT_DIRECTION,
-                ]
-                + [None] * (len(self.node_header) - 3)
-            )
+            # write direction for rhea nodes # Not including reaction direction for now
+            # nodes_file_writer.writerow(
+            #     [
+            #         DEBIO_MAPPER.get(RHEA_LEFT_TO_RIGHT_DIRECTION),
+            #         RHEA_DIRECTION_CATEGORY,
+            #         RHEA_LEFT_TO_RIGHT_DIRECTION,
+            #     ]
+            #     + [None] * (len(self.node_header) - 3)
+            # )
+            # nodes_file_writer.writerow(
+            #     [
+            #         DEBIO_MAPPER.get(RHEA_RIGHT_TO_LEFT_DIRECTION),
+            #         RHEA_DIRECTION_CATEGORY,
+            #         RHEA_RIGHT_TO_LEFT_DIRECTION,
+            #     ]
+            #     + [None] * (len(self.node_header) - 3)
+            # )
 
             progress_class = tqdm if show_status else DummyTqdm
             with progress_class(
                 total=len(rhea_nodes.items()) + 1, desc="Processing RHEA mappings..."
             ) as progress:
                 for k, v in rhea_nodes.items():
+                    # Get reaction identifiers corresponding to different directions (n, n+1, n+2, n+3) and associated with 1 reaction definition
                     tmp_file_writer.writerow(
                         [RHEA_NEW_PREFIX + k, RHEA_CATEGORY, v, RHEA_UNDEFINED_DIRECTION]
                     )
@@ -276,12 +290,16 @@ class RheaMappingsTransform(Transform):
                         for row in mapping_tsv_reader:
                             subject_info = RHEA_NEW_PREFIX + str(row[rhea_idx])
                             object = xref_prefix + str(row[xref_idx])
-                            nodes_file_writer.writerow(
-                                [object, category, None] + [None] * (len(self.node_header) - 3)
-                            )
-                            edges_file_writer.writerow(
-                                [subject_info, predicate, object, relation, ks]
-                            )
+                            # Remove any rows other than Rhea-Rhea relations since those relationships accounted for elsewhere
+                            if not any(
+                                substring in object for substring in relation_types_to_remove
+                            ):
+                                nodes_file_writer.writerow(
+                                    [object, category, None] + [None] * (len(self.node_header) - 3)
+                                )
+                                edges_file_writer.writerow(
+                                    [subject_info, predicate, object, relation, ks]
+                                )
 
                     with open(RHEA_TMP_DIR / "all_terms.tsv", "w", newline="") as tsvfile:
                         all_terms_writer = csv.writer(tsvfile, delimiter="\t")
@@ -307,35 +325,55 @@ class RheaMappingsTransform(Transform):
                                 predicate_info = self._reference_to_tuple(predicate)
                                 for obj in objects:
                                     object_info = self._reference_to_tuple(obj)
+                                    # if 'uniprot:Q01116' in str(object_info):
+                                    #     print(object_info)
                                     # Write the row in the specified format
                                     all_terms_writer.writerow(
                                         [*subject_info, *predicate_info, *object_info]
                                     )
                                     if any(
                                         object_info[0].startswith(prefix)
-                                        for prefix in [CHEBI_PREFIX, EC_PREFIX, GO_PREFIX]
+                                        for prefix in [
+                                            CHEBI_PREFIX,
+                                            EC_PREFIX,
+                                            GO_PREFIX,
+                                            "uniprot",
+                                        ]
                                     ):
                                         if object_info[0].startswith(CHEBI_PREFIX):
                                             category = SUBSTRATE_CATEGORY
                                         elif object_info[0].startswith(GO_PREFIX):
                                             category = GO_CATEGORY
-                                        else:
+                                        elif object_info[0].startswith(EC_PREFIX):
                                             category = EC_CATEGORY
-                                        nodes_file_writer.writerow(
-                                            [object_info[0], category, object_info[1]]
-                                            + [None] * (len(self.node_header) - 3)
-                                        )
-                                        edges_file_writer.writerow(
-                                            [
-                                                subject_info[0],
-                                                RHEA_PREDICATE_MAPPER.get(
-                                                    predicate_info[1], predicate_info[1]
-                                                ),
-                                                object_info[0],
-                                                predicate_info[0],
-                                                "Rhea2*",
-                                            ]
-                                        )
+                                        elif object_info[0].startswith("uniprot"):
+                                            category = PROTEIN_CATEGORY
+                                            # Update the first object of the tuple
+                                            object_info = (
+                                                object_info[0].replace("uniprot:", UNIPROT_PREFIX),
+                                            ) + object_info[1:]
+
+                                        # Remove any rows other than Rhea-Rhea relations since those relationships accounted for elsewhere
+                                        if not any(
+                                            substring in object_info[0]
+                                            for substring in relation_types_to_remove
+                                        ):
+                                            nodes_file_writer.writerow(
+                                                [object_info[0], category, object_info[1]]
+                                                + [None] * (len(self.node_header) - 3)
+                                            )
+
+                                            edges_file_writer.writerow(
+                                                [
+                                                    subject_info[0],
+                                                    RHEA_PREDICATE_MAPPER.get(
+                                                        predicate_info[1], predicate_info[1]
+                                                    ),
+                                                    object_info[0],
+                                                    predicate_info[0],
+                                                    "Rhea2*",
+                                                ]
+                                            )
                 progress.set_description(f"Processing {file} ...")
                 # After each iteration, call the update method to advance the progress bar.
                 progress.update()

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -1,0 +1,36 @@
+"""EC utilities."""
+
+from kg_microbe.transform_utils.constants import (
+    EC_CATEGORY,
+    EC_PREFIX,
+    GO_CATEGORY,
+    GO_PREFIX,
+    PROTEIN_CATEGORY,
+    RHEA_CATEGORY,
+    RHEA_NEW_PREFIX,
+    UNIPROT_PREFIX,
+)
+
+
+def replace_category_ontology(line, id_index, category_index):
+    """
+    Replace node category according to prefix that has already been fixed.
+
+    :param line: A line from the original triples.
+    :type line: str
+    """
+    parts = line.strip().split("\t")
+    if EC_PREFIX in parts[id_index]:
+        new_category = EC_CATEGORY
+        parts[category_index] = new_category
+    if GO_PREFIX in parts[id_index]:
+        new_category = GO_CATEGORY
+        parts[category_index] = new_category
+    if UNIPROT_PREFIX in parts[id_index]:
+        new_category = PROTEIN_CATEGORY
+        parts[category_index] = new_category
+    if RHEA_NEW_PREFIX in parts[id_index]:
+        new_category = RHEA_CATEGORY
+        parts[category_index] = new_category
+    new_line = "\t".join(parts)
+    return new_line

--- a/kg_microbe/utils/unipathways_utils.py
+++ b/kg_microbe/utils/unipathways_utils.py
@@ -43,11 +43,11 @@ def replace_id_with_xref(line, xref_index, id_index, category_index, nodes_dicti
             l_joined = "\t".join(l_parts)
             new_lines.append(l_joined)
     else:
-        new_lines.append(replace_category(line, id_index, category_index))
+        new_lines.append(replace_category_for_unipathways(line, id_index, category_index))
     return new_lines, nodes_dictionary
 
 
-def replace_category(line, id_index, category_index):
+def replace_category_for_unipathways(line, id_index, category_index):
     """
     Replace category of a given node.
 

--- a/merge.yaml
+++ b/merge.yaml
@@ -42,13 +42,13 @@ merged_graph:
         filename:
           - data/transformed/ontologies/go_nodes.tsv
           - data/transformed/ontologies/go_edges.tsv
-    rhea:
-      name: "Rhea"
-      input:
-        format: tsv
-        filename:
-          - data/transformed/ontologies/rhea_nodes.tsv
-          - data/transformed/ontologies/rhea_edges.tsv
+    # rhea: # Redundant to RheaMappingsTransform
+    #   name: "Rhea"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/ontologies/rhea_nodes.tsv
+    #       - data/transformed/ontologies/rhea_edges.tsv
     ec:
       name: "EC"
       input:


### PR DESCRIPTION
Fixed issues with Rhea, RheaMapper, and EC ingest:
1. Rhea ontology and Rhea pyobo ingest will not include direction relationships because they are already included in inverse triples (i.e. directional reaction subclassOf bidirectional reaction)
2. Rhea pyobo ingest will not include CHEBI, GO, Uniprot, or EC relationships because they are already covered by EC, Uniprot ingests. The code is there if we choose to include these
3. EC ingest will not include Uniprot relationships  because they are already covered byUniprot ingest. The code is there if we choose to include these