### PR TITLE
Reuse clean_taxon_name in metatraits_gtdb CURIE construction

### DIFF
--- a/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
+++ b/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set, Union
 
 from kg_microbe.transform_utils.constants import METATRAITS_GTDB, RAW_DATA_DIR
+from kg_microbe.transform_utils.gtdb.utils import clean_taxon_name
 from kg_microbe.transform_utils.metatraits.metatraits import MetaTraitsTransform
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.chemical_mapping_utils import ChemicalMappingLoader
@@ -295,7 +296,7 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
         # because they must match the prefix-free metatraits input labels;
         # only the emitted CURIE carries s__. Input is species-level only
         # (gtdb_species_summary.jsonl.gz; genus/family summaries disabled).
-        gtdb_id = search_name.replace(" ", "_")
+        gtdb_id = clean_taxon_name(search_name)
         synthetic_node_id = f"GTDB:s__{gtdb_id}"
 
         # Extract accession for hierarchical linking
@@ -393,7 +394,7 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
                         # s__ prefix matches the canonical gtdb-transform CURIE
                         # scheme (GTDB:s__<species>) so this subClassOf edge lands
                         # on a real GTDB taxonomy node in the merged graph.
-                        OBJECT_COLUMN: f"GTDB:s__{current_species.replace(' ', '_')}",
+                        OBJECT_COLUMN: f"GTDB:s__{clean_taxon_name(current_species)}",
                         RELATION_COLUMN: RDFS_SUBCLASS_OF,
                         PRIMARY_KNOWLEDGE_SOURCE_COLUMN: "infores:gtdb-metatraits",
                     }


### PR DESCRIPTION
## Summary
Tidy-up: `metatraits_gtdb` built its GTDB CURIEs with an inline `.replace(" ", "_")` at both construction sites, duplicating the canonical logic in `gtdb/utils.clean_taxon_name`. This imports and reuses `clean_taxon_name` so the two GTDB-emitting transforms (`gtdb` and `metatraits_gtdb`) can't drift if the canonical cleaner ever changes.

## Change
- Import `clean_taxon_name` in `metatraits_gtdb`.
- Synthetic node id: `search_name.replace(" ", "_")` → `clean_taxon_name(search_name)`.
- subClassOf target: `current_species.replace(' ', '_')` → `clean_taxon_name(current_species)`.

**Behaviour-identical** — `clean_taxon_name` *is* the same space→underscore replacement. The prefix-stripping lookup-map code (`replace("s__", "")`) is unrelated and left unchanged.

## Verification
- `ruff` + `codespell` clean.
- `tests/test_gtdb.py` + `tests/test_metatraits.py`: 45 passed.
- No circular import (`gtdb/utils.py` has no imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)