### PR TITLE
Make sure the category values are CURIEs in the Madin nodes KGX file

### DIFF
--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -227,7 +227,7 @@ class MadinEtAlTransform(Transform):
                     if metabolism:
                         # create metabolism node and edge to tax_id
                         # use biolink_equivalent URL from METPO tree traversal or fallback to default
-                        category = metabolism.get("inferred_category", METABOLISM_CATEGORY)
+                        category = uri_to_curie(metabolism.get("inferred_category", METABOLISM_CATEGORY))
                         predicate_biolink = metabolism.get("predicate_biolink_equivalent", "")
                         # fallback: if no biolink equivalent use `biolink:has_phenotype`
                         if predicate_biolink:
@@ -267,7 +267,7 @@ class MadinEtAlTransform(Transform):
                             if metpo_mapping:
                                 # create pathway node and edge to tax_id
                                 # use biolink_equivalent URL from METPO tree traversal or fallback to default
-                                category = metpo_mapping.get("inferred_category", PATHWAY_CATEGORY)
+                                category = uri_to_curie(metpo_mapping.get("inferred_category", PATHWAY_CATEGORY))
                                 predicate_biolink = metpo_mapping.get(
                                     "predicate_biolink_equivalent", ""
                                 )
@@ -364,9 +364,9 @@ class MadinEtAlTransform(Transform):
                             if metpo_mapping:
                                 # create carbon substrate node and edge to tax_id
                                 # use biolink_equivalent URL from METPO tree traversal or fallback to default
-                                category = metpo_mapping.get(
+                                category = uri_to_curie(metpo_mapping.get(
                                     "inferred_category", CARBON_SUBSTRATE_CATEGORY
-                                )
+                                ))
                                 predicate_biolink = metpo_mapping.get(
                                     "predicate_biolink_equivalent", ""
                                 )
@@ -460,7 +460,7 @@ class MadinEtAlTransform(Transform):
                         if metpo_mapping:
                             # create cell shape node and edge to tax_id
                             # use biolink_equivalent URL from METPO tree traversal or fallback to default
-                            category = metpo_mapping.get("inferred_category", PHENOTYPIC_CATEGORY)
+                            category = uri_to_curie(metpo_mapping.get("inferred_category", PHENOTYPIC_CATEGORY))
                             predicate_biolink = metpo_mapping.get(
                                 "predicate_biolink_equivalent", ""
                             )


### PR DESCRIPTION
Previously a node in the transformation output KGX file for the Madin et al data source had rows like this:

| id           | category               | name    |
|---------------|------------------------|---------|
| METPO:1000602 | https://biolink.github.io/biolink-model/PhenotypicQuality | aerobic |

After this PR, it will look like this:

| id           | category               | name    |
|---------------|------------------------|---------|
| METPO:1000602 | biolink:PhenotypicQuality | aerobic |

It is a follow up activity from https://github.com/Knowledge-Graph-Hub/kg-microbe/pull/399