### PR TITLE
Use METPO release `2025-12-12`

### DIFF
--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -11,8 +11,8 @@ from kg_microbe.transform_utils.constants import PREFIXMAP_JSON_FILEPATH
 
 # remote URL location in metpo GitHub repository for METPO classes and properties
 # sheets/ROBOT templates respectively, which will be used as the source of METPO mappings
-METPO_CLASSES_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2025-11-24/src/templates/metpo_sheet.tsv"
-METPO_PROPERTIES_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2025-11-24/src/templates/metpo-properties.tsv"
+METPO_CLASSES_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2025-12-12/src/templates/metpo_sheet.tsv"
+METPO_PROPERTIES_ROBOT_TEMPLATE_URL = "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2025-12-12/src/templates/metpo-properties.tsv"
 
 # Remote URL for assay kits mapping (used for API keys from BacDive)
 ASSAY_KITS_SIMPLE_JSON_URL = "https://raw.githubusercontent.com/CultureBotAI/assay-metadata/refs/heads/main/data/assay_kits_simple.json"


### PR DESCRIPTION
Use the latest release of METPO which is https://github.com/berkeleybop/metpo/releases/tag/2025-12-12