### PR TITLE
Grant claude-review workflow write permission on PRs/issues

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
- Bump `pull-requests` and `issues` permissions in `.github/workflows/claude-code-review.yml` from `read` to `write`. The Claude Code Review action needs both to post inline review comments and the summary comment.
- Two-line diff. No other changes.

## Why this is urgent
The action currently fails up-front for every PR with:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.

The Anthropic GitHub App that mints the OAuth token validates the workflow against the *default branch* before issuing credentials. Even when we land the permissions fix on a PR (e.g. PR #559's commit `afb6e411`), the validation rejects it because master still has `read` permissions. The result is that **no PR can run the claude-review workflow** until master is updated.

Before this validation kicked in, the symptom was different but equally bad: the action would mint a token, run a 17-turn review, and rack up `permission_denials_count: 43` because the token couldn't post any comments.

## Evidence
- Original failure (17 turns / \$11.12 / 0 comments posted): https://github.com/Knowledge-Graph-Hub/kg-microbe/actions/runs/25353003011
- Post-fix-on-PR-branch failure (validation against master rejects): https://github.com/Knowledge-Graph-Hub/kg-microbe/actions/runs/25356035009

## Test plan
- [ ] Merge to master.
- [ ] Push a new commit to PR #559 (or any open PR) to retrigger the `pull_request` synchronize event.
- [ ] Confirm the new run mints the App token (no validation error) and posts review comments to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)