### PR TITLE
Drop purge_asymmetric_pollution + KNOWN_BAD_NARROWMATCH (Codex-#558 closed upstream)

### DIFF
--- a/scripts/consolidate_chemical_mappings.py
+++ b/scripts/consolidate_chemical_mappings.py
@@ -1552,106 +1552,6 @@ class ChemicalMappingConsolidator:
             f"{synonyms_added} synonyms harvested from CHEBI xrefs"
         )
 
-    def purge_asymmetric_pollution(self):
-        """
-        Remove child labels that earlier consolidator runs leaked onto parents.
-
-        Prior versions of ``load_mediaingredientmech_sssom`` ran asymmetric
-        (skos:narrowMatch / broadMatch) rows through ``add_chemical(id=
-        object_id, ...)``, which made the broader parent absorb the child's
-        ``subject_label`` as one of its own synonyms and the child's MIM xref
-        as one of its own xrefs. Codex adversarial review #558 round 3 caught
-        this: the runtime name lookup then returned the parent CURIE instead
-        of the child, and the new ``get_parents()`` index was unreachable
-        because the lookup never landed on the child key it was indexed by.
-
-        The current loader skips that path for asymmetric rows, but baseline
-        runs from the existing unified file (via ``load_existing_unified``)
-        carry forward the old pollution. This sweep removes it surgically:
-        for each captured parent relation
-        (child=subject_id, parent=object_id), the child's canonical name and
-        synonyms are removed from the parent's synonym set, and the child's
-        MIM xref is removed from the parent's xref set. Both child and parent
-        records keep their own legitimate data; only the spillover is dropped.
-        """
-        if not self.parent_relations:
-            print("\nNo asymmetric MIM relations captured — skipping pollution purge.")
-            return
-        print("\nPurging asymmetric MIM pollution from parent entity records...")
-
-        # Resolve each parent relation to (child_primary, parent_primary,
-        # mim_subject) so the sweep can act on both label-side and xref-side
-        # spillover.
-        cleaned_synonyms = 0
-        cleaned_xrefs = 0
-        records_touched: set[str] = set()
-        for rel in self.parent_relations:
-            mim_subject = rel.get("subject_id", "")
-            parent_id = rel.get("object_id", "")
-            if not parent_id or parent_id not in self.chemicals:
-                continue
-            parent = self.chemicals[parent_id]
-
-            # The child primary is whatever symmetric MIM exactMatch row
-            # registered against the same MIM subject. Without that link we
-            # don't have a child to attribute the spillover to and the sweep
-            # is a no-op for this relation.
-            child_id = self.mim_to_primary.get(mim_subject)
-
-            # Names to purge: the child's subject_label from this MIM row,
-            # plus the child's canonical_name and all its synonyms (the prior
-            # asymmetric loader fed all of those onto the parent).
-            names_to_drop: set[str] = set()
-            row_subject_label = (rel.get("subject_label") or "").strip()
-            if row_subject_label:
-                names_to_drop.add(row_subject_label)
-            if child_id and child_id in self.chemicals:
-                child = self.chemicals[child_id]
-                if child["canonical_name"]:
-                    names_to_drop.add(child["canonical_name"])
-                names_to_drop.update(s for s in child["synonyms"] if s)
-
-            # Don't drop the parent's own canonical_name even if it
-            # accidentally matches one of these.
-            names_to_drop.discard(parent["canonical_name"])
-
-            removed_syns = parent["synonyms"] & names_to_drop
-            if removed_syns:
-                parent["synonyms"] -= removed_syns
-                cleaned_synonyms += len(removed_syns)
-                records_touched.add(parent_id)
-
-            # The child's MIM xref also leaked onto the parent in the old
-            # loader — remove it. The legitimate place for MIM:<slug> is on
-            # the child primary, not on the broader parent.
-            if mim_subject and mim_subject in parent["xrefs"]:
-                parent["xrefs"].discard(mim_subject)
-                cleaned_xrefs += 1
-                records_touched.add(parent_id)
-
-            # The child primary itself ended up cross-xref'd with the parent
-            # primary in some prior runs (each side claiming the other as an
-            # exactMatch xref), which made propagate_synonyms_via_xrefs treat
-            # them as the same entity and re-bridge the child's labels into
-            # the parent's synonym set. Break the symmetric xref so the
-            # narrowMatch parent_relations row stays the single channel.
-            if child_id and child_id in self.chemicals:
-                if child_id in parent["xrefs"]:
-                    parent["xrefs"].discard(child_id)
-                    cleaned_xrefs += 1
-                    records_touched.add(parent_id)
-                child = self.chemicals[child_id]
-                if parent_id in child["xrefs"]:
-                    child["xrefs"].discard(parent_id)
-                    cleaned_xrefs += 1
-                    records_touched.add(child_id)
-
-        print(
-            f"  Purged {cleaned_synonyms} stray child-label synonym(s) and "
-            f"{cleaned_xrefs} stray MIM xref(s) from {len(records_touched)} "
-            "parent record(s)."
-        )
-
     def propagate_synonyms_via_xrefs(self):
         """
         Pull names across equivalent-CURIE records into each primary's synonyms.
@@ -2244,11 +2144,6 @@ def main():
 
     # Harvest labels for CHEBI xrefs that never got their own primary row.
     consolidator.enrich_with_chebi_xref_labels()
-
-    # Sweep child-label spillover that earlier consolidator runs leaked onto
-    # parent entities via asymmetric MIM rows. Must run BEFORE
-    # propagate_synonyms_via_xrefs so the cleaned data doesn't get re-amplified.
-    consolidator.purge_asymmetric_pollution()
 
     # Propagate names across equivalent-CURIE records via xrefs so losing
     # candidates' labels end up on the primary node as synonyms.

--- a/tests/test_chemical_mapping_utils.py
+++ b/tests/test_chemical_mapping_utils.py
@@ -752,8 +752,8 @@ class TestNarrowMatchChildResolution:
         cid = chemical_mapping_utils.find_chebi_by_name("Vermont Soil")
         assert cid == "kgmicrobe.ingredient:vermont_soil", (
             f"expected kgmicrobe.ingredient:vermont_soil, got {cid!r} "
-            "(asymmetric-MIM pollution likely re-introduced — see "
-            "scripts/consolidate_chemical_mappings.py purge_asymmetric_pollution)"
+            "(asymmetric-MIM pollution likely re-introduced — upstream MIM "
+            "PRs #2/#3/#4 enforce the invariants that prevent it)"
         )
         assert chemical_mapping_utils.get_parents(cid) == ["ENVO:00001998"]
 


### PR DESCRIPTION
## Summary

MIM PRs #2, #3, #4 closed the Codex-#558 hardening pass on the upstream side. The kg-microbe-side workarounds added to compensate for upstream invariant violations are now redundant.

**Removed:**
- `purge_asymmetric_pollution()` (95 LOC) + its `main()` call site in `scripts/consolidate_chemical_mappings.py`. This swept stray child-label synonyms and MIM xrefs that earlier consolidator runs leaked from narrowMatch-MIM subjects onto OBO parents.
- Test docstring reference to `purge_asymmetric_pollution` updated to point at the upstream MIM PRs that now enforce the invariant (`tests/test_chemical_mapping_utils.py`).

**Already removed (this PR confirms it stays gone):**
- `KNOWN_BAD_NARROWMATCH` constant + filter call site — removed in commit `ed421d0e` ("Sync MIM SSSOM and remove redundant KNOWN_BAD_NARROWMATCH filter") on this branch. Its 5 entries no longer appear in the published MIM SSSOM (PR #2 removed them upstream).

## Why these are now redundant

| Workaround | Upstream resolution |
|---|---|
| `purge_asymmetric_pollution` | MIM PR #4 Rule B4 (canonical `object_label`) refuses rows where label doesn't match source ontology's canonical name. MIM PR #2 Rule A refuses auto-classifier rows with zero token overlap. Label drift that fed the pollution is gone at the source. |
| `KNOWN_BAD_NARROWMATCH` | MIM PR #2 removed all 5 rows from the published SSSOM. Defense-in-depth: claw `build_mim_ingredient_sssom.py` token-overlap gate (commit `e00d4f5`) refuses CONSIDER_SPECIFIC overrides where MIM and kg-microbe labels share zero tokens; `categorize_residual_p25.py` producer-side guards (commit `a3e36db`) prevent the residual JSON from emitting bad CONSIDER_SPECIFIC entries. |

Behaviorally, `KNOWN_BAD_NARROWMATCH` lookup is now unconditionally false (input data is hardened upstream), and `purge_asymmetric_pollution()` was a no-op (no parent records to clean) under the new invariants — so the deletions are safe.

## Test plan

- [x] Consolidator runs end-to-end cleanly. Output: 595,755 lines (595,681 mappings) vs baseline 595,436 — net delta near 0 as expected. The "Purged N stray child-label synonym(s) and M stray MIM xref(s)..." log line is gone (no longer called).
- [x] `pytest tests/test_chemical_mapping_utils.py tests/test_chemical_stereochemistry.py -x`: 76/76 passing. `test_vermont_soil_resolves_to_child` still resolves correctly to the `kgmicrobe.ingredient:vermont_soil` child without the purge step.
- [x] `parent_relations` and `_PARENT_INDEX` runtime indexes preserved (still used by `find_chebi_by_name` / `get_parents` lookups and by `export_unified_sssom`).

## Diff stats

```
 scripts/consolidate_chemical_mappings.py | 105 -------------------------------
 tests/test_chemical_mapping_utils.py     |   4 +-
 2 files changed, 2 insertions(+), 107 deletions(-)
```

## Cross-repo references

- **MIM PRs**: #2 (Rule A — zero-token-overlap refusal), #3, #4 (Rule B4 — canonical object_label) — all merged on `MediaIngredientMech`.
- **claw commits**: `e00d4f5` (defensive token-overlap gate in `build_mim_ingredient_sssom.py`), `a3e36db` (producer-side guards in `categorize_residual_p25.py`).
- **kg-microbe prior commit**: `ed421d0e` (removed `KNOWN_BAD_NARROWMATCH`).