### PR TITLE
Extend stub-import transform to cover PO and MICRO

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -253,12 +253,10 @@
   local_name: ro.owl
 
 #
-# PO (Plant Ontology)
-# Used by BacDive isolation_source mappings (root, leaf, flower, rhizome, etc.)
+# PO (Plant Ontology) is no longer downloaded as OWL — it has been
+# migrated to the per-CURIE SemSQL stub-import path. See the
+# `po.db.gz` entry under the stub-import section below.
 #
--
-  url: http://purl.obolibrary.org/obo/po.owl
-  local_name: po.owl
 
 #
 # TAXRANK (Taxonomic Rank Vocabulary)
@@ -426,15 +424,21 @@
 
 
 #
-# **** Selective stub-import ontologies (NCIT, MESH) ****
+# **** Selective stub-import ontologies (NCIT, MESH, BTO, PO, MICRO) ****
 #
-# KG-Microbe does NOT load the full NCIT or MESH ontologies — those belong to
-# kg-microbe-biomedical. But the chemical-mapping consolidator and BacDive
-# isolation-source mapper reference ~150 NCIT/MESH IDs as canonical xrefs for
-# ingredients (e.g. NCIT:C29298 'Oatmeal', mesh:D011136 'Tween'). The
-# OntologiesStubsTransform queries these SemSQL DBs to harvest just the
-# referenced IDs (label + synonyms + xrefs), emitting one labelled stub node
-# each. The DBs themselves are never loaded into the merged KG.
+# KG-Microbe does NOT load these ontologies in full. They each contribute
+# thousands of unrelated nodes when fully loaded but the chemical-mapping
+# consolidator and the BacDive isolation-source mapper reference only a
+# tiny per-ontology footprint (~150 NCIT, ~100 MESH, a handful of BTO/PO,
+# ~34 MICRO). The OntologiesStubsTransform queries these SemSQL DBs (or
+# the OBO Graph JSON in MICRO's case) to harvest just the referenced IDs
+# (label + synonyms + xrefs), emitting one labelled stub node each. The
+# DBs themselves are never loaded into the merged KG.
+#
+# MICRO uses the existing micro.owl download above (converted to micro.json
+# by ROBOT in the stub transform) because MICRO's bbop-sqlite distribution
+# at https://s3.amazonaws.com/bbop-sqlite/micro.db.gz is a 29-byte truncated
+# placeholder rather than a real SemSQL DB.
 #
 -
   url: https://s3.amazonaws.com/bbop-sqlite/ncit.db.gz
@@ -445,3 +449,6 @@
 -
   url: https://s3.amazonaws.com/bbop-sqlite/bto.db.gz
   local_name: bto.db.gz
+-
+  url: https://s3.amazonaws.com/bbop-sqlite/po.db.gz
+  local_name: po.db.gz

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -2988,24 +2988,31 @@ class BacDiveTransform(Transform):
                             # ontology. Loaded-ontology targets (UBERON, ENVO, ...) get
                             # their canonical node from the ontologies transform.
                             #
-                            # NCIT, mesh, and BTO stub nodes are NOT emitted here — the
-                            # OntologiesStubsTransform (kg_microbe/transform_utils/
-                            # ontologies_stubs/) writes label+synonym+xref-enriched
-                            # stubs from the SemSQL DBs, which is strictly richer
-                            # than the label-only fallback below. Emitting both
-                            # here and there would produce duplicate node rows
-                            # that the merge would have to dedupe. The PRIDE/PCO/
+                            # NCIT, mesh, BTO, PO, and MICRO stub nodes are NOT emitted
+                            # here — the OntologiesStubsTransform
+                            # (kg_microbe/transform_utils/ontologies_stubs/) writes
+                            # label+synonym+xref-enriched stubs from the SemSQL DBs
+                            # (NCIT/mesh/BTO/PO) or the obograph JSON (MICRO), which
+                            # is strictly richer than the label-only fallback below.
+                            # Emitting both here and there would produce duplicate node
+                            # rows that the merge would have to dedupe. The PRIDE/PCO/
                             # GENEPIO/FAO/SNOMED prefixes stay on the inline path
                             # because each has 1-3 IDs in the whole repo — not
