### PR TITLE
Add three developer tooling skills: branch-triage-ship, codex-review-kg-microbe, kgm-freshness-check

### DIFF
--- a/.claude/skills/branch-triage-ship/SKILL.md
+++ b/.claude/skills/branch-triage-ship/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: branch-triage-ship
+description: Ship a messy topic branch as a set of clean, focused PRs. Walks through triage of committed commits + working-tree modifications + untracked files, extracts misfiled commits to their own branches, splits orthogonal changes into separate PRs, gitignores build noise, opens follow-up issues for deferred items, and merges in the correct dependency order. Use when a working branch has accumulated mixed commits, uncommitted work, and dozens of untracked scratch files and needs to reach master.
+---
+
+# branch-triage-ship
+
+## Purpose
+
+Take a topic branch that has drifted — mislabeled commits, uncommitted work on multiple orthogonal topics, dozens of untracked files, and possibly tox failing on master already — and land its intended changes as a set of clean, focused PRs.
+
+The end state:
+- The topic branch's declared purpose is exactly what its PR contains.
+- Anything unrelated is either on its own branch/PR, in its own follow-up issue, or explicitly deleted.
+- Working tree is quiet (`git status --short` shows only files you meant to keep).
+- Master CI is green.
+
+## When to use
+
+Trigger this when *any* of these hold:
+- Branch name doesn't describe its actual commits.
+- `git status` shows more than ~5 untracked entries you can't immediately account for.
+- Working tree has tracked-file modifications that clearly belong to different topics.
+- Pre-existing tox / CI failures on master would block the branch's PR.
+- You want to open a PR but "there's a lot going on in here" is the first thing you'd say.
+
+Skip if the branch is single-topic and the working tree is clean — just PR normally.
+
+## Prerequisites
+
+- `gh` CLI authenticated for the target repo.
+- Write access to the branch and the ability to push new branches.
+- If admin-merging: repo admin rights AND explicit user authorization to bypass branch-protection review requirements.
+- Familiarity with the repo's test / lint gate. This skill runs it, not skips it.
+
+## The workflow
+
+Run every phase before starting the next. Each ends with an explicit checkpoint.
+
+### Phase 1 — Diagnose
+
+Collect the raw picture before proposing anything.
+
+```bash
+git status --porcelain          # includes untracked
+git log --oneline origin/master..HEAD
+git diff --stat origin/master..HEAD
+git diff --stat                 # unstaged
+git diff --cached --stat        # staged
+```
+
+Also fetch to make sure `origin/master` is current:
+
+```bash
+git fetch origin master
+```
+
+Produce a classification table with three columns per row:
+- **Path**
+- **Category** — one of: `on-this-branch`, `own-branch`, `gitignore`, `delete`, `needs-decision`
+- **Reason**
+
+For every modified tracked file: read the diff. Classify each into:
+- **on-this-branch** — matches the branch's declared purpose.
+- **own-branch** — orthogonal change; needs its own topic branch.
+- **formatter-only** — pure whitespace / autoformatter output; discard or bundle into a chore commit.
+- **build-artifact** — file that a pipeline / test rewrites; probably should be `git rm --cached`ed and gitignored.
+
+For every commit ahead of master: check whether it belongs on this branch by name (`git show <sha> --stat`).
+
+For every untracked entry: classify by pattern (see the patterns library below), and note anything ambiguous as **needs-decision**.
+
+**Checkpoint 1**: A single classification table exists that covers every path in `git status`. Nothing is unaccounted for.
+
+### Phase 2 — Extract misfiled commits
+
+If any commit ahead of master doesn't belong to this branch:
+
+1. Create a fresh branch off master, cherry-pick the misfiled commits onto it.
+   ```bash
+   git checkout -b feat/<accurate-name> origin/master
+   git cherry-pick <sha1> <sha2> ...
+   ```
+2. Leave the topic branch alone for now — reset comes in phase 3.
+
+Never `git reset --hard` before you've verified the cherry-picks succeeded.
+
+**Checkpoint 2**: All misfiled commits exist on a correctly-named branch. `git log --oneline` on that branch shows only the extracted commits.
+
+### Phase 3 — Preserve working-tree work, then reset
+
+**Only if the topic branch has commits ahead of master that need to go away.** If the branch is clean (no misfiled commits), skip to Phase 4.
+
+Working-tree modifications are lost by `git reset --hard`. Save them first.
+
+```bash
+mkdir -p /tmp/branch-triage
+for f in <files you want to keep>; do
+  cp -p "$f" /tmp/branch-triage/
+done
+```
+
+Then reset:
+
+```bash
+git reset --hard origin/master
+```
+
+Restore the files you saved:
+
+```bash
+for f in /tmp/branch-triage/*; do
+  cp -p "$f" "$(git rev-parse --show-toplevel)/<original-path>"
+done
+```
+
+**Checkpoint 3**: The topic branch is at `origin/master` with only the files you intentionally restored appearing as modifications in `git status`.
+
+### Phase 4 — Split into focused topic branches
+
+Every group in your classification table that is **on-this-branch** stays on this branch. Every group that is **own-branch** goes to a new branch off master:
+
+```bash
+git checkout -b <accurate-topic-name> origin/master
+# restore just the files that belong to that topic
+# stage, commit
+```
+
+Repeat for each orthogonal group.
+
+For **formatter-only** modifications: discard them (`git checkout -- <file>`) unless the user has explicitly asked for a "apply formatter" commit. Formatter noise is inherited from master when master itself fails the formatter; the fix lives on a "chore: apply formatter" branch or in the CI hardening PR.
+
+For **build-artifact** files that are already tracked: reserve for the `git rm --cached` branch in phase 5.
+
+**Checkpoint 4**: You have N branches, each with exactly one topic's commit(s). Each branch is at `origin/master + 1..few commits`.
+
+### Phase 5 — Cleanup branch(es)
+
+Two common cleanup branches (each on its own — do not bundle):
+
+#### 5a. Gitignore build artifacts
+
+For untracked scratch that will keep re-appearing on every run:
+
+```bash
+git checkout -b chore/gitignore-build-artifacts origin/master
+# append to .gitignore
+git add .gitignore
+git commit -m "Gitignore local build artifacts and dated snapshot dirs"
+```
+
+Include only patterns you are confident about. Prefer anchored globs (`/*.out`, `notebooks/*.html`) over wildcards that could catch authored content. See "Patterns library" below.
+
+#### 5b. Untrack regenerable pipeline outputs
+
+For files currently tracked that a pipeline rewrites every run:
+
+```bash
+git checkout -b chore/untrack-regenerable-outputs origin/master
+git rm --cached <file1> <file2> ...
+git commit -m "Untrack regenerable pipeline outputs"
+```
+
+Verify the files remain on disk after `git rm --cached` — the flag is index-only. The gitignore rule from 5a must already exist (or land in the same PR) or the files will re-appear as untracked immediately.
+
+**Checkpoint 5**: Cleanup branches exist. `git status` on the topic branch shows only files that need per-file decisions, which will become a follow-up issue in Phase 8.
+
+### Phase 6 — Verify each branch
+
+Run the repo's test / lint gate on every branch. In a Python + tox repo:
+
+```bash
+for br in <list of branches>; do
+  git checkout "$br"
+  git checkout -- $(git diff --name-only)   # discard tox format leftovers
+  poetry run tox
+done
+```
+
+Common failure modes and what they mean:
+
+- **All branches fail the same test** → the failure is on master, unrelated to any of your branches. Identify which branch fixes it and merge that one first. Note in the other PRs' bodies that CI is inherited-broken until the fix lands.
+- **Format check leaves files dirty** → master's code fails the current formatter. Discard the changes with `git checkout --` before switching branches. Do NOT commit the auto-format changes to your topic branches; they belong in a separate "chore: apply formatter" PR.
+- **Only one branch fails** → real breakage on that branch. Fix before proceeding.
+
+**Checkpoint 6**: You know exactly which branches pass, which fail, and why. Failure reasons are documented and non-blocking (either fixed, or inherited-broken with a clear owner).
+
+### Phase 7 — Push and open PRs
+
+Sequential per branch:
+
+```bash
+git push -u origin <branch>
+gh pr create --base master --head <branch> --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<what changed, in bullet points>
+
+## Test plan
+- [x] `poetry run tox` on this branch — passes / shows only pre-existing master failures fixed by #<companion-pr>.
+- [ ] <manual verification if applicable>
+
+## Related
+- **Blocked on CI:** #<companion-pr>  (only for branches inheriting master fails)
+- Follow-up: #<issue for deferred items>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Rules for PR bodies:
+- Every PR references its blocker PR if it inherits master failures.
+- Every PR references any follow-up issue it defers work to.
+- Test plan bullets are honest about what was run vs what still needs manual verification.
+- Never include a "Test plan" checkbox that was neither run nor is planned. Delete it.
+
+**Checkpoint 7**: One PR per topic branch. Every PR body has: summary, test plan reflecting real coverage, related PRs / issues cross-referenced.
+
+### Phase 8 — File follow-up issues
+
+For every `needs-decision` group in the phase-1 table that didn't become a PR: file a GitHub issue that:
+- Lists each path with a checkbox.
+- Explains the classification prompt ("belongs on which branch, or gitignore, or delete").
+- Cross-links to the PRs that did land.
+
+```bash
+gh issue create --title "..." --body "..."
+```
+
+**Checkpoint 8**: Every deferred item has a GitHub-native home. `NEXT_TASKS.md` or a local checklist file can now be deleted — the durable record is the issue.
+
+### Phase 9 — Merge in dependency order
+
+Merge order matters. Identify the dependency:
+- A branch that fixes master's CI must merge first, or the others will show red CI (annoying to reviewers) even if the actual diff is fine.
+- Anything else can merge in any order after that.
+
+```bash
+gh pr merge <n> --merge      # or --admin --merge  ONLY if explicitly authorized to bypass reviews
+```
+
+Branch protection rules are checked with:
+
+```bash
+gh api repos/<owner>/<repo>/branches/master/protection
+```
+
+If `required_approving_review_count > 0` and you're the sole author, you cannot self-approve. Options:
+- Ask a collaborator to review.
+- If you're admin AND the user has explicitly authorized bypass, use `--admin`.
+- Otherwise, stop here and hand off.
+
+After each merge, update local master:
+
+```bash
+git fetch origin master
+git checkout master
+git merge --ff-only origin/master
+```
+
+**Checkpoint 9**: All PRs are merged. Master is at the expected new tip.
+
+### Phase 10 — Local cleanup
+
+Delete merged local branches:
+
+```bash
+git branch -d <br1> <br2> ...   # -d (safe) refuses if not fully merged
+```
+
+The `-d` flag will refuse to delete a branch that isn't fully merged. If you get an error, do NOT jump to `-D` — investigate first; you probably missed a commit.
+
+Do NOT auto-delete unrelated stale local branches. Their existence is often intentional (work-in-progress that wasn't part of this triage).
+
+**Checkpoint 10**: Only master and pre-existing unrelated branches remain locally. `git status --short` matches the expected residual (typically the follow-up-issue's checklist items).
+
+## Patterns library
+
+### Untracked file classification cheatsheet
+
+| Pattern | Category | Default action |
+|---|---|---|
+| `data/raw_20*/`, `data/raw_last[0-9]*/`, `data/transformed_20*/`, `data/merged_20*/` | build-artifact | gitignore |
+| `*.out`, `*.log`, `*.tmp` at repo root | build-artifact | gitignore |
+| `download.yaml_*`, `merge.yaml_*`, `*.yaml.bak` | build-artifact | gitignore |
+| `*.ipynb_bak`, `*.py_bak`, `**/*.bak` | backup | gitignore |
+| `notebooks/catboost_info/`, `notebooks/*.html`, `notebooks/*_output.tsv` | build-artifact | gitignore |
+| `<name>*.png` / `<name>*.psd` at repo root (mockups) | build-artifact | gitignore |
+| new `.py` in `<pkg>/utils/` with no in-repo references | needs-decision | issue |
+| root-level `.py` (`run.py`, `analyze_*.py`) | needs-decision | issue |
+| new `.py` in a package with a name that collides with an existing package | needs-decision (shadowing risk) | issue with explicit shadowing note |
+| `<pkg>/**/tmp/*.tsv` opened with `"w"` mode by a transform | build-artifact | gitignore + `git rm --cached` |
+| `<pkg>/**/tmp/*.csv` that is < 100 KB and has curated content | reference data | keep tracked |
+| SSSOM `mappings/*.tsv` with new authored rows | on-this-branch | stage on the mappings branch |
+| `download.yaml` with comment-out blocks | own-branch | own branch (with rationale in commit body) |
+| `merged_graph_stats.yaml`, `merged-kg_stats.yaml` diffs | on-a-release-branch | only commit as part of an explicit release |
+| `*.docx`, `*.pdf`, `*.psd` for a paper submission | out-of-scope | ignore / move to `paper_*/` |
+
+### Modified tracked file "smells"
+
+| Symptom | Likely cause | Handling |
+|---|---|---|
+| Diff is only whitespace / line-wrap changes | Formatter run against code that pre-dates the current formatter config | Discard, do not commit into a topic branch |
+| Big binary diff (`Bin` in `git diff --stat`) | Regenerated cache / index | If it's a genuine content refresh (SSSOM `.gz`, embedding index), keep; if it's a byproduct, discard |
+| One-line yaml value change | Config drift | Own commit; likely own branch |
+| Whole-file rewrite of a stats yaml | Rebuild of a merged/stats snapshot | Only commit if this is a release cut; otherwise discard |
+
+## Failure modes to watch for
+
+- **`git reset --hard` before saving working-tree state** — permanent data loss. Phase 3's "preserve then reset" order is mandatory.
+- **Force-pushing to a branch that others have based work on** — check `git ls-remote origin refs/heads/<branch>` and remote tracking before force-pushing.
+- **Admin-merging without explicit authorization** — branch-protection bypass is a sensitive action. If you weren't told, ask.
+- **Bundling formatter changes into a topic PR** — those changes get inherited on every branch off master; do not add them to your topic branches or you'll rebase them into every future PR.
+- **Committing a build artifact that's now gitignored** — if you add a file that matches your new `.gitignore`, git will accept the add (explicit-add wins over ignore). Verify with `git status` after the gitignore commit that only intended files remain.
+- **Closing an issue by merging a PR that doesn't fully address it** — use `Closes #N` only when the PR fully closes the issue. For partial fixes use `Refs #N`.
+
+## Output artifacts
+
+After running this workflow end-to-end, you should have:
+- N merged PRs, one per topic.
+- M open follow-up issues, each with a triage checklist.
+- A commit history on master that reads like a clear sequence of small, focused changes.
+- No local branches left over from the triage.
+- Clean `git status` (or only the intentional untracked residual documented in the follow-up issues).
+
+## Companion skills
+
+- **`kgm-freshness-check`** (kg-microbe-specific) — before touching pipeline outputs, verify what's stale vs master.
+- **`kg-release`** (kg-microbe-specific) — if the triage is release-adjacent, gate the release on the review skills the release cutter looks for.
+- **`resolve-copilot`** — if a Copilot review is already open on the messy branch, address it before or during Phase 6.
+
+## Notes on this repo (kg-microbe)
+
+- Tests run via `poetry run tox`. Full run is ~3-5 minutes.
+- Format step (`tox -e format`) is included in the default tox run and will leave master-inherited whitespace changes in your working tree; discard before switching branches.
+- Branch protection on `master` requires 1 approving review. Admin bypass available; requires explicit user opt-in.
+- Merged branches on GitHub are not auto-deleted; local branches must be deleted with `git branch -d`.
+- The three most common "misfiled commit" targets are (a) METPO snapshot integration commits, (b) SSSOM mapping refresh commits, (c) download.yaml source-disable commits. Each has its own conventional branch prefix.

