### PR TITLE
Wire claude-review --comment + --allowedTools so reviews actually post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,4 +26,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # ``--comment`` instructs the plugin to actually post inline review
+          # comments (without it the plugin only analyzes and emits nothing).
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+          # Without ``--allowedTools`` Claude Code's tool gate denies every
+          # call to ``mcp__github_inline_comment__create_inline_comment`` and
+          # ``gh pr comment`` (~35 denials / run, no comments posted). Pattern
+          # mirrors anthropics/claude-code-action examples and the working
+          # config at Arize-ai/phoenix.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(git fetch *),Bash(git diff *),Bash(git log *),Bash(git show *)"


### PR DESCRIPTION
## Summary
- Add ``--comment`` to the ``/code-review:code-review`` slash command (without it, the plugin analyzes only — never posts)
- Add ``claude_args: --allowedTools \"...\"`` so Claude Code's internal tool gate authorizes the comment-posting MCP tool + the read-only git/gh tools the plugin needs to fetch PR context
- Pattern lifted verbatim from [Arize-ai/phoenix's working config](https://github.com/Arize-ai/phoenix/blob/main/.github/workflows/claude-code-review.yml) and the [pr-review-comprehensive example](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) in anthropics/claude-code-action

## Why this is needed
PR #561 fixed the GitHub-side workflow permissions, but runs on PR #559 still posted nothing. The reason is **two layers of permission**:

| Layer | What it gates | PR #561 fixed? |
|---|---|---|
| GitHub workflow `permissions:` block | Whether the GITHUB_TOKEN can mint write API calls | ✅ yes |
| Claude Code SDK ``--allowedTools`` | Whether *Claude itself* is allowed to call comment-posting tools | ❌ not until this PR |

Without the SDK-level allowlist, Claude tries ``mcp__github_inline_comment__create_inline_comment`` 35–43 times per run, gets denied each time, and the post-buffered-inline-comments step finds an empty buffer.

## Evidence
| Run | Outcome | Cost | num_turns | permission_denials_count | Comments posted |
|---|---|---|---|---|---|
| [25353003011](https://github.com/Knowledge-Graph-Hub/kg-microbe/actions/runs/25353003011) | "success" | \$11.12 | 17 | 43 | 0 |
| [25356035009](https://github.com/Knowledge-Graph-Hub/kg-microbe/actions/runs/25356035009) | "success" | \$11.47 | 18 | 35 | 0 |

## Test plan
- [ ] Merge to master.
- [ ] Push any commit to PR #559 to retrigger the ``pull_request`` synchronize event.
- [ ] Confirm the next run drives ``permission_denials_count`` to ~0 and that inline review comments appear on PR #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)