### PR TITLE
Add SECURITY.md vulnerability-reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+`kg-microbe` is a research knowledge-graph pipeline developed in-tree on the `master` branch. We do not currently publish tagged releases with separate security support windows. Security fixes land on `master` and are picked up by consumers on next pull/build.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for vulnerabilities.
+
+Use **GitHub's private vulnerability reporting** feature instead:
+
+> Security tab → Report a vulnerability
+
+This routes the report privately to the maintainers. If private reporting is not enabled on this repo or you cannot use it, email the maintainer listed in `pyproject.toml` (`authors` field).
+
+## What to expect
+
+- We aim to acknowledge receipt within a few business days.
+- Triage and fix timelines depend on severity and scope.
+- Coordinated disclosure is preferred; please give us a reasonable window before public disclosure.
+
+## Scope
+
+This policy covers code in this repository. Vulnerabilities in upstream dependencies (e.g. `oaklib`, `kgx`, `koza`) should be reported to those projects directly; we track them via Dependabot alerts here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,24 +2,28 @@
 
 ## Supported Versions
 
-`kg-microbe` is a research knowledge-graph pipeline developed in-tree on the `master` branch. We do not currently publish tagged releases with separate security support windows. Security fixes land on `master` and are picked up by consumers on next pull/build.
+`kg-microbe` is a research knowledge-graph pipeline developed in-tree on the `master` branch.
+
+The repository does publish [tagged releases](https://github.com/Knowledge-Graph-Hub/kg-microbe/releases) — these are dated snapshots of the built knowledge graph and its inputs, not software versions with independent support windows. **Only `master` is supported.** Security fixes land there and are picked up by consumers on next pull or build; older release tags are not patched in place.
 
 ## Reporting a Vulnerability
 
 Please **do not** open a public issue for vulnerabilities.
 
-Use **GitHub's private vulnerability reporting** feature instead:
+Preferred route: **GitHub private vulnerability reporting** — Security tab → *Report a vulnerability*.
 
-> Security tab → Report a vulnerability
-
-This routes the report privately to the maintainers. If private reporting is not enabled on this repo or you cannot use it, email the maintainer listed in `pyproject.toml` (`authors` field).
+> **Note:** private vulnerability reporting is not currently enabled on this repository. Until a maintainer turns it on (Settings → Code security → Private vulnerability reporting), that option will not appear. In the meantime, contact the maintainer listed in the `authors` field of `pyproject.toml`.
 
 ## What to expect
 
 - We aim to acknowledge receipt within a few business days.
-- Triage and fix timelines depend on severity and scope.
+- Triage and fix timelines depend on severity and scope. This is a research project without a dedicated security team, so please size your expectations accordingly.
 - Coordinated disclosure is preferred; please give us a reasonable window before public disclosure.
 
 ## Scope
 
-This policy covers code in this repository. Vulnerabilities in upstream dependencies (e.g. `oaklib`, `kgx`, `koza`) should be reported to those projects directly; we track them via Dependabot alerts here.
+This policy covers code in this repository.
+
+Vulnerabilities in upstream dependencies (`oaklib`, `kgx`, `koza`, …) should be reported to those projects directly. We track them here via Dependabot alerts — note that an open alert on this repository is not by itself evidence of exposure; as of 2026-08-15 every open alert named a package already pinned at or past its patched version in `poetry.lock`.
+
+Data content — a wrong ontology grounding, a mis-attributed edge — is a correctness bug, not a security issue. Please file those as normal public issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,9 @@ The repository does publish [tagged releases](https://github.com/Knowledge-Graph
 
 Please **do not** open a public issue for vulnerabilities.
 
-Preferred route: **GitHub private vulnerability reporting** — Security tab → *Report a vulnerability*.
+Use **GitHub private vulnerability reporting**: Security tab → *Report a vulnerability*. This is enabled on the repository and routes the report privately to the maintainers.
 
-> **Note:** private vulnerability reporting is not currently enabled on this repository. Until a maintainer turns it on (Settings → Code security → Private vulnerability reporting), that option will not appear. In the meantime, contact the maintainer listed in the `authors` field of `pyproject.toml`.
+If you cannot use it, contact the maintainer listed in the `authors` field of `pyproject.toml`.
 
 ## What to expect
 


### PR DESCRIPTION
## Status

**DRAFT for team discussion.** Part of the security/quality baseline (#546).

## What this adds

A minimal `SECURITY.md` that directs reporters to GitHub's private vulnerability reporting feature (instead of public issues). Captures supported versions (currently: only `master`, no tagged release windows) and a scope statement (this repo's code; deps go upstream).

## Strengths

- **Reporters know where to go.** Without SECURITY.md, security issues tend to land in public issues, worsening disclosure.
- **Hooks into GitHub's built-in "Report a vulnerability" flow** (requires private vulnerability reporting to be enabled on the repo — separate toggle).
- **Minimal prose.** Nothing binding that's hard to keep.

## Weaknesses

- **Refers to `authors` in `pyproject.toml`** as fallback contact — only one name currently. Team should decide whether to list multiple or a shared alias.
- **Says "no tagged releases with support windows"** — accurate today but worth revisiting if the repo starts cutting releases.
- **Does not prescribe disclosure timelines.** Kept vague on purpose; team can tighten later.
- **Requires enabling private vulnerability reporting separately** (admin toggle) for the GitHub UI route to work.