### PR TITLE
Fix pre-existing ruff lint errors in tests/test_mediadive_bulk_download.py (closes #549)

### DIFF
--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -4,14 +4,11 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
-import pytest
 import requests
 
 from kg_microbe.utils.mediadive_bulk_download import (
     DEFAULT_MAX_WORKERS,
     USER_AGENT,
-    _fetch_medium_detail,
-    _fetch_medium_strains,
     download_detailed_media,
     download_medium_strains,
     get_json_from_api,
@@ -19,6 +16,7 @@ from kg_microbe.utils.mediadive_bulk_download import (
 
 
 class TestDefaults:
+
     """Verify that DEFAULT_MAX_WORKERS and USER_AGENT are sensible values."""
 
     def test_default_max_workers_is_polite(self):
@@ -47,6 +45,7 @@ class TestDefaults:
 
 
 class TestRetryAfter:
+
     """Verify that 429 responses with Retry-After headers are honoured."""
 
     def test_respects_retry_after_header(self):
@@ -80,6 +79,7 @@ class TestRetryAfter:
 
 
 class TestRetryParameters:
+
     """Verify retry_count and retry_delay flow from download functions into get_json_from_api."""
 
     def test_retry_count_is_configurable(self):
@@ -112,6 +112,7 @@ class TestRetryParameters:
 
 
 class TestRateLimiter:
+
     """Verify the Semaphore rate limiter bounds concurrency."""
 
     def test_concurrency_bounded_by_max_workers(self):


### PR DESCRIPTION
## What this does

Runs `ruff check --fix` on `tests/test_mediadive_bulk_download.py`, resolving the 7 auto-fixable errors that have been present on `master`:

- **F401** × 3: unused imports (`pytest`, `_fetch_medium_detail`, `_fetch_medium_strains`)
- **D203** × 4: missing blank line before class docstring (`TestDefaults`, `TestRetryAfter`, `TestRetryParameters`, `TestRateLimiter`)

No semantic change. Test behavior is identical.

Closes #549.

## Strengths

- **Unblocks every PR's CI.** Until this lands, the `Linting` step fails on every PR (see e.g. #548's `build (3.12)` run), even PRs that don't touch Python. Merging this restores a green baseline for everyone.
- **Auto-generated, reviewable.** Every change is what ruff itself recommended. Diff is 7 lines.
- **No new rules enabled.** This doesn't add strictness; it applies fixes ruff was already asking for against the ruleset currently in `pyproject.toml`.

## Weaknesses / things worth flagging

- **Signals that the originating PR didn't enforce its own lint gate.** `test_mediadive_bulk_download.py` was recently added to master with these violations already present. Worth understanding how — did the lint step skip new files? Did the contributor override? Was this merged from a branch where lint passed because of different settings? Not a reason to block this PR, but a governance question for the team.
- **Trivial rebase nuisance** for anyone currently editing this file.
- **Doesn't address the broader problem** that `master` can land PRs with failing CI. That's a branch-protection question tracked in #546.

## Verification

```
$ cd kg-microbe
$ poetry run ruff check tests/test_mediadive_bulk_download.py
All checks passed!
```