### PR TITLE
Change bactotraits synonym column name in METPO classes sheet

### DIFF
--- a/kg_microbe/transform_utils/bactotraits/bactotraits.py
+++ b/kg_microbe/transform_utils/bactotraits/bactotraits.py
@@ -162,7 +162,7 @@ class BactoTraitsTransform(Transform):
         source_name = BACTOTRAITS
         super().__init__(source_name, input_dir, output_dir)
         self.ncbi_impl = get_adapter(f"sqlite:{NCBITAXON_SOURCE}")
-        self.bactotraits_metpo_mappings = load_metpo_mappings("bactotraits synonym")
+        self.bactotraits_metpo_mappings = load_metpo_mappings("bactotraits related synonym")
 
     def _clean_row(self, row):
         # Create a translation table that maps unwanted characters to None


### PR DESCRIPTION
Bactotraits synonym mapping column is called "bactotraits related synonym" in the latest release of METPO.

See classes sheet here: https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2025-11-24/src/templates/metpo_sheet.tsv