### PR TITLE
Disable BactoTraits and metatraits.embl.de downloads

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -199,10 +199,17 @@
 
 #
 # BactoTraits
+# NOTE: Commented out — the host (ordar.otelo.univ-lorraine.fr) serves a broken
+# TLS certificate chain (incomplete intermediate) that no CA bundle can verify,
+# so this download aborts the whole run. BactoTraits V2 is a static Jun-2022
+# dataset; the last public copy is vendored into
+# data/raw/BactoTraits_databaseV2_Jun2022.csv from data/raw_last8/, so the
+# bactotraits transform runs normally. To refresh, fetch the CSV manually
+# (verification relaxed) to that path, then re-enable this entry.
 #
--
-  url: https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
-  local_name: BactoTraits_databaseV2_Jun2022.csv
+#-
+#  url: https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+#  local_name: BactoTraits_databaseV2_Jun2022.csv
 
 #
 # CTD
@@ -394,27 +401,33 @@
 # Microbial trait data from MetaTraits organized by GTDB taxonomy (R220)
 # Enables genome-level trait associations via GTDB taxonomy
 # NOTE: Requires overlap analysis to assess value vs NCBITaxon metatraits
+# NOTE: Commented out — the metatraits.embl.de/static/downloads/ endpoint now
+# returns HTTP 404 for all of these (access moved behind permission from
+# antheaguo@berkeley.edu). The last public copies (2026-03-24) are vendored
+# into data/raw/ from data/raw_last8/. To refresh, obtain access and re-enable.
 #
--
-  url: https://metatraits.embl.de/static/downloads/gtdb_species_summary.jsonl.gz
-  local_name: gtdb_species_summary.jsonl.gz
--
-  url: https://metatraits.embl.de/static/downloads/gtdb_genus_summary.jsonl.gz
-  local_name: gtdb_genus_summary.jsonl.gz
--
-  url: https://metatraits.embl.de/static/downloads/gtdb_family_summary.jsonl.gz
-  local_name: gtdb_family_summary.jsonl.gz
+#-
+#  url: https://metatraits.embl.de/static/downloads/gtdb_species_summary.jsonl.gz
+#  local_name: gtdb_species_summary.jsonl.gz
+#-
+#  url: https://metatraits.embl.de/static/downloads/gtdb_genus_summary.jsonl.gz
+#  local_name: gtdb_genus_summary.jsonl.gz
+#-
+#  url: https://metatraits.embl.de/static/downloads/gtdb_family_summary.jsonl.gz
+#  local_name: gtdb_family_summary.jsonl.gz
 
 #
 # GTDB-NCBITaxon Mappings (for overlap analysis)
 # Maps between GTDB R220 and NCBITaxon taxonomies
+# NOTE: Commented out — same dead metatraits.embl.de endpoint (HTTP 404).
+# Last public copies (2026-03-24) vendored into data/raw/ from data/raw_last8/.
 #
--
-  url: https://metatraits.embl.de/static/downloads/GTDB2NCBI.tsv.gz
-  local_name: GTDB2NCBI.tsv.gz
--
-  url: https://metatraits.embl.de/static/downloads/NCBI2GTDB.tsv.gz
-  local_name: NCBI2GTDB.tsv.gz
+#-
+#  url: https://metatraits.embl.de/static/downloads/GTDB2NCBI.tsv.gz
+#  local_name: GTDB2NCBI.tsv.gz
+#-
+#  url: https://metatraits.embl.de/static/downloads/NCBI2GTDB.tsv.gz
+#  local_name: NCBI2GTDB.tsv.gz
 
 #
 # Biolink Model


### PR DESCRIPTION
## Summary
Comment out four \`download.yaml\` entries that no longer succeed against public endpoints, and document the specific failure mode + vendored fallback path for each so the transforms keep running:

- **BactoTraits** (\`ordar.otelo.univ-lorraine.fr\`) serves a broken TLS certificate chain (incomplete intermediate) that no CA bundle can verify, aborting the whole download. BactoTraits V2 is a static Jun-2022 dataset — vendor the last public copy to \`data/raw/BactoTraits_databaseV2_Jun2022.csv\`.
- **metatraits.embl.de/static/downloads/** — \`gtdb_{species,genus,family}_summary.jsonl.gz\` and \`GTDB2NCBI/NCBI2GTDB.tsv.gz\` now return HTTP 404; access has moved behind permission (contact: \`antheaguo@berkeley.edu\`). Vendor the 2026-03-24 copies to \`data/raw/\`.

Each block gains a \`NOTE\` comment describing the failure and the manual refresh procedure.

## Test plan
- [x] \`poetry run tox\` on this branch shows only pre-existing master failures fixed by companion PR #577 — no new failures introduced by this diff.
- [ ] \`poetry run kg download\` completes without the previous BactoTraits TLS error and metatraits 404s.
- [ ] \`poetry run kg transform -s bactotraits\` and \`-s metatraits_gtdb\` run successfully against the vendored copies.

## Companion untracked files (not in this PR)
\`kg_microbe/transform_utils/bactotraits/BactoTraits.tsv\` (6.2 MB) — vendored copy currently untracked at repo root, decision pending in #579.

## Related
- **Blocked on CI:** #577
- Follow-up: #579 (cleanup untracked scratch — including the BactoTraits vendored copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)