### PR TITLE
Madin transformation pipeline should use custom `biolink:` from prefixmap

### DIFF
--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -57,7 +57,7 @@ from kg_microbe.transform_utils.constants import (
 )
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.dummy_tqdm import DummyTqdm
-from kg_microbe.utils.mapping_file_utils import load_metpo_mappings
+from kg_microbe.utils.mapping_file_utils import load_metpo_mappings, uri_to_curie
 from kg_microbe.utils.ner_utils import annotate
 from kg_microbe.utils.pandas_utils import drop_duplicates
 
@@ -231,7 +231,7 @@ class MadinEtAlTransform(Transform):
                         predicate_biolink = metabolism.get("predicate_biolink_equivalent", "")
                         # fallback: if no biolink equivalent use `biolink:has_phenotype`
                         if predicate_biolink:
-                            predicate = predicate_biolink
+                            predicate = uri_to_curie(predicate_biolink)
                         else:
                             predicate = "biolink:has_phenotype"
                         metabolism_node = [
@@ -273,7 +273,7 @@ class MadinEtAlTransform(Transform):
                                 )
                                 # fallback: if no biolink equivalent use `biolink:capable_of`
                                 if predicate_biolink:
-                                    predicate = predicate_biolink
+                                    predicate = uri_to_curie(predicate_biolink)
                                 else:
                                     predicate = "biolink:capable_of"
                                 pathway_nodes.append(
@@ -372,7 +372,7 @@ class MadinEtAlTransform(Transform):
                                 )
                                 # fallback: if no biolink equivalent use `biolink:consumes`
                                 if predicate_biolink:
-                                    predicate = predicate_biolink
+                                    predicate = uri_to_curie(predicate_biolink)
                                 else:
                                     predicate = "biolink:consumes"
                                 carbon_substrate_nodes.append(
@@ -466,7 +466,7 @@ class MadinEtAlTransform(Transform):
                             )
                             # fallback: if no biolink equivalent use `biolink:has_phenotype`
                             if predicate_biolink:
-                                predicate = predicate_biolink
+                                predicate = uri_to_curie(predicate_biolink)
                             else:
                                 predicate = "biolink:has_phenotype"
                             cell_shape_node = [

--- a/kg_microbe/transform_utils/prefixmap.json
+++ b/kg_microbe/transform_utils/prefixmap.json
@@ -1,3 +1,4 @@
 {
-    "METPO": "https://w3id.org/metpo/"
+    "METPO": "https://w3id.org/metpo/",
+    "biolink": "https://biolink.github.io/biolink-model/"
 }


### PR DESCRIPTION
There is now a `biolink:` prefix defined in the custom prefixmap for KGM and in this PR, the Madin transformation pipeline has been modified such that the edge predicates can pick up on the prefix mappings and convert biolink URL predicates to CURIEs where necessary.

Overall output: Madin KGX transformation files no longer have a mixture of URLs and CURIEs. Now it's just CURIEs.