### PR TITLE
Add .github/dependabot.yml to open weekly dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
       - "dependencies"
       - "github-actions"
     groups:
+      # Only group minor/patch Actions updates; majors stay as individual PRs.
       actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot configuration: opens PRs for dependency updates.
+# Does NOT merge anything automatically — every update still requires a human merge.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python dependencies (Poetry lockfile resolved by the pip ecosystem adapter)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      # One combined PR per week for all minor/patch Python bumps.
+      # Major bumps get their own PRs (Dependabot default) so they can be reviewed individually.
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions pinned in workflow files
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What this does

Configures Dependabot to open weekly PRs for Python and GitHub Actions dependencies.

- **Minor / patch** updates → **one grouped PR per week per ecosystem** (not N separate PRs)
- **Major** updates → individual PRs (Dependabot default; needed for per-PR review)
- Labels: `dependencies` (+ `github-actions` for Actions)

## What it explicitly does NOT do

- Does not merge anything. Every Dependabot PR still requires a human merge click.
- Does not change branch protection, auto-merge, or any other repo setting.
- Does not touch `poetry.lock` directly — Dependabot will resolve and propose updates through its own PRs.

## Strengths

- **Capability-only; no compulsion.** The config only causes Dependabot to *propose* PRs. Nothing merges automatically.
- **Grouped minor/patch reduces review burden.** One weekly PR per ecosystem for small bumps, vs a PR per package (which can be 10+ with 33 open alerts).
- **Addresses latent vulnerability exposure.** The repo currently has 33 open Dependabot alerts (1 critical, 10 high) with no configured mechanism to propose fixes.
- **Easily reversible.** Deleting the file turns Dependabot back off.

## Weaknesses / things worth flagging

- **Adds recurring review burden.** Even grouped, weekly Dependabot PRs need someone to look at them. If the team is already stretched reviewing functional PRs like #531, this is extra load.
- **Grouping / schedule is a judgment call.** Weekly Monday + group-minor-patch reflects my preferences; the team may reasonably prefer a different cadence, per-ecosystem splits, or a tool other than Dependabot (e.g. Renovate has more flexible grouping).
- **One-person-driven config without team input.** Opened this as a proposal during a repo cleanup pass; haven't discussed it with the team. Should be reviewed for fit rather than approved on technical correctness alone.
- **Blocked today by the pre-existing ruff lint error on `master`.** CI fails at the `Linting` step on every PR until #549 / #550 lands. This PR's own CI can't go green until that's fixed.
- **Does not fix the existing 33 alerts directly.** Dependabot will propose PRs over the coming weeks; immediate remediation would need a manual `poetry update` pass (see draft PR forthcoming, if that's the route the team prefers).

## Admin-required follow-ups (partially addresses #546)

These need admin permission (my role is `maintain`). Worth doing once this PR lands to get the most value:

1. **Enable branch protection on `master`** with `qc.yml` jobs as required status checks. Today: no protection configured (`gh api repos/.../branches/master/protection` returns 404). This is the biggest single gap in the repo's merge-safety posture.
2. **Enable `allow_auto_merge` at repo level** (Settings → General → Pull Requests). Adds the per-PR auto-merge button; does not force anything.
3. **Optional**: wire Copilot code review as auto-requested reviewer for non-Dependabot PRs.

## Risk

Low. If the team wants to decline, closing this PR reverts to the status quo (no Dependabot PRs; alerts continue to accumulate).