--- a/.claude/skills/codex-review-kg-microbe/SKILL.md
+++ b/.claude/skills/codex-review-kg-microbe/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: codex-review-kg-microbe
+description: Emit a Codex-ready review prompt for the KG-Microbe repository focused on code logic, consistency, robustness, bugs, bottlenecks, and scalability. Use before delegating a deep review pass to Codex (via the codex:rescue subagent) or another external code-review agent so the target is precisely scoped and the review dimensions are enforced.
+---
+
+# codex-review-kg-microbe
+
+## Purpose
+
+Compose a single self-contained prompt string that Codex (or any comparable
+LLM-backed code reviewer) can consume to review the KG-Microbe repository
+across six specific dimensions:
+
+1. **Code logic** — control flow, data flow, semantic correctness
+2. **Consistency** — API usage, naming, error handling, prefix/CURIE handling, config conventions
+3. **Robustness** — edge cases, malformed input handling, IO failure paths, retry/backoff, idempotency
+4. **Bugs** — provable errors reachable on real inputs (not stylistic)
+5. **Bottlenecks** — hot paths, quadratic patterns, redundant IO, missed batching, sync-in-async
+6. **Scalability** — memory footprint on realistic sizes (150 M UniProt edges, 12 GB `data/raw`, 500 GB RAM regime), streaming vs load-all, multiprocessing correctness
+
+The output is a prompt only — this skill never talks to Codex directly.
+Hand the emitted text off to `codex:rescue` (the `Agent(subagent_type='codex:codex-rescue', ...)` path) or paste it into `codex exec`.
+
+## Usage
+
+`/codex-review-kg-microbe [scope]`
+
+- `scope` (optional) — a repo-relative subtree the review should focus on.
+  Examples: `kg_microbe/transform_utils/bacdive`,
+  `kg_microbe/transform_utils/metatraits_gtdb`,
+  `kg_microbe/merge_utils`, `kg_microbe/utils`, `scripts`, `tests`.
+  Default: the whole repo (`.`).
+
+## Behavior when invoked
+
+When invoked, output the prompt exactly as constructed below, substituting
+`{{scope}}` and today's date (`YYYY-MM-DD`). Do NOT execute the review
+yourself; do NOT edit any files; do NOT summarize the repo.
+
+If `scope` is not supplied, use `.` and add the line
+`Prioritize kg_microbe/transform_utils/ and kg_microbe/merge_utils/ over auxiliary directories.`
+at the end of the "What to focus on" section.
+
+---
+
+## Prompt template
+
+Emit the following as a single fenced block, ready to be piped into Codex.
+The `{{scope}}` placeholder and today's date get filled in; everything
+else is literal.
+
+```
+You are an experienced code reviewer performing a repo-wide review of
+KG-Microbe (Knowledge-Graph-Hub/kg-microbe) at commit HEAD.
+
+## Repo context
+
+KG-Microbe is a Python knowledge-graph construction pipeline with three
+stages — **Download → Transform → Merge** — that ingests BacDive,
+MediaDive, BactoTraits, UniProt, CTD, Disbiome, Wallen et al., Madin et
+al., MetaTraits, GTDB, Rhea, and a handful of OBO ontologies (ENVO,
+ChEBI, GO, NCBITaxon, MONDO, HP, EC), and emits Biolink-modeled
+`nodes.tsv` + `edges.tsv` per source plus a merged KG.
+
+Key entry points:
+
+- CLI: `poetry run kg download | transform | merge | holdouts | query`
+  (`kg_microbe/run.py`, Click-based).
+- Transforms: `kg_microbe/transform_utils/<source>/<source>.py`, each a
+  subclass of `Transform` in `transform_utils/transform.py`. Registered
+  in `DATA_SOURCES` in `transform.py`.
+- Merge: `kg_microbe/merge_utils/merge_kg.py` (KGX library).
+- Shared conventions: `transform_utils/constants.py` (column names,
+  path constants), `transform_utils/custom_curies.yaml`
+  (CURIE→URI map), `transform_utils/translation_table.yaml`
+  (entity-type translations).
+
+Scale to keep in mind:
+- BacDive transform emits ~1 M edges.
+- MetaTraits (GTDB variant) processes ~85 K taxa; sequential mode
+  takes 5–8 h, multiprocessing 1.5–2.5 h. Multiproc is auto-enabled
+  when ≥ 2 input files exist or a single file is chunk-split. Each
+  worker needs ~3 GB RAM (OAK adapter + processing).
+- Merged KG has ~150 M nodes / 555 M edges when UniProt is included.
+- `data/raw/` is ~12 GB; some transforms have historically required
+  >500 GB RAM (NCBI taxonomy trim, UniProt processing).
+
+## Review scope
+
+Focus on: **{{scope}}**
+
+Recurse into every Python file under that path. Ignore vendored data
+files, `data/`, `notebooks/`, `.tox/`, `.venv/`, `__pycache__/`,
+generated `data/transformed/*/nodes.tsv|edges.tsv`, and anything under
+`.gitignore`.
+
+## Review dimensions — required
+
+Evaluate every file you read against **all six** of these dimensions.
+Not every file will have findings in every dimension; that's expected.
+Do not skip a dimension.
+
+1. **Code logic**
+   - Incorrect control flow, off-by-one indexing, wrong operator
+     precedence, mis-ordered arguments, wrong CURIE / predicate
+     applied to the wrong biolink category.
+   - Data-flow bugs where a transformed value never reaches its writer
+     or a computed CURIE is silently dropped.
+   - Category / predicate assignments that violate Biolink's
+     subject/object constraints for the given predicate (see
+     `transform_utils/constants.py` and `metpo_predicates.py`).
+
+2. **Consistency**
+   - Two transforms doing the same thing differently (e.g. CURIE
+     construction, node-header ordering, provenance recording) when
+     they should be sharing a helper.
+   - Inline CURIE literals in code that duplicate rows already in
+     `mappings/` — "data masquerading as code".
+   - Diverging naming for the same concept
+     (`ncbitaxon_id` vs `ncbi_taxid` vs `taxon`).
+   - Ad-hoc error handling styles (bare `except`, `print` vs
+     `logging`, `sys.exit` mid-function).
+
+3. **Robustness**
+   - Malformed input (partial JSON, empty TSV, missing column,
+     truncated download) that the transform assumes is well-formed.
+   - IO paths that don't check `.exists()` / permissions, or that
+     open files without context managers.
+   - Retry / backoff missing where an external API is called
+     (BacDive API, UniProt API, OLS).
+   - Non-idempotent transforms — running twice produces different
+     output than running once.
+   - Silent `except Exception: pass` blocks; dict `.get(k)` without
+     validating the return; `int(str_value)` without try/except when
+     the source column is user-provided.
+
+4. **Bugs**
+   - Findings that are provably wrong on real inputs, not stylistic.
+     Each bug finding MUST include:
+     - Exact file:line
+     - The bug in ≤ 2 sentences
+     - A minimal reproducing scenario (input shape or CLI command)
+     - The expected vs actual behavior
+   - Prefer high-confidence, small-surface bugs over "this looks
+     suspicious" gestures. If you cannot show it's reachable, put it
+     under Robustness instead.
+
+5. **Bottlenecks**
+   - Nested loops or per-row `pd.DataFrame.apply` on a hot path.
+   - Repeated per-row lookups against a dataframe / dict that should
+     have been indexed once at the top.
+   - Redundant IO: reading the same JSON / TSV multiple times per
+     transform run when once would suffice.
+   - Synchronous chains of remote API calls when batching or async
+     would drop wall-clock by >2×.
+   - Missing streaming when a full file load is not required (large
+     JSONL / TSV read into memory then iterated once).
+
+6. **Scalability**
+   - Data structures that grow O(N) with input where a streaming
+     accumulator would be O(1). Explicitly flag anything that would
+     break past ~5 M rows.
+   - Multiprocessing correctness: shared-state hazards, pickling of
+     un-picklable objects, forked workers duplicating a 10 GB parent,
+     unbounded worker counts.
+   - Assumptions that a file fits in RAM (e.g. `pd.read_csv` without
+     `chunksize`).
+   - Global mutable state that would race under multiprocessing.
+
+## Output format — required
+
+For every finding, emit a Markdown-formatted block:
+
+```
+### {severity} · {dimension} · {short-title}
+
+- **File:** `<path>:<line>` (single canonical location; add others in body if needed)
+- **Category:** one of {logic | consistency | robustness | bug | bottleneck | scalability}
+- **Severity:** one of {CRITICAL | HIGH | MEDIUM | LOW}
+- **Confidence:** {HIGH | MEDIUM | LOW}
+- **Impact:** one sentence — who / what is affected on a real run.
+- **Fix sketch:** one or two sentences. If the fix would be > 20 lines,
+  say `fix requires refactor; see notes`.
+- **Notes:** free text; include the minimal repro for bugs and the
+  cross-file references for consistency.
+```
+
+At the very end, produce a single **summary table** grouped by
+`(dimension, severity)` with counts, plus a **top 5 to fix first**
+ranked by `severity × confidence × repo-blast-radius`.
+
+## Explicit non-goals
+
+Do NOT:
+- Propose renames, formatter fixes, or docstring additions unless they
+  block correctness.
+- Rewrite files. Only fix sketches, never diffs.
+- Comment on ontology curation choices (which CHEBI IDs are "right"),
+  only on how the code handles them.
+- Flag deprecation warnings from dependencies that KG-Microbe cannot
+  fix on its side.
+- Duplicate a finding across dimensions — pick the one that best fits
+  the failure mode.
+
+## Ground rules
+
+- All file paths are repo-relative.
+- Prefer high-confidence findings; when a finding is speculative,
+  mark it `Confidence: LOW` and say what you would need to see to
+  raise the confidence.
+- If you spot a systemic issue that recurs across many files, describe
+  it once with a representative site and a full grep-friendly pattern,
+  rather than listing every occurrence.
+- Run today (date: {{today}}). Note any finding where behavior depends
+  on a specific data snapshot or model release that may have changed
+  since this scan.
+```
+
+## Notes on companion skills
+
+- To hand this prompt to Codex, use the `codex:rescue` subagent:
+  `Agent(subagent_type="codex:codex-rescue", prompt="<emitted prompt>")`.
+- After receiving Codex's findings, the `kg-model-review` skill can be
+  used to cross-check any category / predicate claims against the
+  Biolink + METPO models; do not rely on Codex alone for those.
+- If the scope is a single transform, follow up with
+  `kg-path-review` on that transform's `nodes.tsv` / `edges.tsv` to
+  confirm any suspected modeling bugs actually surface in output.

--- a/.claude/skills/kgm-freshness-check/SKILL.md
+++ b/.claude/skills/kgm-freshness-check/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: kgm-freshness-check
+description: Determine whether local KG-Microbe transform outputs (data/transformed/<source>/) and merged KG (data/merged/) are current relative to origin/master. Compares latest commit times on origin/master touching each transform's code directory against local output mtimes; also checks merge stage against merge_utils/, merge.yaml, and every transform output. Use before cutting a release, before running kg-release, or when triaging "why did my merged KG change".
+---
+
+# kgm-freshness-check
+
+## Purpose
+
+Answer one question:
+
+> Do the transform outputs on disk (`data/transformed/<source>/`) and the
+> merged KG (`data/merged/`) reflect the code that is on `origin/master`
+> **right now**, or has master moved on and left them stale?
+
+Compares latest commit timestamps on `origin/master` per code directory
+against local output mtimes, and prints a per-source table + a merge-stage
+summary.
+
+## Usage
+
+```bash
+poetry run python .claude/skills/kgm-freshness-check/kgm_freshness_check.py
+```
+
+Options:
+
+- `--ref <git-ref>` — compare against a different ref (default: `origin/master`)
+- `--source <name>` — check only this source (repeatable). Default: every
+  transform directory that has `<name>/<name>.py`
+- `--json` — emit machine-readable JSON instead of the human table
+- `--skip-fetch` — don't `git fetch origin master` even if the ref is
+  missing locally
+
+Exit codes: `0` = all FRESH, `1` = some STALE / MISSING, `2` = invocation
+error (ref unresolved, etc.).
+
+## Status codes
+
+### Per source
+
+| Status | Meaning | Suggested action |
+|---|---|---|
+| `FRESH` | Output mtime is newer than the latest commit on `origin/master` touching the code dir, AND the local working tree matches master. | Nothing to do. |
+| `STALE_VS_CODE` | Master has commits touching this transform newer than the local output. | `poetry run kg transform -s <source>` |
+| `LOCAL_CHANGES` | Local working tree diverges from `origin/master` for this transform's code dir. "Current vs master" is undefined until the diff lands. | Land the local diff (PR + merge), then re-check. |
+| `MISSING_OUTPUT` | No `.tsv` / `.tsv.gz` in `data/transformed/<source>/`. | `poetry run kg transform -s <source>` |
+| `NO_CODE` | `<source>/` directory exists but no `<source>.py` — probably a helper folder, not a transform. Skipped from freshness scoring. | none |
+
+### Merge
+
+| Status | Meaning | Suggested action |
+|---|---|---|
+| `FRESH` | Merged output is newer than `merge_utils/` code on master AND newer than `merge.yaml` AND newer than every transform output. | Nothing to do. |
+| `STALE_VS_INPUTS` | At least one transform output is newer than the merged output. | Re-merge. |
+| `STALE_VS_YAML` | `merge.yaml` (or `merge.minimal.yaml`) is newer than the merged output. | Re-merge. |
+| `STALE_VS_CODE` | `merge_utils/` has commits on master newer than the merged output. | Re-merge (and rerun transforms if their `STALE_VS_CODE` is triggered by the same code bump). |
+| `MISSING_OUTPUT` | No `data/merged/merged-kg_edges.tsv[.gz]` or `data/merged/merged-kg.tar.gz` on disk. | `poetry run kg merge -y merge.yaml` |
+
+## Example output
+
+```
+SOURCE                 STATUS           CODE COMMIT (UTC)     OUTPUT MTIME (UTC)    LOCAL  NOTE
+------------------------------------------------------------------------------------------------
+bacdive                STALE_VS_CODE    2026-06-25T03:11:06Z  2026-06-22T21:24:00Z  no     code advanced 2.3 days after last output build; rerun `poetry run kg transform -s bacdive`
+bactotraits            FRESH            2024-07-01T00:00:00Z  2026-06-22T22:25:00Z  no
+bakta                  MISSING_OUTPUT   2026-06-01T00:00:00Z  -                     no     data/transformed/bakta/ has no .tsv/.tsv.gz
+metatraits_gtdb        LOCAL_CHANGES    2026-06-26T00:00:00Z  2026-06-24T13:17:00Z  yes    local code diverges from origin/master; freshness vs master is not defined until the diff lands
+...
+
+MERGE
+-----
+  status           : STALE_VS_INPUTS
+  merged output    : data/merged/merged-kg_edges.tsv
+  merged mtime     : 2026-06-20T00:00:00Z
+  merge_utils code : 2026-06-10T00:00:00Z (1aaaf8f8)
+  merge yaml       : merge.yaml (2026-06-18T00:00:00Z)
+  stale against    :
+    - data/transformed/bacdive/
+    - data/transformed/metatraits_gtdb/
+  action           : rerun `poetry run kg merge -y merge.yaml` (or the config in use)
+
+SUMMARY
+-------
+  FRESH            8
+  STALE_VS_CODE    2
+  LOCAL_CHANGES    1
+  MISSING_OUTPUT   1
+  NO_CODE          0
+  merge            STALE_VS_INPUTS
+```
+
+## When to invoke
+
+- **Before every `kg-release`** — a release built from stale outputs is
+  the failure mode this skill exists to catch.
+- **When a merged KG surprised you** — is the change explained by master
+  moving on and forcing a rebuild, or is it a genuine transform bug?
+- **When debugging a CI diff** — the CI often builds from a specific
+  commit, so a `FRESH` verdict locally + a different result in CI tells
+  you the code hasn't diverged.
+- **Before running `poetry run tox`** in a release-adjacent state.
+
+## Companion skills
+
+- `kg-release` — the release cutter is the primary caller. Add
+  `poetry run python .claude/skills/kgm-freshness-check/kgm_freshness_check.py`
+  as a pre-flight if the release-gate script doesn't already run it.
+- `kg-model-review` and `kg-path-review` — run those on the merged KG
+  after re-running any STALE transforms.
+
+## Limitations
+
+- Timestamps are file mtimes, not commit-time metadata inside the file.
+  Copying an output from another checkout with `cp -p` preserves mtime;
+  a fresh `poetry run kg transform` sets mtime to now.
+- Multiprocessing rebuilds set the mtime on every worker's output, so a
+  half-finished transform can look partially fresh.
+- The ref default is `origin/master`. On a fork, override with `--ref`.
+- The `data/raw/` inputs are not currently checked. If a raw input was
+  refreshed but its transform wasn't rerun, this skill will report the
+  transform FRESH. That's a known gap; add a `--check-raw` mode if it
+  becomes an issue.

--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Freshness check for KG-Microbe transform / merge outputs vs origin/master.
+
+For every transform directory under kg_microbe/transform_utils/<source>/,
+compare:
+  - the latest commit that touched the transform code on origin/master, vs
+  - the mtime of the transform's data/transformed/<source>/{nodes,edges}.tsv output.
+
+Also report:
+  - whether the local working tree has changes to the transform code that
+    diverge from origin/master (LOCAL_CHANGES).
+  - merge-stage freshness: merge.yaml + merge_utils/ vs data/merged/*.
+
+Per-source status codes:
+  FRESH             — output mtime > latest code commit AND no local changes
+  STALE_VS_CODE     — output mtime < latest code commit on origin/master
+  LOCAL_CHANGES     — working tree diverges from origin/master for this dir
+                     (in that case, "current relative to master" is not
+                     meaningful; still report code-commit-vs-output for info)
+  MISSING_OUTPUT    — no nodes.tsv/edges.tsv on disk
+  NO_CODE           — code dir exists but no matching <source>.py (skip)
+
+Merge status codes:
+  FRESH           — merged output newer than every transform output and
+                    newer than merge.yaml and newer than merge_utils/
+  STALE_VS_INPUTS — merged output older than one or more transform outputs
+  STALE_VS_CODE   — merged output older than merge_utils/ code on origin/master
+  STALE_VS_YAML   — merged output older than merge.yaml
+  MISSING_OUTPUT  — no merged-kg_edges.tsv on disk
+
+Exit codes:
+  0 — all FRESH
+  1 — some STALE / MISSING (real problem)
+  2 — invocation error (no origin/master, script error)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Iterable, Optional
+
+REPO = Path(__file__).resolve().parents[3]
+TRANSFORM_ROOT = REPO / "kg_microbe" / "transform_utils"
+TRANSFORMED_DIR = REPO / "data" / "transformed"
+MERGE_UTILS_DIR = REPO / "kg_microbe" / "merge_utils"
+DEFAULT_REF = "origin/master"
+
+# Merge config file candidates. First existing one wins for the reporting
+# "merge config touched" timestamp, but every existing candidate is compared
+# against the merged output.
+MERGE_YAML_CANDIDATES = ["merge.yaml", "merge.minimal.yaml"]
+
+# Merged output candidates — checked in order; first hit wins.
+MERGED_OUTPUT_CANDIDATES = [
+    "data/merged/merged-kg_edges.tsv",
+    "data/merged/merged-kg.tar.gz",
+    "data/merged/merged-kg_edges.tsv.gz",
+]
+
+
+@dataclass
+class SourceReport:
+    """One row of the per-source freshness report."""
+
+    source: str
+    status: str
+    code_commit_ts: Optional[int]  # unix seconds; None if never committed
+    code_commit_sha: Optional[str]
+    output_mtime: Optional[float]
+    local_changes: bool
+    note: str = ""
+
+    def as_row(self) -> dict:
+        """Return a JSON-safe dict version for stdout printing."""
+        d = asdict(self)
+        d["code_commit_iso"] = _iso(self.code_commit_ts)
+        d["output_mtime_iso"] = _iso(self.output_mtime)
+        return d
+
+
+@dataclass
+class MergeReport:
+    """One-row summary for the merge stage."""
+
+    status: str
+    merged_output: Optional[str]
+    merged_mtime: Optional[float]
+    merge_utils_commit_ts: Optional[int]
+    merge_utils_commit_sha: Optional[str]
+    merge_yaml_mtime: Optional[float]
+    merge_yaml_path: Optional[str]
+    stale_against: list = field(default_factory=list)
+    note: str = ""
+
+    def as_row(self) -> dict:
+        """Return a JSON-safe dict version."""
+        d = asdict(self)
+        d["merged_mtime_iso"] = _iso(self.merged_mtime)
+        d["merge_utils_commit_iso"] = _iso(self.merge_utils_commit_ts)
+        d["merge_yaml_mtime_iso"] = _iso(self.merge_yaml_mtime)
+        return d
+
+
+def _iso(ts: Optional[float]) -> Optional[str]:
+    """Return an ISO-8601 UTC string for a unix timestamp, or None."""
+    if ts is None:
+        return None
+    import datetime as _dt
+
+    return _dt.datetime.utcfromtimestamp(int(ts)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _git(args: list[str], cwd: Path = REPO) -> str:
+    r = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=False
+    )
+    return r.stdout.strip()
+
+
+def _ensure_ref(ref: str) -> None:
+    """Verify the ref exists locally; try `git fetch` if not."""
+    if _git(["rev-parse", "--verify", ref]) == "":
+        sys.stderr.write(f"[freshness] {ref} not found locally; running git fetch\n")
+        subprocess.run(
+            ["git", "fetch", "origin", "master"], cwd=REPO, check=False
+        )
+    if _git(["rev-parse", "--verify", ref]) == "":
+        sys.stderr.write(
+            f"[freshness] {ref} still not resolvable; aborting.\n"
+        )
+        sys.exit(2)
+
+
+def _latest_commit(path: Path, ref: str) -> tuple[Optional[int], Optional[str]]:
+    """Return (unix_ts, short_sha) of the latest commit on `ref` touching `path`."""
+    rel = str(path.relative_to(REPO))
+    out = _git(["log", "-1", "--format=%ct %h", ref, "--", rel])
+    if not out:
+        return None, None
+    ts_str, _, sha = out.partition(" ")
+    try:
+        return int(ts_str), sha
+    except ValueError:
+        return None, None
+
+
+def _has_local_diff(path: Path, ref: str) -> bool:
+    """True iff the working tree + index differ from ref for path."""
+    rel = str(path.relative_to(REPO))
+    return bool(_git(["diff", ref, "--", rel]).strip())
+
+
+def _output_mtime(source_name: str) -> Optional[float]:
+    """Newest mtime across the expected nodes/edges outputs for a source."""
+    src_dir = TRANSFORMED_DIR / source_name
+    if not src_dir.is_dir():
+        return None
+    hits = list(src_dir.glob("*.tsv")) + list(src_dir.glob("*.tsv.gz"))
+    if not hits:
+        return None
+    return max(p.stat().st_mtime for p in hits)
+
+
+def _list_transform_sources() -> list[str]:
+    """Return every kg_microbe/transform_utils/<name>/ that looks like a transform."""
+    out = []
+    for entry in sorted(TRANSFORM_ROOT.iterdir()):
+        if not entry.is_dir() or entry.name.startswith(("_", ".")):
+            continue
+        # Transforms name their entrypoint either <name>.py (most sources)
+        # or <name>_transform.py (ontologies, ontologies_stubs).
+        if (entry / f"{entry.name}.py").is_file() or (
+            entry / f"{entry.name}_transform.py"
+        ).is_file():
+            out.append(entry.name)
+    return out
+
+
+def check_source(source: str, ref: str) -> SourceReport:
+    """Evaluate freshness for one transform source."""
+    code_dir = TRANSFORM_ROOT / source
+    py_file = code_dir / f"{source}.py"
+    alt_py = code_dir / f"{source}_transform.py"
+    if not py_file.is_file() and not alt_py.is_file():
+        return SourceReport(
+            source=source,
+            status="NO_CODE",
+            code_commit_ts=None,
+            code_commit_sha=None,
+            output_mtime=None,
+            local_changes=False,
+            note=f"{py_file.name} / {alt_py.name} missing",
+        )
+
+    commit_ts, commit_sha = _latest_commit(code_dir, ref)
+    local = _has_local_diff(code_dir, ref)
+    out_mtime = _output_mtime(source)
+
+    if out_mtime is None:
+        status = "MISSING_OUTPUT"
+        note = f"data/transformed/{source}/ has no .tsv/.tsv.gz"
+    elif local:
+        status = "LOCAL_CHANGES"
+        note = (
+            "local code diverges from " + ref
+            + "; freshness vs master is not defined until the diff lands"
+        )
+    elif commit_ts is None:
+        status = "FRESH"
+        note = f"no commit on {ref} touches this dir; treating as fresh"
+    elif out_mtime >= commit_ts:
+        status = "FRESH"
+        note = ""
+    else:
+        delta_days = (commit_ts - out_mtime) / 86400.0
+        status = "STALE_VS_CODE"
+        note = (
+            f"code advanced {delta_days:.1f} days after last output build; "
+            f"rerun `poetry run kg transform -s {source}`"
+        )
+
+    return SourceReport(
+        source=source,
+        status=status,
+        code_commit_ts=commit_ts,
+        code_commit_sha=commit_sha,
+        output_mtime=out_mtime,
+        local_changes=local,
+        note=note,
+    )
+
+
+def check_merge(source_reports: Iterable[SourceReport], ref: str) -> MergeReport:
+    """Evaluate freshness of the merge stage output."""
+    merged_path = None
+    merged_mtime = None
+    for cand in MERGED_OUTPUT_CANDIDATES:
+        p = REPO / cand
+        if p.exists():
+            merged_path = cand
+            merged_mtime = p.stat().st_mtime
+            break
+
+    merge_yaml_path = None
+    merge_yaml_mtime = None
+    for cand in MERGE_YAML_CANDIDATES:
+        p = REPO / cand
+        if p.is_file():
+            merge_yaml_path = cand
+            merge_yaml_mtime = p.stat().st_mtime
+            break
+
+    utils_ts, utils_sha = _latest_commit(MERGE_UTILS_DIR, ref)
+
+    if merged_mtime is None:
+        return MergeReport(
+            status="MISSING_OUTPUT",
+            merged_output=None,
+            merged_mtime=None,
+            merge_utils_commit_ts=utils_ts,
+            merge_utils_commit_sha=utils_sha,
+            merge_yaml_mtime=merge_yaml_mtime,
+            merge_yaml_path=merge_yaml_path,
+            note="no data/merged/merged-kg_edges.tsv[.gz] or .tar.gz on disk",
+        )
+
+    stale_against: list[str] = []
+    if utils_ts is not None and merged_mtime < utils_ts:
+        stale_against.append("merge_utils code")
+    if merge_yaml_mtime is not None and merged_mtime < merge_yaml_mtime:
+        stale_against.append(merge_yaml_path or "merge yaml")
+    for r in source_reports:
+        if r.output_mtime is not None and merged_mtime < r.output_mtime:
+            stale_against.append(f"data/transformed/{r.source}/")
+
+    if not stale_against:
+        status = "FRESH"
+        note = ""
+    else:
+        # Choose the primary status label by precedence.
+        if any(s == "merge_utils code" for s in stale_against):
+            status = "STALE_VS_CODE"
+        elif any(
+            s == (merge_yaml_path or "merge yaml") for s in stale_against
+        ):
+            status = "STALE_VS_YAML"
+        else:
+            status = "STALE_VS_INPUTS"
+        note = "rerun `poetry run kg merge -y merge.yaml` (or the config in use)"
+
+    return MergeReport(
+        status=status,
+        merged_output=merged_path,
+        merged_mtime=merged_mtime,
+        merge_utils_commit_ts=utils_ts,
+        merge_utils_commit_sha=utils_sha,
+        merge_yaml_mtime=merge_yaml_mtime,
+        merge_yaml_path=merge_yaml_path,
+        stale_against=stale_against,
+        note=note,
+    )
+
+
+def _format_table(rows: list[SourceReport]) -> str:
+    header = (
+        f"{'SOURCE':<22} {'STATUS':<16} {'CODE COMMIT (UTC)':<21} "
+        f"{'OUTPUT MTIME (UTC)':<21} LOCAL  NOTE"
+    )
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        lines.append(
+            f"{r.source:<22} {r.status:<16} "
+            f"{_iso(r.code_commit_ts) or '-':<21} "
+            f"{_iso(r.output_mtime) or '-':<21} "
+            f"{'yes' if r.local_changes else 'no':<6} "
+            f"{r.note}"
+        )
+    return "\n".join(lines)
+
+
+def _format_merge(m: MergeReport) -> str:
+    lines = [
+        "",
+        "MERGE",
+        "-----",
+        f"  status           : {m.status}",
+        f"  merged output    : {m.merged_output or '(none)'}",
+        f"  merged mtime     : {_iso(m.merged_mtime) or '-'}",
+        f"  merge_utils code : {(_iso(m.merge_utils_commit_ts) or '-')} "
+        f"({m.merge_utils_commit_sha or '-'})",
+        f"  merge yaml       : {m.merge_yaml_path or '(none)'} "
+        f"({_iso(m.merge_yaml_mtime) or '-'})",
+    ]
+    if m.stale_against:
+        lines.append("  stale against    :")
+        for s in m.stale_against:
+            lines.append(f"    - {s}")
+    if m.note:
+        lines.append(f"  action           : {m.note}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Entry point."""
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--ref",
+        default=DEFAULT_REF,
+        help=f"git ref to compare against (default: {DEFAULT_REF})",
+    )
+    p.add_argument(
+        "--source",
+        action="append",
+        help="only check this source (repeatable). Default: every transform dir",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON instead of the human table",
+    )
+    p.add_argument(
+        "--skip-fetch",
+        action="store_true",
+        help="don't run `git fetch origin master` even if the ref is unresolved",
+    )
+    args = p.parse_args()
+
+    if not args.skip_fetch:
+        _ensure_ref(args.ref)
+    else:
+        # still fail loudly if the ref is genuinely missing
+        if _git(["rev-parse", "--verify", args.ref]) == "":
+            sys.stderr.write(
+                f"[freshness] {args.ref} not resolvable and --skip-fetch set; aborting.\n"
+            )
+            return 2
+
+    sources = args.source or _list_transform_sources()
+    reports = [check_source(s, args.ref) for s in sources]
+    merge = check_merge(reports, args.ref)
+
+    if args.json:
+        payload = {
+            "ref": args.ref,
+            "sources": [r.as_row() for r in reports],
+            "merge": merge.as_row(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_table(reports))
+        print(_format_merge(merge))
+        # concise summary counts
+        from collections import Counter
+
+        c = Counter(r.status for r in reports)
+        print("")
+        print("SUMMARY")
+        print("-------")
+        for status in ["FRESH", "STALE_VS_CODE", "LOCAL_CHANGES", "MISSING_OUTPUT", "NO_CODE"]:
+            print(f"  {status:<16} {c.get(status, 0)}")
+        print(f"  merge            {merge.status}")
+
+    # exit code
+    non_fresh_sources = any(
+        r.status not in ("FRESH", "NO_CODE") for r in reports
+    )
+    if non_fresh_sources or merge.status != "FRESH":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds three Claude-Code skills under \`.claude/skills/\` for repo hygiene, external code review, and pipeline-freshness checks.

- **\`branch-triage-ship\`** — 10-phase playbook for turning a messy topic branch (mislabeled commits, mixed working-tree work, dozens of untracked scratch files, master-inherited tox failures) into a set of clean, focused PRs. Patterns library for classifying untracked entries and modified-tracked-file "smells". Failure-modes list. kg-microbe-specific notes at the end.
- **\`codex-review-kg-microbe\`** — emit a Codex-ready review prompt targeting the repo (or a subtree) across six explicit dimensions: code logic, consistency, robustness, bugs, bottlenecks, scalability. Static prompt template with a required finding schema; the skill never invokes Codex itself.
- **\`kgm-freshness-check\`** — Python CLI comparing every transform's output mtime against the latest commit on \`origin/master\` touching that transform's code dir, plus merge stage against \`merge_utils/\` + \`merge.yaml\` + every transform output. Reports \`FRESH\` / \`STALE_VS_CODE\` / \`LOCAL_CHANGES\` / \`MISSING_OUTPUT\` per source and an aggregate status for merge. Use before releases and when triaging "why did my merged KG change".

## Test plan
- [x] \`poetry run tox\` on this branch — 339 passed, all 6 envs green.
- [x] \`poetry run python .claude/skills/kgm-freshness-check/kgm_freshness_check.py\` smoke-tested on the local tree — produced the expected FRESH/MISSING_OUTPUT mix across 18 transform dirs.
- [x] Static skill markdown loads via the Claude Code Skill tool (both \`codex-review-kg-microbe\` and \`branch-triage-ship\` are single-file playbooks).

## Related

Companion follow-up already in place from the same triage session:
- #579 — cleanup untracked scratch checklist
- \`branch-triage-ship\` was authored from the workflow that produced #577 / #578 / #581 / #582 / #583 in this repo (all merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)