### PR TITLE
Convert METPO URIs to CURIEs

### DIFF
--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -44,6 +44,7 @@ CHEBI_SOURCE = RAW_DATA_DIR / "chebi.owl"
 GO_SOURCE = RAW_DATA_DIR / "go.owl"
 EC_SOURCE = RAW_DATA_DIR / "ec.owl"
 METABOLITE_MAPPING_FILE = BACDIVE_DIR / "metabolite_mapping.json"
+PREFIXMAP_JSON_FILEPATH = TRANSFORM_UTILS_DIR / "prefixmap.json"    # custom prefixmap file path
 
 # KEYS FOR JSON FILE
 GENERAL = "General"

--- a/kg_microbe/transform_utils/prefixmap.json
+++ b/kg_microbe/transform_utils/prefixmap.json
@@ -1,0 +1,3 @@
+{
+    "METPO": "https://w3id.org/metpo/"
+}

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -1,12 +1,32 @@
 """Utilities for handling mapping files from remote sources."""
 import csv
+import json
 from typing import Dict
 
+import curies
 import requests
+
+from kg_microbe.transform_utils.constants import PREFIXMAP_JSON_FILEPATH
 
 # remote URL location in metpo GitHub repository for ROBOT template
 # which will be used as the source of METPO mappings
 METPO_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/src/templates/metpo_sheet.tsv"
+
+
+def uri_to_curie(uri: str) -> str:
+    """
+    Convert a URI to a CURIE using custom prefix map.
+    
+    :param uri: The URI to convert
+    :return: The CURIE representation of the URI, or the original URI if conversion fails
+    """
+    with open(PREFIXMAP_JSON_FILEPATH, 'r') as f:
+        prefix_map = json.load(f)
+    
+    converter = curies.Converter.from_prefix_map(prefix_map)
+    curie = converter.compress(uri)
+    
+    return curie if curie is not None else uri
 
 
 def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
@@ -34,10 +54,13 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
         reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
         for row in reader:
             synonym = row.get(synonym_column, '').strip()
-            metpo_curie = row.get(' ID', '').strip()
+            metpo_iri = row.get(' ID', '').strip()
             metpo_label = row.get('label', '').strip()
 
-            if synonym and metpo_curie:
+            if synonym and metpo_iri:
+                # Convert IRI to CURIE using the uri_to_curie function
+                metpo_curie = uri_to_curie(metpo_iri)
+                
                 mappings[synonym] = {
                     'curie': metpo_curie,
                     'label': metpo_label

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -16,16 +16,16 @@ METPO_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/
 def uri_to_curie(uri: str) -> str:
     """
     Convert a URI to a CURIE using custom prefix map.
-    
+
     :param uri: The URI to convert
     :return: The CURIE representation of the URI, or the original URI if conversion fails
     """
     with open(PREFIXMAP_JSON_FILEPATH, 'r') as f:
         prefix_map = json.load(f)
-    
+
     converter = curies.Converter.from_prefix_map(prefix_map)
     curie = converter.compress(uri)
-    
+
     return curie if curie is not None else uri
 
 
@@ -60,7 +60,7 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
             if synonym and metpo_iri:
                 # Convert IRI to CURIE using the uri_to_curie function
                 metpo_curie = uri_to_curie(metpo_iri)
-                
+
                 mappings[synonym] = {
                     'curie': metpo_curie,
                     'label': metpo_label


### PR DESCRIPTION
Fixes #364 

The edges.tsv/nodes.tsv for BacDive now uses METPO term CURIEs instead of full URIs.