### PR TITLE
Consume new terms from METPO sheet in Madin pipeline

### DIFF
--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -254,7 +254,9 @@ class MadinEtAlTransform(Transform):
                         pathways_not_in_metpo = []
                         for pathway in pathways:
                             metpo_mapping = self.madin_metpo_mappings.get(pathway.strip(), None)
+                            # print(f"Pathway: {pathway}, METPO mapping: {metpo_mapping}")
                             if metpo_mapping:
+                                # create pathway node and edge to tax_id
                                 pathway_nodes.append([
                                     metpo_mapping['curie'],
                                     PATHWAY_CATEGORY,
@@ -329,7 +331,9 @@ class MadinEtAlTransform(Transform):
                         carbon_substrates_not_in_metpo = []
                         for substrate in carbon_substrates:
                             metpo_mapping = self.madin_metpo_mappings.get(substrate.strip(), None)
+                            # print(f"Substrate: {substrate}, METPO mapping: {metpo_mapping}")
                             if metpo_mapping:
+                                # create carbon substrate node and edge to tax_id
                                 carbon_substrate_nodes.append([
                                     metpo_mapping['curie'],
                                     CARBON_SUBSTRATE_CATEGORY,
@@ -397,7 +401,9 @@ class MadinEtAlTransform(Transform):
                     if cell_shape:
                         # First try to find mapping in METPO
                         metpo_mapping = self.madin_metpo_mappings.get(cell_shape.strip(), None)
+                        # print(f"Cell shape: {cell_shape}, METPO mapping: {metpo_mapping}")
                         if metpo_mapping:
+                            # create cell shape node and edge to tax_id
                             cell_shape_node = [
                                 metpo_mapping['curie'],
                                 PHENOTYPIC_CATEGORY,

--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -98,7 +98,7 @@ class MadinEtAlTransform(Transform):
         source_name = MADIN_ETAL
         super().__init__(source_name, input_dir, output_dir, nlp)  # set some variables
         self.nlp = nlp
-        self.madin_metpo_mappings = load_metpo_mappings('madin synonym')
+        self.madin_metpo_mappings = load_metpo_mappings('madin synonym or field')
         self.environments_file = self.input_base_dir / "environments.csv"
 
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True):
@@ -171,7 +171,6 @@ class MadinEtAlTransform(Transform):
                 str(self.nlp_output_dir / go_result_fn), sep="\t", low_memory=False
             )
 
-        metabolism_map = self.madin_metpo_mappings
         envo_cols = [TYPE_COLUMN, ENVO_TERMS_COLUMN, ENVO_ID_COLUMN]
         envo_df = pd.read_csv(
             self.environments_file, low_memory=False, usecols=envo_cols
@@ -222,8 +221,10 @@ class MadinEtAlTransform(Transform):
                     tax_name = filtered_row[ORG_NAME_COLUMN]
                     tax_node = [tax_id, NCBI_CATEGORY, tax_name]
 
-                    metabolism = metabolism_map.get(filtered_row[METABOLISM_COLUMN], None)
+                    # block handling "metabolism" column from Madin etal dataset/CSV sheet
+                    metabolism = self.madin_metpo_mappings.get(filtered_row[METABOLISM_COLUMN], None)
                     if metabolism:
+                        # create metabolism node and edge to tax_id
                         metabolism_node = [
                             metabolism['curie'],
                             METABOLISM_CATEGORY,
@@ -235,6 +236,8 @@ class MadinEtAlTransform(Transform):
                             metabolism['curie'],
                             BIOLOGICAL_PROCESS,
                         ]
+
+                    # block handling "pathways" column from Madin etal dataset/CSV sheet
                     # Get these from NER results
                     pathways = (
                         None
@@ -244,49 +247,71 @@ class MadinEtAlTransform(Transform):
                         ]
                     )
                     if pathways:
-                        # go_condition_1 = go_result[TAX_ID_COLUMN] == tax_id
-                        go_condition = go_result[TRAITS_DATASET_LABEL_COLUMN].isin(pathways)
-                        go_result_for_tax_id = go_result.loc[go_condition]
-                        if go_result_for_tax_id.empty:
-                            pathway_nodes = [
-                                [PATHWAY_PREFIX + item.strip(), PATHWAY_CATEGORY, item.strip()]
-                                for item in pathways
-                            ]
-                            tax_pathway_edge = [
-                                [
+                        pathway_nodes = []
+                        tax_pathway_edge = []
+
+                        # First try to find mappings in METPO
+                        pathways_not_in_metpo = []
+                        for pathway in pathways:
+                            metpo_mapping = self.madin_metpo_mappings.get(pathway.strip(), None)
+                            if metpo_mapping:
+                                pathway_nodes.append([
+                                    metpo_mapping['curie'],
+                                    PATHWAY_CATEGORY,
+                                    metpo_mapping['label'],
+                                ])
+                                tax_pathway_edge.append([
                                     tax_id,
                                     NCBI_TO_PATHWAY_EDGE,
-                                    PATHWAY_PREFIX + item.strip().lower(),
+                                    metpo_mapping['curie'],
                                     BIOLOGICAL_PROCESS,
-                                ]
-                                for item in pathways
-                            ]
-                        else:
-                            exact_condition_go = (
-                                go_result_for_tax_id[OBJECT_LABEL_COLUMN]
-                                == go_result_for_tax_id[SUBJECT_LABEL_COLUMN]
-                            )
-                            exact_match_go_df = go_result_for_tax_id[exact_condition_go]
-                            if not exact_match_go_df.empty:
-                                go_result_for_tax_id = exact_match_go_df
-                            pathway_nodes = []
-                            tax_pathway_edge = []
-                            for row in go_result_for_tax_id.iterrows():
-                                pathway_nodes.append(
-                                    [row[1].object_id, PATHWAY_CATEGORY, row[1].object_label]
-                                )
-                                tax_pathway_edge.append(
-                                    [
+                                ])
+                            else:
+                                pathways_not_in_metpo.append(pathway)
+
+                        # For pathways not found in METPO, fall back to NER results
+                        if pathways_not_in_metpo:
+                            go_condition = go_result[TRAITS_DATASET_LABEL_COLUMN].isin(pathways_not_in_metpo)
+                            go_result_for_tax_id = go_result.loc[go_condition]
+                            if go_result_for_tax_id.empty:
+                                # Use fallback naming if no NER results
+                                for item in pathways_not_in_metpo:
+                                    pathway_nodes.append([
+                                    PATHWAY_PREFIX + item.strip(),
+                                    PATHWAY_CATEGORY,
+                                    item.strip()
+                                ])
+                                    tax_pathway_edge.append([
                                         tax_id,
                                         NCBI_TO_PATHWAY_EDGE,
-                                        row[1].object_id,
+                                        PATHWAY_PREFIX + item.strip().lower(),
                                         BIOLOGICAL_PROCESS,
-                                    ]
+                                    ])
+                            else:
+                                exact_condition_go = (
+                                    go_result_for_tax_id[OBJECT_LABEL_COLUMN]
+                                    == go_result_for_tax_id[SUBJECT_LABEL_COLUMN]
                                 )
+                                exact_match_go_df = go_result_for_tax_id[exact_condition_go]
+                                if not exact_match_go_df.empty:
+                                    go_result_for_tax_id = exact_match_go_df
+                                for row in go_result_for_tax_id.iterrows():
+                                    pathway_nodes.append(
+                                        [row[1].object_id, PATHWAY_CATEGORY, row[1].object_label]
+                                    )
+                                    tax_pathway_edge.append(
+                                        [
+                                            tax_id,
+                                            NCBI_TO_PATHWAY_EDGE,
+                                            row[1].object_id,
+                                            BIOLOGICAL_PROCESS,
+                                        ]
+                                    )
 
                         node_writer.writerows(pathway_nodes)
                         edge_writer.writerows(tax_pathway_edge)
 
+                    # block handling "carbon substrates" column from Madin etal dataset/CSV sheet
                     carbon_substrates = (
                         None
                         if filtered_row[CARBON_SUBSTRATES_COLUMN].split(",") == ["NA"]
@@ -297,78 +322,106 @@ class MadinEtAlTransform(Transform):
                     )
 
                     if carbon_substrates:
+                        carbon_substrate_nodes = []
+                        tax_carbon_substrate_edge = []
 
-                        # chebi_condition_1 = chebi_result[TAX_ID_COLUMN] == tax_id
-                        chebi_condition = chebi_result[TRAITS_DATASET_LABEL_COLUMN].isin(
-                            carbon_substrates
-                        )
-                        chebi_result_for_tax_id = chebi_result.loc[chebi_condition]
-                        if chebi_result_for_tax_id.empty:
-                            carbon_substrate_nodes = [
-                                [
-                                    CARBON_SUBSTRATE_PREFIX + item.strip(),
+                        # First try to find mappings in METPO
+                        carbon_substrates_not_in_metpo = []
+                        for substrate in carbon_substrates:
+                            metpo_mapping = self.madin_metpo_mappings.get(substrate.strip(), None)
+                            if metpo_mapping:
+                                carbon_substrate_nodes.append([
+                                    metpo_mapping['curie'],
                                     CARBON_SUBSTRATE_CATEGORY,
-                                    item.strip(),
-                                ]
-                                for item in carbon_substrates
-                            ]
-                            tax_carbon_substrate_edge = [
-                                [
+                                    metpo_mapping['label'],
+                                ])
+                                tax_carbon_substrate_edge.append([
                                     tax_id,
                                     NCBI_TO_CARBON_SUBSTRATE_EDGE,
-                                    CARBON_SUBSTRATE_PREFIX + item.strip(),
+                                    metpo_mapping['curie'],
                                     TROPHICALLY_INTERACTS_WITH,
-                                ]
-                                for item in carbon_substrates
-                            ]
+                                ])
+                            else:
+                                carbon_substrates_not_in_metpo.append(substrate)
 
-                        else:
-                            carbon_substrate_nodes = []
-                            tax_carbon_substrate_edge = []
-                            exact_condition_chebi = (
-                                chebi_result_for_tax_id[OBJECT_LABEL_COLUMN]
-                                == chebi_result_for_tax_id[SUBJECT_LABEL_COLUMN]
+                        # For carbon substrates not found in METPO, fall back to ChEBI NER results
+                        if carbon_substrates_not_in_metpo:
+                            chebi_condition = chebi_result[TRAITS_DATASET_LABEL_COLUMN].isin(
+                                carbon_substrates_not_in_metpo
                             )
-                            exact_match_chebi_df = chebi_result_for_tax_id[exact_condition_chebi]
-                            if not exact_match_chebi_df.empty:
-                                chebi_result_for_tax_id = exact_match_chebi_df
-                            for row in chebi_result_for_tax_id.iterrows():
-                                carbon_substrate_nodes.append(
-                                    [
+                            chebi_result_for_tax_id = chebi_result.loc[chebi_condition]
+                            if chebi_result_for_tax_id.empty:
+                                # Use fallback naming if no NER results
+                                for item in carbon_substrates_not_in_metpo:
+                                    carbon_substrate_nodes.append([
+                                        CARBON_SUBSTRATE_PREFIX + item.strip(),
+                                        CARBON_SUBSTRATE_CATEGORY,
+                                        item.strip(),
+                                    ])
+                                    tax_carbon_substrate_edge.append([
+                                        tax_id,
+                                        NCBI_TO_CARBON_SUBSTRATE_EDGE,
+                                        CARBON_SUBSTRATE_PREFIX + item.strip(),
+                                        TROPHICALLY_INTERACTS_WITH,
+                                    ])
+                            else:
+                                exact_condition_chebi = (
+                                    chebi_result_for_tax_id[OBJECT_LABEL_COLUMN]
+                                    == chebi_result_for_tax_id[SUBJECT_LABEL_COLUMN]
+                                )
+                                exact_match_chebi_df = chebi_result_for_tax_id[exact_condition_chebi]
+                                if not exact_match_chebi_df.empty:
+                                    chebi_result_for_tax_id = exact_match_chebi_df
+                                for row in chebi_result_for_tax_id.iterrows():
+                                    carbon_substrate_nodes.append([
                                         row[1].object_id,
                                         CARBON_SUBSTRATE_CATEGORY,
                                         row[1].object_label,
-                                    ]
-                                )
-                                tax_carbon_substrate_edge.append(
-                                    [
+                                    ])
+                                    tax_carbon_substrate_edge.append([
                                         tax_id,
                                         NCBI_TO_CARBON_SUBSTRATE_EDGE,
                                         row[1].object_id,
                                         BIOLOGICAL_PROCESS,
-                                    ]
-                                )
+                                    ])
 
                         node_writer.writerows(carbon_substrate_nodes)
                         edge_writer.writerows(tax_carbon_substrate_edge)
 
+                    # block handling "cell shape" column from Madin etal dataset/CSV sheet
                     cell_shape = (
                         None
                         if filtered_row[CELL_SHAPE_COLUMN] == "NA"
                         else filtered_row[CELL_SHAPE_COLUMN]
                     )
                     if cell_shape:
-                        cell_shape_node = [
-                            SHAPE_PREFIX + cell_shape,
-                            PHENOTYPIC_CATEGORY,
-                            cell_shape,
-                        ]
-                        tax_to_cell_shape_edge = [
-                            tax_id,
-                            NCBI_TO_SHAPE_EDGE,
-                            SHAPE_PREFIX + cell_shape,
-                            HAS_PHENOTYPE,
-                        ]
+                        # First try to find mapping in METPO
+                        metpo_mapping = self.madin_metpo_mappings.get(cell_shape.strip(), None)
+                        if metpo_mapping:
+                            cell_shape_node = [
+                                metpo_mapping['curie'],
+                                PHENOTYPIC_CATEGORY,
+                                metpo_mapping['label'],
+                            ]
+                            tax_to_cell_shape_edge = [
+                                tax_id,
+                                NCBI_TO_SHAPE_EDGE,
+                                metpo_mapping['curie'],
+                                HAS_PHENOTYPE,
+                            ]
+                        else:
+                            # Fall back to original logic
+                            cell_shape_node = [
+                                SHAPE_PREFIX + cell_shape,
+                                PHENOTYPIC_CATEGORY,
+                                cell_shape,
+                            ]
+                            tax_to_cell_shape_edge = [
+                                tax_id,
+                                NCBI_TO_SHAPE_EDGE,
+                                SHAPE_PREFIX + cell_shape,
+                                HAS_PHENOTYPE,
+                            ]
                     # envo_df
                     isolation_source = envo_mapping.get(filtered_row[ISOLATION_SOURCE_COLUMN], None)
                     if isolation_source:

--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -37,7 +37,6 @@ from kg_microbe.transform_utils.constants import (
     NCBI_CATEGORY,
     NCBI_TO_CARBON_SUBSTRATE_EDGE,
     NCBI_TO_ISOLATION_SOURCE_EDGE,
-    NCBI_TO_METABOLISM_EDGE,
     NCBI_TO_PATHWAY_EDGE,
     NCBI_TO_SHAPE_EDGE,
     NCBITAXON_PREFIX,
@@ -68,6 +67,7 @@ PARENT_DIR = Path(__file__).resolve().parent
 
 
 class MadinEtAlTransform(Transform):
+
     """
     Ingest Madin et al dataset (NCBI/GTDB).
 
@@ -94,7 +94,6 @@ class MadinEtAlTransform(Transform):
         :param input_dir: Input file path (str)
         :param output_dir: Output file path (str)
         """
-
         source_name = MADIN_ETAL
         super().__init__(source_name, input_dir, output_dir, nlp)  # set some variables
         self.nlp = nlp

--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -94,7 +94,7 @@ class MadinEtAlTransform(Transform):
         :param input_dir: Input file path (str)
         :param output_dir: Output file path (str)
         """
-        
+
         source_name = MADIN_ETAL
         super().__init__(source_name, input_dir, output_dir, nlp)  # set some variables
         self.nlp = nlp
@@ -227,10 +227,11 @@ class MadinEtAlTransform(Transform):
                     )
                     if metabolism:
                         # create metabolism node and edge to tax_id
-                        # Use biolink equivalent for category, predicate biolink equivalent from properties
+                        # use `biolink equivalent` for 'category' and
+                        # for 'predicate', `biolink equivalent` from properties
                         category = metabolism.get("biolink_equivalent", METABOLISM_CATEGORY)
                         predicate_biolink = metabolism.get("predicate_biolink_equivalent", "")
-                        # If no biolink equivalent, fall back to biolink:has_phenotype
+                        # fallback: if no biolink equivalent use `biolink:has_phenotype`
                         if predicate_biolink:
                             predicate = predicate_biolink
                         else:
@@ -267,12 +268,13 @@ class MadinEtAlTransform(Transform):
                             # print(f"Pathway: {pathway}, METPO mapping: {metpo_mapping}")
                             if metpo_mapping:
                                 # create pathway node and edge to tax_id
-                                # Use biolink equivalent for category, predicate biolink equivalent from properties
+                                # use `biolink equivalent` for 'category' and
+                                # for 'predicate', `biolink equivalent` from properties
                                 category = metpo_mapping.get("biolink_equivalent", PATHWAY_CATEGORY)
                                 predicate_biolink = metpo_mapping.get(
                                     "predicate_biolink_equivalent", ""
                                 )
-                                # If no biolink equivalent, fall back to biolink:capable_of
+                                # fallback: if no biolink equivalent use `biolink:capable_of`
                                 if predicate_biolink:
                                     predicate = predicate_biolink
                                 else:
@@ -364,14 +366,15 @@ class MadinEtAlTransform(Transform):
                             # print(f"Substrate: {substrate}, METPO mapping: {metpo_mapping}")
                             if metpo_mapping:
                                 # create carbon substrate node and edge to tax_id
-                                # Use biolink equivalent for category, predicate biolink equivalent from properties
+                                # use `biolink equivalent` for 'category' and
+                                # for 'predicate', `biolink equivalent` from properties
                                 category = metpo_mapping.get(
                                     "biolink_equivalent", CARBON_SUBSTRATE_CATEGORY
                                 )
                                 predicate_biolink = metpo_mapping.get(
                                     "predicate_biolink_equivalent", ""
                                 )
-                                # If no biolink equivalent, fall back to biolink:consumes
+                                # fallback: if no biolink equivalent use `biolink:consumes`
                                 if predicate_biolink:
                                     predicate = predicate_biolink
                                 else:
@@ -460,12 +463,13 @@ class MadinEtAlTransform(Transform):
                         # print(f"Cell shape: {cell_shape}, METPO mapping: {metpo_mapping}")
                         if metpo_mapping:
                             # create cell shape node and edge to tax_id
-                            # Use biolink equivalent for category, predicate biolink equivalent from properties
+                            # use `biolink equivalent` for 'category' and
+                            # for 'predicate', `biolink equivalent` from properties
                             category = metpo_mapping.get("biolink_equivalent", PHENOTYPIC_CATEGORY)
                             predicate_biolink = metpo_mapping.get(
                                 "predicate_biolink_equivalent", ""
                             )
-                            # If no biolink equivalent, fall back to biolink:has_phenotype
+                            # fallback: if no biolink equivalent use `biolink:has_phenotype`
                             if predicate_biolink:
                                 predicate = predicate_biolink
                             else:

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -16,7 +16,8 @@ METPO_PROPERTIES_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkele
 
 
 def uri_to_curie(uri: str) -> str:
-    """Convert a URI to a CURIE using a `curies` library specified custom Prefix Map.
+    """
+    Convert a URI to a CURIE using a `curies` library specified custom Prefix Map.
 
     It also checks if the input uri is already a CURIE, in which case it returns
     the CURIE value as-is.
@@ -85,7 +86,8 @@ class MetpoTreeNode:
         self.children.append(child)
 
     def find_biolink_equivalent_parent(self) -> Optional[str]:
-        """Find the closest parent (including self) that has a biolink equivalent.
+        """
+        Find the closest parent (including self) that has a biolink equivalent.
 
         (value populated in the `biolink equivalent` column).
         """
@@ -236,7 +238,8 @@ def _load_metpo_properties() -> Dict[str, Dict[str, str]]:
 
 
 def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
-    """Load METPO mappings from METPO classes ROBOT template file for a given synonym column.
+    """
+    Load METPO mappings from METPO classes ROBOT template file for a given synonym column.
 
     Implements the logic to find appropriate _predicates_ by traversing the parent hierarchy to find
     `biolink equivalent` and then mapping to properties.

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -45,6 +45,7 @@ def uri_to_curie(uri: str) -> str:
 
 
 class MetpoTreeNode:
+
     """
     Represents a node in the METPO class hierarchy tree.
 
@@ -61,6 +62,13 @@ class MetpoTreeNode:
     def __init__(
         self, iri: str, label: str, synonyms: List[str] = None, biolink_equivalent: str = None
     ):
+        """Initialize a MetpoTreeNode.
+
+        :param iri: The IRI or CURIE of the node
+        :param label: The human-readable label of the node
+        :param synonyms: List of synonyms for the node, defaults to None
+        :param biolink_equivalent: Biolink equivalent IRI if available, defaults to None
+        """
         self.iri = iri  # specified as CURIEs in the METPO classes/properties sheets
         self.label = label  # human-readable label
         self.synonyms = (
@@ -76,8 +84,10 @@ class MetpoTreeNode:
         self.children.append(child)
 
     def find_biolink_equivalent_parent(self) -> Optional[str]:
-        """Find the closest parent (including self) that has a biolink equivalent
-        (value populated in the `biolink equivalent` column)."""
+        """
+        Find the closest parent (including self) that has a biolink equivalent
+        (value populated in the `biolink equivalent` column).
+        """
         current = self
         while current is not None:
             if current.biolink_equivalent:
@@ -178,9 +188,9 @@ def _load_metpo_properties() -> Dict[str, Dict[str, str]]:
     Load METPO properties and create a mapping from RANGE class labels to property info.
 
     For example, from the METPO properties sheet, we can extract:
-    | ID               | label            | RANGE                 | biolink equivalent                                          |
-    |------------------|------------------|-----------------------|-------------------------------------------------------------|
-    | METPO:2000102    | has phenotype    | phenotype             | https://biolink.github.io/biolink-model/has_phenotype       |
+    | ID            | label         | RANGE     | biolink equivalent                                    |
+    |---------------|---------------|-----------|-------------------------------------------------------|
+    | METPO:2000102 | has phenotype | phenotype | https://biolink.github.io/biolink-model/has_phenotype |
 
     This would create a mapping that looks like below:
     {
@@ -230,9 +240,10 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
     Implements the logic to find appropriate _predicates_ by traversing the parent hierarchy to find
     `biolink equivalent` and then mapping to properties.
 
-    :param synonym_column: The column name to use for synonyms (e.g., 'bacdive keyword synonym', 'madin synonym or field', etc.)
+    :param synonym_column: The column name to use for synonyms 
+        (e.g., 'bacdive keyword synonym', 'madin synonym or field', etc.)
     :return: Dictionary mapping synonyms to METPO curie, label, and predicate information.
-             Format: {synonym: {'curie': metpo_curie, 'label': metpo_label, 'predicate': predicate_label}}
+        Format: {synonym: {'curie': metpo_curie, 'label': metpo_label, 'predicate': predicate_label}}
     :rtype: Dict[str, Dict[str, str]]
     :raises requests.exceptions.HTTPError: If unable to fetch from remote URL
     :raises ValueError: If the response content is empty or invalid

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -1,7 +1,7 @@
 """Utilities for handling mapping files from remote sources."""
 import csv
 import json
-from typing import Dict
+from typing import Dict, List, Optional
 
 import curies
 import requests
@@ -11,6 +11,7 @@ from kg_microbe.transform_utils.constants import PREFIXMAP_JSON_FILEPATH
 # remote URL location in metpo GitHub repository for ROBOT template
 # which will be used as the source of METPO mappings
 METPO_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/src/templates/metpo_sheet.tsv"
+METPO_PROPERTIES_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/src/templates/metpo-properties.tsv"
 
 
 def uri_to_curie(uri: str) -> str:
@@ -29,13 +30,131 @@ def uri_to_curie(uri: str) -> str:
     return curie if curie is not None else uri
 
 
+class MetpoTreeNode:
+    """
+    Represents a node in the METPO class hierarchy tree.
+    """
+    def __init__(self, iri: str, label: str, synonyms: List[str] = None):
+        self.iri = iri
+        self.label = label
+        self.synonyms = synonyms or []
+        self.children: List['MetpoTreeNode'] = []
+        self.parent: Optional['MetpoTreeNode'] = None
+    
+    def add_child(self, child: 'MetpoTreeNode'):
+        """Add a child node and set its parent."""
+        child.parent = self
+        self.children.append(child)
+    
+    def get_root_class_iri(self) -> str:
+        """Get the IRI of the root class by traversing up the tree."""
+        current = self
+        while current.parent is not None:
+            current = current.parent
+        return current.iri
+    
+    def find_synonym_node(self, synonym: str) -> Optional['MetpoTreeNode']:
+        """Find the node that contains the given synonym."""
+        if synonym in self.synonyms:
+            return self
+        
+        for child in self.children:
+            result = child.find_synonym_node(synonym)
+            if result:
+                return result
+        
+        return None
+
+
+def _build_metpo_tree() -> Dict[str, MetpoTreeNode]:
+    """
+    Build a tree structure from METPO classes based on parent-child relationships.
+    
+    :return: Dictionary mapping IRIs to MetpoTreeNode objects
+    """
+    try:
+        response = requests.get(METPO_ROBOT_TEMPLATE_URL, timeout=30)
+        response.raise_for_status()
+        
+        if not response.text.strip():
+            raise ValueError("The contents of the metpo sheet file are empty or invalid.")
+        
+        lines = response.text.splitlines()
+        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
+        
+        # First pass: create all nodes
+        nodes = {}
+        for row in reader:
+            iri = row.get(' ID', '').strip()
+            label = row.get('label', '').strip()
+            madin_synonym = row.get('madin synonym or field', '').strip()
+            
+            if iri and label:
+                # Handle pipe-separated synonyms
+                if madin_synonym:
+                    synonyms = [s.strip() for s in madin_synonym.split('|') if s.strip()]
+                else:
+                    synonyms = []
+                nodes[iri] = MetpoTreeNode(iri, label, synonyms)
+        
+        # Second pass: establish parent-child relationships
+        lines = response.text.splitlines()
+        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
+        
+        roots = set(nodes.keys())
+        
+        for row in reader:
+            iri = row.get(' ID', '').strip()
+            parent_iri = row.get('parent class', '').strip()
+            
+            if iri in nodes and parent_iri and parent_iri in nodes:
+                nodes[parent_iri].add_child(nodes[iri])
+                roots.discard(iri)
+        
+        return nodes
+        
+    except requests.exceptions.HTTPError as e:
+        raise requests.exceptions.HTTPError(f"Please ensure the METPO sheet URL is accessible: {e}") from e
+
+
+def _load_metpo_properties() -> Dict[str, str]:
+    """
+    Load METPO properties and create a mapping from RANGE class IRI to property label.
+    
+    :return: Dictionary mapping RANGE IRIs to property labels
+    """
+    try:
+        response = requests.get(METPO_PROPERTIES_URL, timeout=30)
+        response.raise_for_status()
+        
+        if not response.text.strip():
+            raise ValueError("The contents of the metpo properties file are empty or invalid.")
+        
+        lines = response.text.splitlines()
+        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
+        
+        range_to_label = {}
+        for row in reader:
+            range_iri = row.get('RANGE', '').strip()
+            label = row.get('label', '').strip()
+            
+            if range_iri and label:
+                range_to_label[range_iri] = label
+        
+        return range_to_label
+        
+    except requests.exceptions.HTTPError as e:
+        raise requests.exceptions.HTTPError(f"Please ensure the METPO properties URL is accessible: {e}") from e
+
+
 def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
     """
     Load METPO mappings from ROBOT template file (in metpo repository) for a specific synonym column.
+    Now supports building tree structure and finding appropriate predicates.
 
-    :param synonym_column: The column name to use for synonyms (e.g., 'bacdive keyword synonym', 'madin synonym', etc.)
-    :return: Dictionary mapping synonyms to METPO curie and label information.
-             Format: {synonym: {'curie': metpo_curie, 'label': metpo_label}}
+    :param synonym_column: The column name to use for synonyms (e.g., 'bacdive keyword synonym', 'madin synonym or field', etc.)
+    :return: Dictionary mapping synonyms to METPO curie, label, and predicate information.
+             Format: {synonym: {'curie': metpo_curie, 'label': metpo_label, 'predicate': predicate_label}}
     :rtype: Dict[str, Dict[str, str]]
     :raises requests.exceptions.HTTPError: If unable to fetch from remote URL
     :raises ValueError: If the response content is empty or invalid
@@ -43,6 +162,13 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
     mappings = {}
 
     try:
+        # Build the METPO tree structure
+        nodes = _build_metpo_tree()
+        
+        # Load properties mapping
+        range_to_predicate = _load_metpo_properties()
+        
+        # Load the main sheet for synonyms
         response = requests.get(METPO_ROBOT_TEMPLATE_URL, timeout=30)
         response.raise_for_status()
 
@@ -50,8 +176,8 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
             raise ValueError("The contents of the file at the remote URL are empty or invalid.")
 
         lines = response.text.splitlines()
-        # Skip the second header row and use the first row for column names
         reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
+        
         for row in reader:
             synonym = row.get(synonym_column, '').strip()
             metpo_iri = row.get(' ID', '').strip()
@@ -61,10 +187,24 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
                 # Convert IRI to CURIE using the uri_to_curie function
                 metpo_curie = uri_to_curie(metpo_iri)
 
-                mappings[synonym] = {
-                    'curie': metpo_curie,
-                    'label': metpo_label
-                }
+                # Find the appropriate predicate
+                predicate_label = "has phenotype"  # default
+                if metpo_iri in nodes:
+                    node = nodes[metpo_iri]
+                    root_iri = node.get_root_class_iri()
+                    if root_iri in range_to_predicate:
+                        predicate_label = range_to_predicate[root_iri]
+
+                # Handle pipe-separated synonyms
+                synonyms = [s.strip() for s in synonym.split('|')]
+
+                for syn in synonyms:
+                    if syn:  # Only add non-empty synonyms
+                        mappings[syn] = {
+                            'curie': metpo_curie,
+                            'label': metpo_label,
+                            'predicate': predicate_label
+                        }
 
         return mappings
 

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -1,4 +1,5 @@
 """Utilities for handling mapping files from remote sources."""
+
 import csv
 import json
 from typing import Dict, List, Optional
@@ -10,18 +11,23 @@ from kg_microbe.transform_utils.constants import PREFIXMAP_JSON_FILEPATH
 
 # remote URL location in metpo GitHub repository for ROBOT template
 # which will be used as the source of METPO mappings
-METPO_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/src/templates/metpo_sheet.tsv"
-METPO_PROPERTIES_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/src/templates/metpo-properties.tsv"
+METPO_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2025-09-23/src/templates/metpo_sheet.tsv"
+METPO_PROPERTIES_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2025-09-23/src/templates/metpo-properties.tsv"
 
 
 def uri_to_curie(uri: str) -> str:
     """
     Convert a URI to a CURIE using custom prefix map.
+    Now also handles cases where the input is already a CURIE.
 
-    :param uri: The URI to convert
-    :return: The CURIE representation of the URI, or the original URI if conversion fails
+    :param uri: The URI to convert, or a CURIE that's already in the correct format
+    :return: The CURIE representation of the URI, or the original input if it's already a CURIE
     """
-    with open(PREFIXMAP_JSON_FILEPATH, 'r') as f:
+    # If it's already a CURIE (contains ':' and doesn't start with http), return as-is
+    if ":" in uri and not uri.startswith("http"):
+        return uri
+
+    with open(PREFIXMAP_JSON_FILEPATH, "r") as f:
         prefix_map = json.load(f)
 
     converter = curies.Converter.from_prefix_map(prefix_map)
@@ -31,126 +37,152 @@ def uri_to_curie(uri: str) -> str:
 
 
 class MetpoTreeNode:
+
     """
     Represents a node in the METPO class hierarchy tree.
     """
-    def __init__(self, iri: str, label: str, synonyms: List[str] = None):
+
+    def __init__(
+        self, iri: str, label: str, synonyms: List[str] = None, biolink_equivalent: str = None
+    ):
         self.iri = iri
         self.label = label
         self.synonyms = synonyms or []
-        self.children: List['MetpoTreeNode'] = []
-        self.parent: Optional['MetpoTreeNode'] = None
-    
-    def add_child(self, child: 'MetpoTreeNode'):
+        self.biolink_equivalent = biolink_equivalent
+        self.children: List["MetpoTreeNode"] = []
+        self.parent: Optional["MetpoTreeNode"] = None
+
+    def add_child(self, child: "MetpoTreeNode"):
         """Add a child node and set its parent."""
         child.parent = self
         self.children.append(child)
-    
-    def get_root_class_iri(self) -> str:
-        """Get the IRI of the root class by traversing up the tree."""
+
+    def find_biolink_equivalent_parent(self) -> Optional[str]:
+        """Find the closest parent (including self) that has a biolink equivalent."""
         current = self
-        while current.parent is not None:
+        while current is not None:
+            if current.biolink_equivalent:
+                return current.biolink_equivalent
             current = current.parent
-        return current.iri
-    
-    def find_synonym_node(self, synonym: str) -> Optional['MetpoTreeNode']:
+        return None
+
+    def find_synonym_node(self, synonym: str) -> Optional["MetpoTreeNode"]:
         """Find the node that contains the given synonym."""
         if synonym in self.synonyms:
             return self
-        
+
         for child in self.children:
             result = child.find_synonym_node(synonym)
             if result:
                 return result
-        
+
         return None
 
 
 def _build_metpo_tree() -> Dict[str, MetpoTreeNode]:
     """
     Build a tree structure from METPO classes based on parent-child relationships.
-    
-    :return: Dictionary mapping IRIs to MetpoTreeNode objects
+
+    :return: Dictionary mapping IRIs/CURIEs to MetpoTreeNode objects
     """
     try:
         response = requests.get(METPO_ROBOT_TEMPLATE_URL, timeout=30)
         response.raise_for_status()
-        
+
         if not response.text.strip():
             raise ValueError("The contents of the metpo sheet file are empty or invalid.")
-        
+
         lines = response.text.splitlines()
-        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
-        
+        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split("\t"), delimiter="\t")
+
         # First pass: create all nodes
         nodes = {}
         for row in reader:
-            iri = row.get(' ID', '').strip()
-            label = row.get('label', '').strip()
-            madin_synonym = row.get('madin synonym or field', '').strip()
-            
+            iri = row.get("ID", "").strip()  # Now this is a CURIE like METPO:1000059
+            label = row.get("label", "").strip()
+            madin_synonym = row.get("madin synonym or field", "").strip()
+            biolink_equivalent = row.get("biolink equivalent", "").strip()
+
             if iri and label:
                 # Handle pipe-separated synonyms
                 if madin_synonym:
-                    synonyms = [s.strip() for s in madin_synonym.split('|') if s.strip()]
+                    synonyms = [s.strip() for s in madin_synonym.split("|") if s.strip()]
                 else:
                     synonyms = []
-                nodes[iri] = MetpoTreeNode(iri, label, synonyms)
-        
+                nodes[iri] = MetpoTreeNode(iri, label, synonyms, biolink_equivalent)
+
         # Second pass: establish parent-child relationships
         lines = response.text.splitlines()
-        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
-        
+        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split("\t"), delimiter="\t")
+
         roots = set(nodes.keys())
-        
+
         for row in reader:
-            iri = row.get(' ID', '').strip()
-            parent_iri = row.get('parent class', '').strip()
-            
-            if iri in nodes and parent_iri and parent_iri in nodes:
-                nodes[parent_iri].add_child(nodes[iri])
-                roots.discard(iri)
-        
+            iri = row.get("ID", "").strip()
+            parent_label = row.get("parent class", "").strip()
+
+            if iri in nodes and parent_label:
+                # Find parent by label since parent class column contains labels, not CURIEs
+                parent_iri = None
+                for candidate_iri, candidate_node in nodes.items():
+                    if candidate_node.label == parent_label:
+                        parent_iri = candidate_iri
+                        break
+
+                if parent_iri and parent_iri in nodes:
+                    nodes[parent_iri].add_child(nodes[iri])
+                    roots.discard(iri)
+
         return nodes
-        
+
     except requests.exceptions.HTTPError as e:
-        raise requests.exceptions.HTTPError(f"Please ensure the METPO sheet URL is accessible: {e}") from e
+        raise requests.exceptions.HTTPError(
+            f"Please ensure the METPO sheet URL is accessible: {e}"
+        ) from e
 
 
-def _load_metpo_properties() -> Dict[str, str]:
+def _load_metpo_properties() -> Dict[str, Dict[str, str]]:
     """
-    Load METPO properties and create a mapping from RANGE class IRI to property label.
-    
-    :return: Dictionary mapping RANGE IRIs to property labels
+    Load METPO properties and create a mapping from RANGE class labels to property info.
+
+    :return: Dictionary mapping RANGE class labels to property info (label and biolink_equivalent)
     """
     try:
         response = requests.get(METPO_PROPERTIES_URL, timeout=30)
         response.raise_for_status()
-        
+
         if not response.text.strip():
             raise ValueError("The contents of the metpo properties file are empty or invalid.")
-        
+
         lines = response.text.splitlines()
-        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
-        
-        range_to_label = {}
+        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split("\t"), delimiter="\t")
+
+        range_to_predicate = {}
         for row in reader:
-            range_iri = row.get('RANGE', '').strip()
-            label = row.get('label', '').strip()
-            
-            if range_iri and label:
-                range_to_label[range_iri] = label
-        
-        return range_to_label
-        
+            range_class = row.get("RANGE", "").strip()
+            label = row.get("label", "").strip()
+            biolink_equivalent = row.get("biolink equivalent", "").strip()
+
+            if range_class and label:
+                # Map RANGE class labels to property info
+                range_to_predicate[range_class] = {
+                    "label": label,
+                    "biolink_equivalent": biolink_equivalent,
+                }
+
+        return range_to_predicate
+
     except requests.exceptions.HTTPError as e:
-        raise requests.exceptions.HTTPError(f"Please ensure the METPO properties URL is accessible: {e}") from e
+        raise requests.exceptions.HTTPError(
+            f"Please ensure the METPO properties URL is accessible: {e}"
+        ) from e
 
 
 def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
     """
     Load METPO mappings from ROBOT template file (in metpo repository) for a specific synonym column.
-    Now supports building tree structure and finding appropriate predicates.
+    Implements the logic to find appropriate predicates by traversing parent hierarchy to find
+    biolink equivalent and then mapping to properties.
 
     :param synonym_column: The column name to use for synonyms (e.g., 'bacdive keyword synonym', 'madin synonym or field', etc.)
     :return: Dictionary mapping synonyms to METPO curie, label, and predicate information.
@@ -164,10 +196,10 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
     try:
         # Build the METPO tree structure
         nodes = _build_metpo_tree()
-        
-        # Load properties mapping
+
+        # Load properties mapping (RANGE class label -> predicate label)
         range_to_predicate = _load_metpo_properties()
-        
+
         # Load the main sheet for synonyms
         response = requests.get(METPO_ROBOT_TEMPLATE_URL, timeout=30)
         response.raise_for_status()
@@ -176,37 +208,53 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
             raise ValueError("The contents of the file at the remote URL are empty or invalid.")
 
         lines = response.text.splitlines()
-        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split('\t'), delimiter='\t')
-        
+        reader = csv.DictReader(lines[2:], fieldnames=lines[0].split("\t"), delimiter="\t")
+
         for row in reader:
-            synonym = row.get(synonym_column, '').strip()
-            metpo_iri = row.get(' ID', '').strip()
-            metpo_label = row.get('label', '').strip()
+            synonym = row.get(synonym_column, "").strip()
+            metpo_curie = row.get("ID", "").strip()  # Already a CURIE
+            metpo_label = row.get("label", "").strip()
+            biolink_equivalent = row.get("biolink equivalent", "").strip()
 
-            if synonym and metpo_iri:
-                # Convert IRI to CURIE using the uri_to_curie function
-                metpo_curie = uri_to_curie(metpo_iri)
-
-                # Find the appropriate predicate
+            if synonym and metpo_curie:
+                # Find the appropriate predicate using the logic:
+                # 1. Find the closest parent with biolink equivalent
+                # 2. Use the parent's label to find matching RANGE in properties sheet
+                # 3. Get the predicate info for that RANGE
                 predicate_label = "has phenotype"  # default
-                if metpo_iri in nodes:
-                    node = nodes[metpo_iri]
-                    root_iri = node.get_root_class_iri()
-                    if root_iri in range_to_predicate:
-                        predicate_label = range_to_predicate[root_iri]
+                predicate_biolink_equivalent = ""  # default empty
+                if metpo_curie in nodes:
+                    node = nodes[metpo_curie]
+                    # Find the parent node that has a biolink equivalent
+                    current = node
+                    while current is not None:
+                        if current.biolink_equivalent:
+                            # Use the parent's label to look up in properties RANGE
+                            parent_label = current.label
+                            if parent_label in range_to_predicate:
+                                predicate_label = range_to_predicate[parent_label]["label"]
+                                predicate_biolink_equivalent = range_to_predicate[parent_label][
+                                    "biolink_equivalent"
+                                ]
+                            break
+                        current = current.parent
 
                 # Handle pipe-separated synonyms
-                synonyms = [s.strip() for s in synonym.split('|')]
+                synonyms = [s.strip() for s in synonym.split("|")]
 
                 for syn in synonyms:
                     if syn:  # Only add non-empty synonyms
                         mappings[syn] = {
-                            'curie': metpo_curie,
-                            'label': metpo_label,
-                            'predicate': predicate_label
+                            "curie": metpo_curie,
+                            "label": metpo_label,
+                            "predicate": predicate_label,
+                            "predicate_biolink_equivalent": predicate_biolink_equivalent,
+                            "biolink_equivalent": biolink_equivalent,
                         }
 
         return mappings
 
     except requests.exceptions.HTTPError as e:
-        raise requests.exceptions.HTTPError(f"Please ensure the remote URL is accessible: {e}") from e
+        raise requests.exceptions.HTTPError(
+            f"Please ensure the remote URL is accessible: {e}"
+        ) from e

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -16,8 +16,8 @@ METPO_PROPERTIES_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkele
 
 
 def uri_to_curie(uri: str) -> str:
-    """
-    Convert a URI to a CURIE using a `curies` library specified custom Prefix Map.
+    """Convert a URI to a CURIE using a `curies` library specified custom Prefix Map.
+
     It also checks if the input uri is already a CURIE, in which case it returns
     the CURIE value as-is.
 
@@ -62,7 +62,8 @@ class MetpoTreeNode:
     def __init__(
         self, iri: str, label: str, synonyms: List[str] = None, biolink_equivalent: str = None
     ):
-        """Initialize a MetpoTreeNode.
+        """
+        Initialize a MetpoTreeNode.
 
         :param iri: The IRI or CURIE of the node
         :param label: The human-readable label of the node
@@ -84,8 +85,8 @@ class MetpoTreeNode:
         self.children.append(child)
 
     def find_biolink_equivalent_parent(self) -> Optional[str]:
-        """
-        Find the closest parent (including self) that has a biolink equivalent
+        """Find the closest parent (including self) that has a biolink equivalent.
+
         (value populated in the `biolink equivalent` column).
         """
         current = self
@@ -235,12 +236,12 @@ def _load_metpo_properties() -> Dict[str, Dict[str, str]]:
 
 
 def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
-    """
-    Load METPO mappings from METPO classes ROBOT template file for a given synonym column.
+    """Load METPO mappings from METPO classes ROBOT template file for a given synonym column.
+
     Implements the logic to find appropriate _predicates_ by traversing the parent hierarchy to find
     `biolink equivalent` and then mapping to properties.
 
-    :param synonym_column: The column name to use for synonyms 
+    :param synonym_column: The column name to use for synonyms
         (e.g., 'bacdive keyword synonym', 'madin synonym or field', etc.)
     :return: Dictionary mapping synonyms to METPO curie, label, and predicate information.
         Format: {synonym: {'curie': metpo_curie, 'label': metpo_label, 'predicate': predicate_label}}


### PR DESCRIPTION
- [x] Add generic logic to handle new METPO classes/properties sheet structure
  - [x] Be able to parse out and handle Madin column names/synonyms appropriately
- [x] Use Madin synonym to METPO class mappings in Madin pipeline