### PR TITLE
Add logic to infer phenotypic category from METPO classes sheet

### DIFF
--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -67,7 +67,6 @@ PARENT_DIR = Path(__file__).resolve().parent
 
 
 class MadinEtAlTransform(Transform):
-
     """
     Ingest Madin et al dataset (NCBI/GTDB).
 
@@ -98,6 +97,7 @@ class MadinEtAlTransform(Transform):
         super().__init__(source_name, input_dir, output_dir, nlp)  # set some variables
         self.nlp = nlp
         self.madin_metpo_mappings = load_metpo_mappings("madin synonym or field")
+        print(self.madin_metpo_mappings)
         self.environments_file = self.input_base_dir / "environments.csv"
 
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True):
@@ -226,9 +226,8 @@ class MadinEtAlTransform(Transform):
                     )
                     if metabolism:
                         # create metabolism node and edge to tax_id
-                        # use `biolink equivalent` for 'category' and
-                        # for 'predicate', `biolink equivalent` from properties
-                        category = metabolism.get("biolink_equivalent", METABOLISM_CATEGORY)
+                        # use biolink_equivalent URL from METPO tree traversal or fallback to default
+                        category = metabolism.get("inferred_category", METABOLISM_CATEGORY)
                         predicate_biolink = metabolism.get("predicate_biolink_equivalent", "")
                         # fallback: if no biolink equivalent use `biolink:has_phenotype`
                         if predicate_biolink:
@@ -267,9 +266,8 @@ class MadinEtAlTransform(Transform):
                             # print(f"Pathway: {pathway}, METPO mapping: {metpo_mapping}")
                             if metpo_mapping:
                                 # create pathway node and edge to tax_id
-                                # use `biolink equivalent` for 'category' and
-                                # for 'predicate', `biolink equivalent` from properties
-                                category = metpo_mapping.get("biolink_equivalent", PATHWAY_CATEGORY)
+                                # use biolink_equivalent URL from METPO tree traversal or fallback to default
+                                category = metpo_mapping.get("inferred_category", PATHWAY_CATEGORY)
                                 predicate_biolink = metpo_mapping.get(
                                     "predicate_biolink_equivalent", ""
                                 )
@@ -365,10 +363,9 @@ class MadinEtAlTransform(Transform):
                             # print(f"Substrate: {substrate}, METPO mapping: {metpo_mapping}")
                             if metpo_mapping:
                                 # create carbon substrate node and edge to tax_id
-                                # use `biolink equivalent` for 'category' and
-                                # for 'predicate', `biolink equivalent` from properties
+                                # use biolink_equivalent URL from METPO tree traversal or fallback to default
                                 category = metpo_mapping.get(
-                                    "biolink_equivalent", CARBON_SUBSTRATE_CATEGORY
+                                    "inferred_category", CARBON_SUBSTRATE_CATEGORY
                                 )
                                 predicate_biolink = metpo_mapping.get(
                                     "predicate_biolink_equivalent", ""
@@ -462,9 +459,8 @@ class MadinEtAlTransform(Transform):
                         # print(f"Cell shape: {cell_shape}, METPO mapping: {metpo_mapping}")
                         if metpo_mapping:
                             # create cell shape node and edge to tax_id
-                            # use `biolink equivalent` for 'category' and
-                            # for 'predicate', `biolink equivalent` from properties
-                            category = metpo_mapping.get("biolink_equivalent", PHENOTYPIC_CATEGORY)
+                            # use biolink_equivalent URL from METPO tree traversal or fallback to default
+                            category = metpo_mapping.get("inferred_category", PHENOTYPIC_CATEGORY)
                             predicate_biolink = metpo_mapping.get(
                                 "predicate_biolink_equivalent", ""
                             )

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -46,7 +46,6 @@ def uri_to_curie(uri: str) -> str:
 
 
 class MetpoTreeNode:
-
     """
     Represents a node in the METPO class hierarchy tree.
 
@@ -278,20 +277,25 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
             biolink_equivalent = row.get("biolink equivalent", "").strip()
 
             if synonym and metpo_curie:
-                # Find the appropriate predicate using the logic:
+                # Find the appropriate predicate and category using tree traversal logic:
                 # 1. find the closest parent with `biolink equivalent`
                 # 2. use the parent's label to find matching RANGE in properties sheet
                 # 3. get the predicate info for that RANGE
+                # 4. use the parent's label as the category
                 predicate_label = "has phenotype"  # default
                 predicate_biolink_equivalent = ""  # default empty
+                inferred_category = ""  # default empty, will be inferred from parent
                 if metpo_curie in nodes:
                     node = nodes[metpo_curie]
                     # find the parent node that has a `biolink equivalent`
                     current = node
                     while current is not None:
                         if current.biolink_equivalent:
-                            # use the parent's label to look up in properties RANGE
+                            # use the parent's biolink_equivalent URL as the category
                             parent_label = current.label
+                            inferred_category = (
+                                current.biolink_equivalent
+                            )  # use parent's biolink_equivalent URL as category
                             if parent_label in range_to_predicate:
                                 predicate_label = range_to_predicate[parent_label]["label"]
                                 predicate_biolink_equivalent = range_to_predicate[parent_label][
@@ -311,6 +315,7 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
                             "predicate": predicate_label,
                             "predicate_biolink_equivalent": predicate_biolink_equivalent,
                             "biolink_equivalent": biolink_equivalent,
+                            "inferred_category": inferred_category,
                         }
 
         return mappings


### PR DESCRIPTION
In the METPO classes sheet, for a given synonym we need to look for the closest parent which has a value asserted in the `biolink equivalent` column and use that (biolink URL) value while constructing the edges/nodes KGX files.