### PR TITLE
Fix pre-existing tox failures: METPO chemical-tolerance predicates + proposal collisions + docstr gaps

### DIFF
--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -310,9 +310,7 @@ class OntologiesTransform(Transform):
         dropped_edges = 0
         for graph in data.get("graphs", []) or []:
             deprecated_ids = {
-                node["id"]
-                for node in graph.get("nodes", []) or []
-                if node.get("id") and self._is_deprecated_node(node)
+                node["id"] for node in graph.get("nodes", []) or [] if node.get("id") and self._is_deprecated_node(node)
             }
             if not deprecated_ids:
                 continue
@@ -321,9 +319,7 @@ class OntologiesTransform(Transform):
             graph["nodes"] = kept_nodes
 
             edges = graph.get("edges", []) or []
-            kept_edges = [
-                e for e in edges if e.get("sub") not in deprecated_ids and e.get("obj") not in deprecated_ids
-            ]
+            kept_edges = [e for e in edges if e.get("sub") not in deprecated_ids and e.get("obj") not in deprecated_ids]
             dropped_edges += len(edges) - len(kept_edges)
             graph["edges"] = kept_edges
 
@@ -457,6 +453,7 @@ class OntologiesTransform(Transform):
             print(f"  Fixing EC categories (all terms → {EC_CATEGORY})...")
 
             def fix_ec_category(row):
+                """Force EC nodes to the EC category, else replace deprecated categories."""
                 ec_id = row["id"]
                 if pd.notna(ec_id) and ec_id.startswith(EC_PREFIX):
                     return EC_CATEGORY

--- a/kg_microbe/utils/metpo_predicates.py
+++ b/kg_microbe/utils/metpo_predicates.py
@@ -83,6 +83,14 @@ METPO_TO_BIOLINK_PREDICATE = {
     "METPO:2000511": "biolink:related_to",  # has observation (organism -> assay)
     "METPO:2000067": "biolink:has_attribute",  # isolated from host with quality (organism -> PATO)
     "METPO:2000068": "biolink:has_attribute",  # isolated from environment with quality (organism -> PATO)
+    # Chemical-tolerance predicate pair (organism -> chemical). Emitted as raw
+    # METPO by metatraits (e.g. the bile-acid susceptibility trait routes through
+    # METPO:2000065 -> CHEBI:3098). Mapped here so the reviewer's VALID_PREDICATES
+    # set covers them and downstream consumers can resolve a biolink fallback.
+    # Neither biolink predicate is in PREDICATE_TO_RELATION, so the emitted
+    # relation column is unchanged (falls back to HAS_PHENOTYPE / RO:0002200).
+    "METPO:2000064": "biolink:associated_with_resistance_to",  # tolerates
+    "METPO:2000065": "biolink:associated_with_sensitivity_to",  # does not tolerate
 }
 
 # Biolink predicate -> RO relation

--- a/scripts/extract_metpo_proposals.py
+++ b/scripts/extract_metpo_proposals.py
@@ -1349,7 +1349,10 @@ def validate_against_metpo(
 
     A collision is allowed only when the colliding label/synonym is also
     declared in EXISTING_METPO_ALIASES (i.e. we have explicitly accepted that
-    this concept is being modeled by an existing METPO ID).
+    this concept is being modeled by an existing METPO ID), or when the
+    existing METPO term shares the proposal's own ``proposed_id`` -- i.e. the
+    proposal has since been adopted into METPO at exactly its intended ID, so
+    it is the same concept rather than a clash with a different term.
     """
     label_index, synonym_index = _load_metpo_index(snapshot)
     alias_keys = _alias_proposed_keys()
@@ -1364,14 +1367,16 @@ def validate_against_metpo(
             if key in alias_keys:
                 continue
             hit = label_index.get(key)
-            if hit:
+            if hit and hit[0] != term.proposed_id:
                 collisions.append(
                     f"{term.proposed_id} ({source}={text!r}) collides with "
                     f"{hit[0]} {hit[1]!r} (existing label)"
                 )
                 continue
-            hit = synonym_index.get(key)
             if hit:
+                continue
+            hit = synonym_index.get(key)
+            if hit and hit[0] != term.proposed_id:
                 collisions.append(
                     f"{term.proposed_id} ({source}={text!r}) collides with "
                     f"{hit[0]} {hit[1]!r} (existing synonym)"

--- a/tests/test_consolidate_chemical_mappings.py
+++ b/tests/test_consolidate_chemical_mappings.py
@@ -221,6 +221,7 @@ class LoaderFilteringTests(unittest.TestCase):
         cols = header.rstrip("\n").split("\t")
 
         def render_row(original, mapped, chebi_id, chebi_label):
+            """Build a compound-mappings TSV row dict for the given values."""
             d = {c: "" for c in cols}
             d["medium_id"] = "test_medium"
             d["original"] = original
@@ -314,6 +315,7 @@ class LoaderFilteringTests(unittest.TestCase):
         ]
 
         def render(row):
+            """Render a unified-SSSOM row tuple as a tab-separated line."""
             sid, slabel, oid, olabel, formula, category, source_tag = row
             return (
                 "\t".join(


### PR DESCRIPTION
## Summary
- Add METPO:2000064 (`tolerates`) → `associated_with_resistance_to` and METPO:2000065 (`does not tolerate`) → `associated_with_sensitivity_to` in `METPO_TO_BIOLINK_PREDICATE`. The bile-acid susceptibility trait routed through METPO:2000065 → CHEBI:3098 was leaking into the merged KG with no biolink fallback (surfaced by `kg-model-review`'s predicate check).
- Allow self-ID matches (`proposed_id == existing METPO id`) in `validate_against_metpo` so `test_extract_metpo_proposals::test_outputs_match_committed` stops failing after refreshed METPO snapshot graduated 7 proposals (`urease`, `catalase`, `oxidase`, `coagulase`, `xerophile`, `epibiont`; METPO:1007082–1007093) into the ontology at their exact proposed IDs. Genuine cross-ID collisions still raise.
- Add docstrings to three nested helpers surfaced by `docstr-coverage` (`fix_ec_category` in `ontologies_transform.py`; `render_row`/`render` in `test_consolidate_chemical_mappings.py`).

## Test plan
- [x] \`poetry run tox\` passes on this branch — 339 tests, 0 failures, all 6 tox envs green.
- [x] Extractor output is byte-for-byte unchanged (verified in-commit).
- [x] Neither of the two new biolink predicates is in \`PREDICATE_TO_RELATION\`, so emitted relations stay \`RO:0002200\` and no edge output changes.

## Companion PRs unblocked by this one
These two commits (\`b2b6c57f\`, \`a237751b\`) were previously mislabeled on a mappings-refresh branch. Merging them here first unbreaks tox on:
- \`chore/gitignore-build-artifacts\`
- \`feat/download-disable-broken-sources\`
- \`chore/refresh-unified-chemical-mappings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)