-                            # worth a SemSQL fetch. (BTO was originally in that
-                            # group too but moved to the SemSQL path after the
-                            # MIM 2026-05-18 republish added `BTO:0004304 cell
-                            # lysate`, doubling its in-repo footprint.)
+                            # worth a SemSQL fetch. (BTO was originally in that group
+                            # too but moved to the SemSQL path after the MIM
+                            # 2026-05-18 republish added `BTO:0004304 cell lysate`,
+                            # doubling its in-repo footprint. PO and MICRO were
+                            # promoted from full-ontology loading to the stub path
+                            # in May 2026 because each has ~30 or fewer referenced
+                            # CURIEs but contributes thousands of unrelated nodes
+                            # when loaded fully.)
                             stub_prefix = subject_id.split(":", 1)[0] if ":" in subject_id else ""
                             if stub_prefix in STUB_ONTOLOGY_PREFIXES and stub_prefix not in {
                                 "NCIT",
                                 "mesh",
                                 "BTO",
+                                "PO",
+                                "MICRO",
                             }:
                                 node_writer.writerow(
                                     self._create_node_row(

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -84,9 +84,16 @@ ONTOLOGIES_MAP = {
     "foodon": "foodon.owl",
     "pato": "pato.owl",
     "ro": "ro.owl",
-    "po": "po.owl",            # Plant Ontology — BacDive isolation_source plant anatomy
     "taxrank": "taxrank.owl",  # Taxonomic Rank — NCBITaxon transform rank annotations
-    "micro": "micro.owl",      # Microbial Conditions Ontology — MIM media ingredient mappings
+    # NOTE: PO (Plant Ontology) and MICRO (Microbial Conditions Ontology)
+    # used to be full-load entries here. The merged KG only references a
+    # handful of CURIEs from each (~6-8 PO, ~34 MICRO) — both ontologies
+    # are now per-CURIE imports via the OntologiesStubsTransform
+    # (kg_microbe/transform_utils/ontologies_stubs/), which emits one
+    # labelled stub node per referenced CURIE instead of pulling in
+    # ~2,170 + ~17,600 unrelated nodes. PO uses the bbop-sqlite SemSQL DB
+    # (data/raw/po.db); MICRO uses the obograph JSON (data/raw/micro.json)
+    # because MICRO's bbop-sqlite distribution is broken.
 }
 
 
@@ -95,6 +102,8 @@ class OntologiesTransform(Transform):
     """OntologyTransform parses an Obograph JSON form of an Ontology into nodes nad edges."""
 
     # Mapping of ontology names to InforES standard knowledge sources
+    # (po and micro removed — now emitted as per-CURIE stubs via
+    # OntologiesStubsTransform; see ONTOLOGIES_MAP note above)
     ONTOLOGY_KNOWLEDGE_SOURCES = {
         "chebi": "infores:chebi",
         "envo": "infores:envo",
@@ -109,9 +118,7 @@ class OntologiesTransform(Transform):
         "foodon": "infores:foodon",
         "pato": "infores:pato",
         "ro": "infores:ro",
-        "po": "infores:po",
         "taxrank": "infores:taxrank",
-        "micro": "infores:micro",
     }
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -1,41 +1,59 @@
 """
 Ontologies-stubs transform.
 
-KG-Microbe deliberately does NOT load the full NCIT or MESH ontologies — those
-belong to the sibling ``kg-microbe-biomedical`` pipeline. But the
-chemical-mapping consolidator and the BacDive isolation-source mapper reference
-~150 NCIT and MESH IDs as canonical xrefs for ingredients (e.g.
-``NCIT:C29298 'Oatmeal'``, ``mesh:D011136 'Tween'``). Without this transform
-those CURIEs would appear as dangling node ids in the merged KG: edges point at
-them but no node row carries the label.
+KG-Microbe deliberately does NOT load the full NCIT, MESH, BTO, PO, or MICRO
+ontologies — those would each add thousands of unrelated nodes for what is in
+practice a small per-mapping reference footprint. But the chemical-mapping
+consolidator and the BacDive isolation-source mapper reference ~150 NCIT,
+~100 MESH, a handful of BTO/PO IDs, and ~150 MICRO IDs as canonical xrefs for
+ingredients, growth media, plant-anatomy isolation sources, and microbial
+conditions (e.g. ``NCIT:C29298 'Oatmeal'``, ``mesh:D011136 'Tween'``,
+``PO:0009046 'flower'``, ``MICRO:0000082 'nutrient broth'``). Without this
+transform those CURIEs would appear as dangling node ids in the merged KG:
+edges point at them but no node row carries the label.
 
 This transform:
 
 1. Calls :func:`~kg_microbe.utils.stub_curie_collection.collect_stub_curies` to
-   discover every NCIT and MESH CURIE referenced anywhere under ``mappings/``.
-2. For each CURIE, queries the local SemSQL DB (``data/raw/ncit.db``,
-   ``data/raw/mesh.db``) via OAK to fetch its ``rdfs:label``, exact synonyms,
-   and dbxrefs. The same pattern is used by the chemical-mapping consolidator
-   for ChEBI in ``scripts/consolidate_chemical_mappings.py``.
+   discover every NCIT / mesh / BTO / PO / MICRO CURIE referenced anywhere
+   under ``mappings/``.
+2. For each CURIE, fetches metadata via OAK. The adapter type depends on
+   ``STUB_ONTOLOGY_SOURCES[prefix]["source_type"]``:
+
+   * ``"semsql"`` (default — NCIT, mesh, BTO, PO): queries the local SemSQL
+     DB (``data/raw/{ncit,mesh,bto,po}.db``) via OAK. The same pattern is
+     used by the chemical-mapping consolidator for ChEBI in
+     ``scripts/consolidate_chemical_mappings.py``.
+   * ``"obograph_json"`` (MICRO): MICRO's bbop-sqlite SemSQL DB is broken
+     (a 29-byte placeholder), so we fall back to parsing the already-
+     downloaded ``data/raw/micro.json`` (produced by ROBOT during the
+     ontologies transform's OWL→JSON conversion) via an in-house
+     adapter. The adapter normalizes both standard
+     (``http://purl.obolibrary.org/obo/MICRO_0000082``) and quirky
+     (``http://purl.obolibrary.org/obo/MicrO.owl/MICRO_0003152``) IRI
+     forms to the canonical ``MICRO:NNNN`` CURIE.
+
 3. Writes one KGX node TSV per stub ontology to
-   ``data/transformed/ontologies_stubs/{ncit,mesh}_nodes.tsv`` carrying
-   ``id, category, name, synonym, xref, provided_by, knowledge_source``.
-   No edges file — stubs are isolated nodes; edges arrive from the source
-   transforms (BacDive, MediaDive ingredients via the chemical-mapping path,
-   etc.).
+   ``data/transformed/ontologies_stubs/{ncit,mesh,bto,po,micro}_nodes.tsv``
+   carrying ``id, category, name, synonym, xref, provided_by,
+   knowledge_source``. No edges file — stubs are isolated nodes; edges
+   arrive from the source transforms (BacDive, MediaDive ingredients via
+   the chemical-mapping path, etc.).
 
 Note for downstream consumers: if a KG built with this transform is ever
-merged with a kg-microbe-biomedical KG that loads NCIT/MESH fully, biolink
-merge semantics will union nodes — the stub node here is a strict subset of
-what the full ontology would emit (label/synonym/xref only; no edges, no
-deprecated flag, no parent classes), so the union will simply pick the
-fuller record.
+merged with a kg-microbe-biomedical KG that loads any of these ontologies
+fully, biolink merge semantics will union nodes — the stub node here is a
+strict subset of what the full ontology would emit (label/synonym/xref only;
+no edges, no deprecated flag, no parent classes), so the union will simply
+pick the fuller record.
 """
 
 from __future__ import annotations
 
 import csv
 import gzip
+import json
+import re
 import shutil
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set
@@ -57,14 +75,23 @@ from kg_microbe.utils.stub_curie_collection import collect_stub_curies
 
 # Stub ontologies handled by this transform. Each entry maps the canonical
 # CURIE prefix (case-sensitive — must match how the prefix appears in
-# existing mapping rows) to the local SemSQL DB and the InforES knowledge
-# source string.
+# existing mapping rows) to the input filename, OAK-adapter source_type, and
+# the InforES knowledge source string.
+#
+# source_type controls how `_open_adapter` reaches into the file:
+#   * "semsql"        — OAK `sqlite:` adapter against a bbop-sqlite SemSQL DB
+#                       (decompressed from a sibling .db.gz on demand).
+#   * "obograph_json" — in-house `_ObographJsonAdapter` reading an OBO Graph
+#                       JSON produced by ROBOT (used for MICRO because its
+#                       bbop-sqlite distribution is a broken 29-byte file).
 STUB_ONTOLOGY_SOURCES: Dict[str, Dict[str, str]] = {
     "NCIT": {
+        "source_type": "semsql",
         "db_filename": "ncit.db",
         "knowledge_source": "infores:ncit",
     },
     "mesh": {
+        "source_type": "semsql",
         "db_filename": "mesh.db",
         "knowledge_source": "infores:mesh",
     },
@@ -73,8 +100,32 @@ STUB_ONTOLOGY_SOURCES: Dict[str, Dict[str, str]] = {
         # mappings (wound fluid from BacDive isolation_source; cell lysate
         # added by the MIM 2026-05-18 republish). Added here so those nodes
         # carry full label + synonyms + xrefs instead of label-only stubs.
+        "source_type": "semsql",
         "db_filename": "bto.db",
         "knowledge_source": "infores:bto",
+    },
+    "PO": {
+        # Plant Ontology. ~6-8 CURIEs in current kg-microbe mappings
+        # (root, leaf, flower, rhizome, etc.) referenced by BacDive
+        # isolation_source. Previously loaded in full by the ontologies
+        # transform (~2,170 nodes); the stub path emits one labelled node
+        # per reference and skips the rest.
+        "source_type": "semsql",
+        "db_filename": "po.db",
+        "knowledge_source": "infores:po",
+    },
+    "MICRO": {
+        # Microbial Conditions Ontology (Carrine Blank's MicrO). ~34
+        # distinct CURIEs in current kg-microbe mappings (~150 total
+        # references from chemical/ingredient mappings) — nutrient broth,
+        # tryptic soy agar, peptone, etc. Previously loaded in full
+        # (~17,600 nodes / ~10 MB OWL). MICRO's bbop-sqlite SemSQL DB is
+        # a 29-byte placeholder, so the stub path parses the OBO Graph
+        # JSON produced by ROBOT (data/raw/micro.json, already required
+        # for legacy reasons by the full-load path) directly.
+        "source_type": "obograph_json",
+        "db_filename": "micro.json",
+        "knowledge_source": "infores:micro",
     },
 }
 
@@ -83,7 +134,7 @@ ONTOLOGIES_STUBS_SOURCE_NAME = "ontologies_stubs"
 
 class OntologiesStubsTransform(Transform):
 
-    """Emit one labelled stub node per referenced NCIT / MESH / BTO CURIE."""
+    """Emit one labelled stub node per referenced NCIT / mesh / BTO / PO / MICRO CURIE."""
 
     def __init__(
         self,
@@ -161,15 +212,15 @@ class OntologiesStubsTransform(Transform):
                 missing.append(curie)
                 label = curie
             row = [
-                curie,                      # id
-                STUB_ONTOLOGY_CATEGORY,     # category
-                label,                      # name
-                None,                        # description
-                _join_pipe(xrefs),          # xref
+                curie,  # id
+                STUB_ONTOLOGY_CATEGORY,  # category
+                label,  # name
+                None,  # description
+                _join_pipe(xrefs),  # xref
                 ONTOLOGIES_STUBS_SOURCE_NAME,  # provided_by
-                _join_pipe(synonyms),       # synonym
-                None,                        # deprecated
-                None,                        # same_as
+                _join_pipe(synonyms),  # synonym
+                None,  # deprecated
+                None,  # same_as
             ]
             rows.append(row)
 
@@ -183,12 +234,37 @@ class OntologiesStubsTransform(Transform):
 
     def _open_adapter(self, prefix: str, db_path: Path):
         """
-        Open an OAK SemSQL adapter against the local DB; return None on failure.
+        Open the configured OAK-compatible adapter for ``prefix``; return None if the source file is missing.
 
-        OBO Foundry distributes the SemSQL DBs as ``.db.gz`` and ``download.yaml``
-        stores the gzipped form. If the unzipped ``.db`` is missing but a sibling
-        ``.db.gz`` is present, decompress it once (idempotent) and use the result.
+        Dispatches on the ``source_type`` field of :data:`STUB_ONTOLOGY_SOURCES`:
+
+        * ``"semsql"`` — OAK SemSQL adapter against ``db_path``. OBO Foundry
+          distributes the SemSQL DBs as ``.db.gz`` and ``download.yaml``
+          stores the gzipped form, so if the unzipped ``.db`` is missing but
+          a sibling ``.db.gz`` is present, decompress it once (idempotent)
+          and use the result.
+        * ``"obograph_json"`` — in-house :class:`_ObographJsonAdapter` that
+          implements the subset of the OAK adapter interface this transform
+          actually calls (``label``, ``entity_aliases``,
+          ``entity_metadata_map``).
         """
+        cfg = STUB_ONTOLOGY_SOURCES.get(prefix, {})
+        source_type = cfg.get("source_type", "semsql")
+        if source_type == "obograph_json":
+            if not db_path.is_file():
+                # MICRO ships only as OWL in download.yaml; convert once via
+                # ROBOT if the sibling .owl is present. Mirrors the .db.gz →
+                # .db decompression flow below.
+                owl_path = db_path.with_suffix(".owl")
+                if owl_path.is_file():
+                    print(f"  [{prefix}] converting {owl_path.name} → {db_path.name} via ROBOT")
+                    from kg_microbe.utils.robot_utils import convert_to_json
+
+                    convert_to_json(str(owl_path.parent), owl_path.stem)
+                if not db_path.is_file():
+                    return None
+            return _ObographJsonAdapter.from_file(db_path)
+        # semsql (default)
         if not db_path.is_file():
             gz_path = db_path.with_suffix(db_path.suffix + ".gz")
             if gz_path.is_file():
@@ -200,9 +276,7 @@ class OntologiesStubsTransform(Transform):
         try:
             from oaklib import get_adapter
         except ImportError as exc:  # pragma: no cover — oaklib is a dep
-            raise RuntimeError(
-                f"oaklib import failed while opening SemSQL adapter for {prefix}: {exc}"
-            ) from exc
+            raise RuntimeError(f"oaklib import failed while opening SemSQL adapter for {prefix}: {exc}") from exc
         return get_adapter(f"sqlite:{db_path}")
 
     def _fetch_metadata(self, adapter, curie: str):
@@ -259,3 +333,76 @@ def _join_pipe(values: Iterable[str]) -> str:
     """Pipe-join a sequence; return ``""`` when empty (matches existing TSV convention)."""
     items = [v for v in values if v]
     return "|".join(items) if items else ""
+
+
+# Match the local ID at the tail of an OBO Foundry IRI. Handles both the
+# standard ``http://purl.obolibrary.org/obo/MICRO_0000082`` shape and MicrO's
+# quirky ``http://purl.obolibrary.org/obo/MicrO.owl/MICRO_0003152`` variant.
+_OBO_LOCAL_ID_RE = re.compile(r"/([A-Za-z][A-Za-z0-9]*)_([A-Za-z0-9]+)$")
+
+
+class _ObographJsonAdapter:
+
+    """
+    Minimal OAK-adapter-shaped reader over an OBO Graph JSON file.
+
+    Implements only the methods :class:`OntologiesStubsTransform` calls
+    (``label``, ``entity_aliases``, ``entity_metadata_map``); everything else
+    intentionally remains undefined so a future caller that needs more of the
+    OAK interface fails loudly rather than silently returning empties.
+
+    Used for ontologies whose bbop-sqlite SemSQL distribution is unavailable
+    or broken (MICRO at time of writing).
+    """
+
+    def __init__(self, nodes_by_curie: Dict[str, Dict]):
+        """Cache the parsed obograph JSON keyed by canonical ``PREFIX:local`` CURIE."""
+        self._nodes = nodes_by_curie
+
+    @classmethod
+    def from_file(cls, json_path: Path) -> "_ObographJsonAdapter":
+        """Parse ``json_path`` (OBO Graph JSON) and key its nodes by canonical CURIE."""
+        with json_path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        nodes_by_curie: Dict[str, Dict] = {}
+        for graph in data.get("graphs", []) or []:
+            for node in graph.get("nodes", []) or []:
+                iri = node.get("id") or ""
+                m = _OBO_LOCAL_ID_RE.search(iri)
+                if not m:
+                    continue
+                curie = f"{m.group(1)}:{m.group(2)}"
+                # First occurrence wins (obograph rarely duplicates within a graph).
+                nodes_by_curie.setdefault(curie, node)
+        return cls(nodes_by_curie)
+
+    def label(self, curie: str) -> str:
+        """Return ``rdfs:label`` for ``curie`` or ``""`` if absent."""
+        node = self._nodes.get(curie)
+        return (node or {}).get("lbl") or ""
+
+    def entity_aliases(self, curie: str) -> List[str]:
+        """Return all synonym literals for ``curie`` (any predicate kind)."""
+        node = self._nodes.get(curie) or {}
+        meta = node.get("meta") or {}
+        out: List[str] = []
+        for syn in meta.get("synonyms", []) or []:
+            val = syn.get("val") if isinstance(syn, dict) else None
+            if val:
+                out.append(val)
+        return out
+
+    def entity_metadata_map(self, curie: str) -> Dict[str, List[str]]:
+        """
+        Return a dict shaped like OAK's ``entity_metadata_map`` output.
+
+        Only the ``oio:hasDbXref`` key is populated — that's the only field
+        the stub transform consumes from the OAK metadata map. Other
+        OAK-emitted keys (``IAO:0000115`` definition, ``createdBy``, etc.)
+        are intentionally omitted; the stub transform does not write them.
+        """
+        node = self._nodes.get(curie) or {}
+        meta = node.get("meta") or {}
+        xrefs = [x.get("val") if isinstance(x, dict) else x for x in (meta.get("xrefs") or [])]
+        xrefs = [x for x in xrefs if x]
+        return {"oio:hasDbXref": xrefs} if xrefs else {}

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -4,10 +4,11 @@ Ontologies-stubs transform.
 KG-Microbe deliberately does NOT load the full NCIT, MESH, BTO, PO, or MICRO
 ontologies — those would each add thousands of unrelated nodes for what is in
 practice a small per-mapping reference footprint. But the chemical-mapping
-consolidator and the BacDive isolation-source mapper reference ~150 NCIT,
-~100 MESH, a handful of BTO/PO IDs, and ~150 MICRO IDs as canonical xrefs for
-ingredients, growth media, plant-anatomy isolation sources, and microbial
-conditions (e.g. ``NCIT:C29298 'Oatmeal'``, ``mesh:D011136 'Tween'``,
+consolidator and the BacDive isolation-source mapper reference ~73 distinct
+NCIT IDs, ~95 distinct mesh IDs, a handful of distinct BTO/PO IDs, and
+~34 distinct MICRO IDs (across ~150 total reference rows) as canonical
+xrefs for ingredients, growth media, plant-anatomy isolation sources, and
+microbial conditions (e.g. ``NCIT:C29298 'Oatmeal'``, ``mesh:D011136 'Tween'``,
 ``PO:0009046 'flower'``, ``MICRO:0000082 'nutrient broth'``). Without this
 transform those CURIEs would appear as dangling node ids in the merged KG:
 edges point at them but no node row carries the label.
@@ -25,10 +26,13 @@ This transform:
      used by the chemical-mapping consolidator for ChEBI in
      ``scripts/consolidate_chemical_mappings.py``.
    * ``"obograph_json"`` (MICRO): MICRO's bbop-sqlite SemSQL DB is broken
-     (a 29-byte placeholder), so we fall back to parsing the already-
-     downloaded ``data/raw/micro.json`` (produced by ROBOT during the
-     ontologies transform's OWL→JSON conversion) via an in-house
-     adapter. The adapter normalizes both standard
+     (a 29-byte placeholder), so we fall back to parsing
+     ``data/raw/micro.json`` via an in-house adapter. The JSON is
+     generated on demand by :func:`_open_adapter` (which invokes ROBOT
+     against the downloaded ``data/raw/micro.owl`` from ``download.yaml``
+     if the JSON is missing) — MICRO is no longer part of the full
+     ontologies-transform load path, so nothing else produces this file.
+     The adapter normalizes both standard
      (``http://purl.obolibrary.org/obo/MICRO_0000082``) and quirky
      (``http://purl.obolibrary.org/obo/MicrO.owl/MICRO_0003152``) IRI
      forms to the canonical ``MICRO:NNNN`` CURIE.
@@ -121,8 +125,10 @@ STUB_ONTOLOGY_SOURCES: Dict[str, Dict[str, str]] = {
         # tryptic soy agar, peptone, etc. Previously loaded in full
         # (~17,600 nodes / ~10 MB OWL). MICRO's bbop-sqlite SemSQL DB is
         # a 29-byte placeholder, so the stub path parses the OBO Graph
-        # JSON produced by ROBOT (data/raw/micro.json, already required
-        # for legacy reasons by the full-load path) directly.
+        # JSON converted from micro.owl. The JSON is generated on demand
+        # by _open_adapter via a ROBOT subprocess; nothing else produces
+        # it (MICRO is no longer part of the full ontologies-transform
+        # load path).
         "source_type": "obograph_json",
         "db_filename": "micro.json",
         "knowledge_source": "infores:micro",
@@ -195,9 +201,22 @@ class OntologiesStubsTransform(Transform):
 
         adapter = self._open_adapter(prefix, db_path)
         if adapter is None:
+            source_type = STUB_ONTOLOGY_SOURCES.get(prefix, {}).get("source_type", "semsql")
+            if source_type == "obograph_json":
+                owl_path = db_path.with_suffix(".owl")
+                detail = (
+                    f"expected OBO Graph JSON at {db_path} (auto-generated from "
+                    f"{owl_path} via ROBOT on first run). Neither file is present — "
+                    f"run `poetry run kg download` to fetch the OWL, then re-run "
+                    f"this transform."
+                )
+            else:
+                detail = (
+                    f"expected SemSQL DB at {db_path} (or sibling {db_path.name}.gz "
+                    f"to auto-decompress). Run `poetry run kg download` to fetch it."
+                )
             raise FileNotFoundError(
-                f"OAK adapter for {prefix} could not be opened (expected SemSQL DB at "
-                f"{db_path}). Run `poetry run kg download` to fetch it. The stub "
+                f"OAK adapter for {prefix} could not be opened: {detail} The stub "
                 f"transform refuses to silently emit unlabelled nodes — that would "
                 f"reintroduce the dangling-xref hazard this transform exists to fix."
             )

--- a/kg_microbe/utils/isolation_source_mapping_utils.py
+++ b/kg_microbe/utils/isolation_source_mapping_utils.py
@@ -90,15 +90,22 @@ PREDICATE_OVERRIDE_CURIES: frozenset = frozenset({
 #
 # Two stub-import paths exist for these prefixes:
 #
-# 1. NCIT, mesh, and BTO: a SemSQL-backed enriched stub source. The
-#    OntologiesStubsTransform (kg_microbe/transform_utils/ontologies_stubs/)
-#    queries data/raw/{ncit,mesh,bto}.db via OAK to fetch rdfs:label, exact
-#    synonyms, and dbxrefs for every NCIT/mesh/BTO CURIE that appears
-#    anywhere under mappings/. Output:
-#    data/transformed/ontologies_stubs/{ncit,mesh,bto}_nodes.tsv. This is
-#    the preferred path — stubs carry full metadata, not just a label. The
-#    BacDive inline emit at bacdive.py defers to this transform for these
-#    three prefixes (see the `not in {"NCIT", "mesh", "BTO"}` branch there).
+# 1. NCIT, mesh, BTO, PO, MICRO: enriched stub sources emitted by the
+#    OntologiesStubsTransform (kg_microbe/transform_utils/ontologies_stubs/).
+#    For each referenced CURIE the transform fetches rdfs:label, exact
+#    synonyms, and dbxrefs:
+#      * NCIT, mesh, BTO, PO use the OAK SemSQL adapter against
+#        data/raw/{ncit,mesh,bto,po}.db (downloaded from bbop-sqlite).
+#      * MICRO uses an in-house obograph-JSON adapter against
+#        data/raw/micro.json (MICRO's bbop-sqlite distribution is a broken
+#        29-byte file at time of writing).
+#    Output: data/transformed/ontologies_stubs/{ncit,mesh,bto,po,micro}_nodes.tsv.
+#    This is the preferred path — stubs carry full metadata, not just a
+#    label. The BacDive inline emit at bacdive.py defers to this transform
+#    for these five prefixes (see the inline skip-set there). MICRO is
+#    listed here for documentation completeness even though no
+#    isolation_source rows currently target MICRO; the bacdive transform
+#    never emits MICRO inline because the same skip-set covers it.
 #
 # 2. The long-tail prefixes (PRIDE, PCO, GENEPIO, FAO, SNOMED): each has
 #    1-3 IDs in the whole repo, so the BacDive transform writes a thin
@@ -126,6 +133,8 @@ STUB_ONTOLOGY_PREFIXES: frozenset = frozenset({
     "FAO",      # 1 ID: mycorrhiza (Fungal Anatomy Ontology)
     "BTO",      # 1 ID: wound fluid (BRENDA Tissue Ontology)
     "SNOMED",   # 1 ID after filtering: sugary food (clinical procedure rows are dropped via banned substrings)
+    "PO",       # ~6-8 IDs: root, leaf, flower, rhizome, etc. (Plant Ontology)
+    "MICRO",    # 0 isolation_source IDs but ~34 elsewhere (chemical/ingredient mappings)
 })
 STUB_ONTOLOGY_CATEGORY = "biolink:OntologyClass"
 

--- a/merge.no_metatraits.yaml
+++ b/merge.no_metatraits.yaml
@@ -68,7 +68,7 @@ merged_graph:
         filename:
           - data/transformed/ontologies/metpo_nodes.tsv
           - data/transformed/ontologies/metpo_edges.tsv
-    # Selective per-CURIE stub-import for NCIT and MESH — see merge.yaml.
+    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, MICRO — see merge.yaml.
     ontologies_stubs:
       name: "ontologies_stubs"
       input:
@@ -77,6 +77,8 @@ merged_graph:
           - data/transformed/ontologies_stubs/ncit_nodes.tsv
           - data/transformed/ontologies_stubs/mesh_nodes.tsv
           - data/transformed/ontologies_stubs/bto_nodes.tsv
+          - data/transformed/ontologies_stubs/po_nodes.tsv
+          - data/transformed/ontologies_stubs/micro_nodes.tsv
     bacdive:
       name: "bacdive"
       input:

--- a/merge.yaml
+++ b/merge.yaml
@@ -82,9 +82,10 @@ merged_graph:
         filename:
           - data/transformed/ontologies/metpo_nodes.tsv
           - data/transformed/ontologies/metpo_edges.tsv
-    # Selective per-CURIE stub-import for NCIT and MESH — only the IDs
-    # referenced by mappings/* are imported (not the full ontologies).
-    # See kg_microbe/transform_utils/ontologies_stubs/ for the transform.
+    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, and MICRO —
+    # only the IDs referenced by mappings/* are imported (not the full
+    # ontologies). See kg_microbe/transform_utils/ontologies_stubs/ for
+    # the transform.
     ontologies_stubs:
       name: "ontologies_stubs"
       input:
@@ -93,6 +94,8 @@ merged_graph:
           - data/transformed/ontologies_stubs/ncit_nodes.tsv
           - data/transformed/ontologies_stubs/mesh_nodes.tsv
           - data/transformed/ontologies_stubs/bto_nodes.tsv
+          - data/transformed/ontologies_stubs/po_nodes.tsv
+          - data/transformed/ontologies_stubs/micro_nodes.tsv
     bacdive:
       name: "bacdive"
       input:

--- a/merge_bakta.yaml
+++ b/merge_bakta.yaml
@@ -84,7 +84,7 @@ merged_graph:
         filename:
           - data/transformed/ontologies/metpo_nodes.tsv
           - data/transformed/ontologies/metpo_edges.tsv
-    # Selective per-CURIE stub-import for NCIT and MESH — see merge.yaml.
+    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, MICRO — see merge.yaml.
     ontologies_stubs:
       name: "ontologies_stubs"
       input:
@@ -93,6 +93,8 @@ merged_graph:
           - data/transformed/ontologies_stubs/ncit_nodes.tsv
           - data/transformed/ontologies_stubs/mesh_nodes.tsv
           - data/transformed/ontologies_stubs/bto_nodes.tsv
+          - data/transformed/ontologies_stubs/po_nodes.tsv
+          - data/transformed/ontologies_stubs/micro_nodes.tsv
     bacdive:
       name: "bacdive"
       input:

--- a/tests/test_ontologies_stubs.py
+++ b/tests/test_ontologies_stubs.py
@@ -206,7 +206,7 @@ def test_transform_synonym_does_not_duplicate_label(tmp_path):
 
 
 def test_transform_raises_when_db_missing(tmp_path):
-    """If neither the .db nor the .db.gz exists, the transform fails loudly (not silently)."""
+    """SemSQL prefix with neither .db nor .db.gz fails loudly with a SemSQL-specific message."""
     # Use the real OntologiesStubsTransform here (not the _StubbedTransform) so the
     # _open_adapter path runs against an empty input dir.
     transform = OntologiesStubsTransform(
@@ -226,7 +226,31 @@ def test_transform_raises_when_db_missing(tmp_path):
             output_file=tmp_path / "out" / "ncit_nodes.tsv",
         ),
     )
-    with pytest.raises(FileNotFoundError, match="ncit.db"):
+    with pytest.raises(FileNotFoundError, match="SemSQL DB.*ncit.db"):
+        transform.run()
+
+
+def test_transform_raises_with_obograph_json_message_when_micro_inputs_missing(tmp_path):
+    """MICRO with neither micro.json nor micro.owl fails with an obograph-JSON-specific message."""
+    transform = OntologiesStubsTransform(
+        input_dir=tmp_path / "raw",  # empty — neither micro.json nor micro.owl present
+        output_dir=tmp_path / "out",
+    )
+    (tmp_path / "raw").mkdir()
+    object.__setattr__(
+        transform,
+        "run",
+        lambda data_file=None: transform._write_stub_nodes(
+            prefix="MICRO",
+            curies=["MICRO:0000082"],
+            db_path=tmp_path / "raw" / "micro.json",
+            knowledge_source="infores:micro",
+            output_file=tmp_path / "out" / "micro_nodes.tsv",
+        ),
+    )
+    # Must mention OBO Graph JSON, the .json path, and the ROBOT-from-OWL fallback —
+    # not the SemSQL DB phrasing that's correct for NCIT/mesh/BTO/PO.
+    with pytest.raises(FileNotFoundError, match="OBO Graph JSON.*micro.json.*ROBOT"):
         transform.run()
 
 

--- a/tests/test_ontologies_stubs.py
+++ b/tests/test_ontologies_stubs.py
@@ -11,6 +11,7 @@ import pytest
 from kg_microbe.transform_utils.ontologies_stubs.ontologies_stubs_transform import (
     STUB_ONTOLOGY_SOURCES,
     OntologiesStubsTransform,
+    _ObographJsonAdapter,
 )
 from kg_microbe.utils.isolation_source_mapping_utils import (
     STUB_ONTOLOGY_CATEGORY,
@@ -48,8 +49,14 @@ class _StubbedTransform(OntologiesStubsTransform):
 
     """Subclass that swaps in an in-memory adapter so tests don't touch SemSQL DBs on disk."""
 
-    def __init__(self, *, adapters: Dict[str, _FakeAdapter], curies: Dict[str, Set[str]],
-                 input_dir: Path, output_dir: Path):
+    def __init__(
+        self,
+        *,
+        adapters: Dict[str, _FakeAdapter],
+        curies: Dict[str, Set[str]],
+        input_dir: Path,
+        output_dir: Path,
+    ):
         super().__init__(input_dir=input_dir, output_dir=output_dir)
         self._fake_adapters = adapters
         self._fake_curies = curies
@@ -88,15 +95,33 @@ def test_stub_ontology_sources_subset_of_stub_prefixes():
     assert set(STUB_ONTOLOGY_SOURCES.keys()).issubset(STUB_ONTOLOGY_PREFIXES)
 
 
-def test_stub_ontology_sources_covers_ncit_mesh_bto():
+def test_stub_ontology_sources_covers_ncit_mesh_bto_po_micro():
     """
-    Cover the three prefixes that need full SemSQL-backed enrichment.
+    Cover the five prefixes that need full metadata-enriched stub emission.
 
     NCIT and mesh were added in the initial commit; BTO was added after the
     MIM 2026-05-18 republish brought in `BTO:0004304 cell lysate`, doubling
-    the BTO footprint and crossing the "worth a SemSQL fetch" threshold.
+    the BTO footprint and crossing the "worth a SemSQL fetch" threshold;
+    PO and MICRO were promoted from full-ontology loading to the per-CURIE
+    stub path shortly after (PO via SemSQL, MICRO via obograph JSON since
+    its bbop-sqlite distribution is a broken 29-byte placeholder).
     """
-    assert set(STUB_ONTOLOGY_SOURCES.keys()) == {"NCIT", "mesh", "BTO"}
+    assert set(STUB_ONTOLOGY_SOURCES.keys()) == {"NCIT", "mesh", "BTO", "PO", "MICRO"}
+
+
+def test_micro_source_type_is_obograph_json():
+    """MICRO must dispatch to the obograph-JSON adapter, not SemSQL."""
+    assert STUB_ONTOLOGY_SOURCES["MICRO"]["source_type"] == "obograph_json"
+    assert STUB_ONTOLOGY_SOURCES["MICRO"]["db_filename"].endswith(".json")
+
+
+def test_semsql_sources_use_db_files():
+    """NCIT, mesh, BTO, PO all use the SemSQL adapter against a .db file."""
+    for prefix in ("NCIT", "mesh", "BTO", "PO"):
+        cfg = STUB_ONTOLOGY_SOURCES[prefix]
+        # source_type may be absent (defaults to semsql) or explicit "semsql".
+        assert cfg.get("source_type", "semsql") == "semsql"
+        assert cfg["db_filename"].endswith(".db")
 
 
 # ---------------------------------------------------------------------------
@@ -107,17 +132,18 @@ def test_stub_ontology_sources_covers_ncit_mesh_bto():
 def test_transform_writes_label_synonyms_xrefs(tmp_path):
     """A CURIE with full metadata in the fake adapter must round-trip into the TSV."""
     adapters = {
-        "NCIT": _FakeAdapter({
-            "NCIT:C29298": {
-                "label": "Oatmeal",
-                "aliases": ["Avena sativa rolled groats", "Porridge oats"],
-                "xrefs": ["FOODON:00001540", "wikipedia:Oatmeal"],
-            },
-        }),
+        "NCIT": _FakeAdapter(
+            {
+                "NCIT:C29298": {
+                    "label": "Oatmeal",
+                    "aliases": ["Avena sativa rolled groats", "Porridge oats"],
+                    "xrefs": ["FOODON:00001540", "wikipedia:Oatmeal"],
+                },
+            }
+        ),
     }
     curies = {"NCIT": {"NCIT:C29298"}, "mesh": set()}
-    t = _StubbedTransform(adapters=adapters, curies=curies,
-                          input_dir=tmp_path / "in", output_dir=tmp_path / "out")
+    t = _StubbedTransform(adapters=adapters, curies=curies, input_dir=tmp_path / "in", output_dir=tmp_path / "out")
     (tmp_path / "in").mkdir()
     t.run()
     rows = _read_tsv(tmp_path / "out" / "ontologies_stubs" / "ncit_nodes.tsv")
@@ -134,8 +160,7 @@ def test_transform_falls_back_to_curie_when_label_missing(tmp_path):
     """Missing label must NOT produce an empty `name` cell — fall back to the CURIE."""
     adapters = {"NCIT": _FakeAdapter({})}  # adapter knows nothing
     curies = {"NCIT": {"NCIT:C99999"}, "mesh": set()}
-    t = _StubbedTransform(adapters=adapters, curies=curies,
-                          input_dir=tmp_path / "in", output_dir=tmp_path / "out")
+    t = _StubbedTransform(adapters=adapters, curies=curies, input_dir=tmp_path / "in", output_dir=tmp_path / "out")
     (tmp_path / "in").mkdir()
     t.run()
     rows = _read_tsv(tmp_path / "out" / "ontologies_stubs" / "ncit_nodes.tsv")
@@ -147,8 +172,7 @@ def test_transform_writes_empty_tsv_when_no_curies(tmp_path):
     """No CURIEs → empty file with header (so merge.yaml's filename declaration is satisfied)."""
     adapters = {"mesh": _FakeAdapter({})}
     curies = {"NCIT": set(), "mesh": set()}
-    t = _StubbedTransform(adapters=adapters, curies=curies,
-                          input_dir=tmp_path / "in", output_dir=tmp_path / "out")
+    t = _StubbedTransform(adapters=adapters, curies=curies, input_dir=tmp_path / "in", output_dir=tmp_path / "out")
     (tmp_path / "in").mkdir()
     t.run()
     out = tmp_path / "out" / "ontologies_stubs"
@@ -162,17 +186,18 @@ def test_transform_writes_empty_tsv_when_no_curies(tmp_path):
 def test_transform_synonym_does_not_duplicate_label(tmp_path):
     """If an alias equals the label, drop it from the synonym set (keep them disjoint)."""
     adapters = {
-        "NCIT": _FakeAdapter({
-            "NCIT:C29298": {
-                "label": "Oatmeal",
-                "aliases": ["Oatmeal", "Porridge oats"],
-                "xrefs": [],
-            },
-        }),
+        "NCIT": _FakeAdapter(
+            {
+                "NCIT:C29298": {
+                    "label": "Oatmeal",
+                    "aliases": ["Oatmeal", "Porridge oats"],
+                    "xrefs": [],
+                },
+            }
+        ),
     }
     curies = {"NCIT": {"NCIT:C29298"}, "mesh": set()}
-    t = _StubbedTransform(adapters=adapters, curies=curies,
-                          input_dir=tmp_path / "in", output_dir=tmp_path / "out")
+    t = _StubbedTransform(adapters=adapters, curies=curies, input_dir=tmp_path / "in", output_dir=tmp_path / "out")
     (tmp_path / "in").mkdir()
     t.run()
     rows = _read_tsv(tmp_path / "out" / "ontologies_stubs" / "ncit_nodes.tsv")
@@ -190,13 +215,17 @@ def test_transform_raises_when_db_missing(tmp_path):
     )
     (tmp_path / "raw").mkdir()
     # Force collection to return at least one CURIE so we exercise the missing-DB branch.
-    object.__setattr__(transform, "run", lambda data_file=None: transform._write_stub_nodes(
-        prefix="NCIT",
-        curies=["NCIT:C29298"],
-        db_path=tmp_path / "raw" / "ncit.db",
-        knowledge_source="infores:ncit",
-        output_file=tmp_path / "out" / "ncit_nodes.tsv",
-    ))
+    object.__setattr__(
+        transform,
+        "run",
+        lambda data_file=None: transform._write_stub_nodes(
+            prefix="NCIT",
+            curies=["NCIT:C29298"],
+            db_path=tmp_path / "raw" / "ncit.db",
+            knowledge_source="infores:ncit",
+            output_file=tmp_path / "out" / "ncit_nodes.tsv",
+        ),
+    )
     with pytest.raises(FileNotFoundError, match="ncit.db"):
         transform.run()
 
@@ -211,15 +240,15 @@ _STUB_OUTPUT_DIR = REPO_ROOT / "data" / "transformed" / "ontologies_stubs"
 
 
 def _stub_outputs_present() -> bool:
-    return (_STUB_OUTPUT_DIR / "ncit_nodes.tsv").is_file() and (
-        _STUB_OUTPUT_DIR / "mesh_nodes.tsv"
-    ).is_file()
+    # The integration assertion below loads every stub prefix, so require
+    # all five outputs to be present before running it.
+    return all((_STUB_OUTPUT_DIR / f"{prefix.lower()}_nodes.tsv").is_file() for prefix in STUB_ONTOLOGY_SOURCES)
 
 
 @pytest.mark.skipif(not _stub_outputs_present(), reason="stub transform output not generated yet")
 def test_every_referenced_curie_has_stub_node():
-    """Every NCIT/mesh CURIE referenced under mappings/ must resolve to a stub node row."""
-    expected = collect_stub_curies(["NCIT", "mesh"])
+    """Every NCIT/mesh/BTO/PO/MICRO CURIE referenced under mappings/ must resolve to a stub node row."""
+    expected = collect_stub_curies(["NCIT", "mesh", "BTO", "PO", "MICRO"])
     for prefix, curies in expected.items():
         out = _STUB_OUTPUT_DIR / f"{prefix.lower()}_nodes.tsv"
         rows = _read_tsv(out)
@@ -232,3 +261,64 @@ def test_every_referenced_curie_has_stub_node():
         # Every emitted row must carry a non-empty name (no dangling-style placeholders).
         empty_names = [row["id"] for row in rows if not (row["name"] or "").strip()]
         assert not empty_names, f"{prefix} stub rows with empty name: {empty_names}"
+
+
+# ---------------------------------------------------------------------------
+# Obograph-JSON adapter (MICRO fallback when SemSQL DB is unavailable)
+# ---------------------------------------------------------------------------
+
+
+def test_obograph_json_adapter_handles_both_iri_shapes(tmp_path):
+    """Standard and MicrO-quirky IRI forms must both resolve to the canonical CURIE."""
+    fixture = {
+        "graphs": [
+            {
+                "nodes": [
+                    {
+                        # Standard OBO IRI shape.
+                        "id": "http://purl.obolibrary.org/obo/MICRO_0000082",
+                        "lbl": "nutrient broth",
+                        "meta": {
+                            "synonyms": [
+                                {"pred": "hasBroadSynonym", "val": "nutrient medium"},
+                            ],
+                            "xrefs": [{"val": "Wikipedia:Nutrient_broth"}],
+                        },
+                    },
+                    {
+                        # MicrO's quirky IRI shape (note the extra MicrO.owl/ segment).
+                        "id": "http://purl.obolibrary.org/obo/MicrO.owl/MICRO_0003152",
+                        "lbl": "phenylacetic acid fermentation assay",
+                        "meta": {
+                            "synonyms": [
+                                {"pred": "hasRelatedSynonym", "val": "o-toluate"},
+                                # Malformed entry (no val) — must be silently skipped.
+                                {"pred": "hasRelatedSynonym"},
+                            ],
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+    import json
+
+    path = tmp_path / "micro.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    adapter = _ObographJsonAdapter.from_file(path)
+    # Standard-shape IRI → CURIE
+    assert adapter.label("MICRO:0000082") == "nutrient broth"
+    assert adapter.entity_aliases("MICRO:0000082") == ["nutrient medium"]
+    assert adapter.entity_metadata_map("MICRO:0000082") == {
+        "oio:hasDbXref": ["Wikipedia:Nutrient_broth"],
+    }
+    # Quirky-shape IRI → CURIE
+    assert adapter.label("MICRO:0003152") == "phenylacetic acid fermentation assay"
+    assert adapter.entity_aliases("MICRO:0003152") == ["o-toluate"]
+    # No xrefs metadata in fixture → empty dict.
+    assert adapter.entity_metadata_map("MICRO:0003152") == {}
+    # Unknown CURIE → empty results (no exceptions).
+    assert adapter.label("MICRO:9999999") == ""
+    assert adapter.entity_aliases("MICRO:9999999") == []
+    assert adapter.entity_metadata_map("MICRO:9999999") == {}


### PR DESCRIPTION
## Summary

Promote PO (Plant Ontology) and MICRO (Microbial Conditions Ontology) from full-ontology loading to the per-CURIE SemSQL stub-import path already used by NCIT, mesh, and BTO. The merged KG references only 6 PO CURIEs and 34 MICRO CURIEs, so loading the full ontologies (~2,170 PO and ~17,600 MICRO nodes) was contributing thousands of unrelated nodes for no semantic gain.

- **PO**: SemSQL via `po.db` (bbop-sqlite, 4.6 MB) — same path as NCIT/mesh/BTO
- **MICRO**: OBO Graph JSON via a new in-house `_ObographJsonAdapter` — MICRO's bbop-sqlite distribution is a broken 29-byte placeholder, so the adapter parses `micro.json` (produced by ROBOT from the already-downloaded `micro.owl`) and normalizes both the standard `http://purl.obolibrary.org/obo/MICRO_NNNN` IRI shape and MicrO's quirky `http://purl.obolibrary.org/obo/MicrO.owl/MICRO_NNNN` variant to the canonical `MICRO:NNNN` CURIE.
- Adds `po.db.gz` to `download.yaml`; removes the now-orphaned `po.owl` entry. Keeps `micro.owl` for the obograph-JSON fallback.
- Extends BacDive's inline-emit skip-list and `STUB_ONTOLOGY_PREFIXES` so the dangling-target check passes and BacDive doesn't double-emit label-only stubs.

## Test plan

- [x] `poetry run kg transform -s ontologies_stubs` produces 73 NCIT + 95 mesh + 2 BTO + **6 PO** + **34 MICRO** stub nodes, all with non-empty names
- [x] `collect_stub_curies(['PO','MICRO'])` finds the 6 + 34 CURIEs from the committed mappings
- [x] 27 unit tests pass across `test_ontologies_stubs.py`, `test_isolation_source_mapping_utils.py`, `test_stub_curie_collection.py`
- [x] New `_ObographJsonAdapter` unit test exercises both standard and quirky IRI shapes plus malformed-synonym handling
- [x] `ruff check kg_microbe/ tests/` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)