### PR TITLE
Replace `oxygen` mapping section from `custom_curies.yaml` with alternate logic

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -623,7 +623,7 @@ class BacDiveTransform(Transform):
                 if bacdive_label in ['aerobic', 'anaerobic', 'microaerophilic', 'facultatively aerobic']:
                     ox_key = f"Ox_{bacdive_label.replace(' ', '_')}"
                     keyword_map[ox_key] = {
-                        "category": "biolink:PhenotypicQuality", 
+                        "category": "biolink:PhenotypicQuality",
                         "predicate": "biolink:has_phenotype",
                         "curie": mapping['curie'],
                         "name": mapping['label']

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -608,6 +608,27 @@ class BacDiveTransform(Transform):
                 for second_level_key, nested_data in first_level_value.items()
             }
 
+            # create keyword_map with mappings from self.oxygen_phenotype_mappings
+            # instead of relying on the (now deleted) "oxygen" section of the
+            # CUSTOM_CURIES_YAML_FILE file
+            for bacdive_label, mapping in self.oxygen_phenotype_mappings.items():
+                keyword_map[bacdive_label] = {
+                    "category": "biolink:PhenotypicQuality",
+                    "predicate": "biolink:has_phenotype",
+                    "curie": mapping['curie'],
+                    "name": mapping['label']
+                }
+                # there are also mappings for the "Ox_" prefix variants in the CUSTOM_CURIES_YAML_FILE file
+                # so add those to keyword_map as well
+                if bacdive_label in ['aerobic', 'anaerobic', 'microaerophilic', 'facultatively aerobic']:
+                    ox_key = f"Ox_{bacdive_label.replace(' ', '_')}"
+                    keyword_map[ox_key] = {
+                        "category": "biolink:PhenotypicQuality", 
+                        "predicate": "biolink:has_phenotype",
+                        "curie": mapping['curie'],
+                        "name": mapping['label']
+                    }
+
             # Choose the appropriate context manager based on the flag
             progress_class = tqdm if show_status else DummyTqdm
             with progress_class(

--- a/kg_microbe/transform_utils/custom_curies.yaml
+++ b/kg_microbe/transform_utils/custom_curies.yaml
@@ -14,53 +14,6 @@ chemical_production: &chemical_production_block
   category: "biolink:ChemicalSubstance"
   predicate: "biolink:produces"
 
-oxygen:
-  aerobe: &aerobe_block
-    curie: "oxygen:aerobe"
-    name: "aerobe"
-    <<: *phenotypic_quality_block
-  Ox_aerobic: *aerobe_block
-
-  anaerobe: &anaerobe_block
-    curie: "oxygen:anaerobe"
-    name: "anaerobe"
-    <<: *phenotypic_quality_block
-  Ox_anaerobic: *anaerobe_block
-  obligate_aerobe:
-    curie: "oxygen:obligate_aerobe"
-    name: "obligate aerobe"
-    <<: *phenotypic_quality_block
-  microaerophile: &microaerophile_block
-    curie: "oxygen:microaerophile"
-    name: "microaerophile"
-    <<: *phenotypic_quality_block
-  Ox_microaerophile: *microaerophile_block
-  facultative_anaerobe:
-    curie: "oxygen:facultative_anaerobe"
-    name: "facultative anaerobe"
-    <<: *phenotypic_quality_block
-  obligate_anaerobe:
-    curie: "oxygen:obligate_anaerobe"
-    name: "obligate anaerobe"
-    <<: *phenotypic_quality_block
-  facultative_aerobe: &facultative_aerobe_block
-    curie: "oxygen:facultative_aerobe"
-    name: "facultative aerobe"
-    <<: *phenotypic_quality_block
-  Ox_facultative_aerobe: *facultative_aerobe_block
-  aerotolerant:
-    curie: "oxygen:aerotolerant"
-    name: "aerotolerant"
-    <<: *phenotypic_quality_block
-  microaerotolerant:
-    curie: "oxygen:microaerotolerant"
-    name: "microaerotolerant"
-    <<: *phenotypic_quality_block
-  facultative_aerobe_anaerobe:
-    curie: "oxygen:facultative_aerobe_anaerobe"
-    name: "facultative aerobe/anaerobe"
-    <<: *phenotypic_quality_block
-
 temperature:
   psychrophilic:
     curie: "temperature:psychrophilic"


### PR DESCRIPTION
This is a first PR in a larger effort to eliminate the use of the `kg_microbe/transform_utils/custom_curies.yaml` file in this repo. We are starting with just the _oxygen_ mappings that are represented in the custom_curies.yaml file, and writing alternate logic in the bacdive transformation script to capture the same mappings for the oxygen preference mappings, except, here we are using the one single authoritative SOT which is the mappings file from METPO: https://github.com/berkeleybop/metpo/blob/main/generated/bacdive_oxygen_phenotype_mappings.tsv

In the edges.tsv/nodes.tsv output after this modification, we don't see any nodes/edges using terms in the "oxygen:" namespace.