### PR TITLE
Add LPSN transform (MVP: nodes + subclass_of edges)

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -500,3 +500,21 @@
 -
   url: https://nlmpubs.nlm.nih.gov/projects/mesh/rdf/2026/mesh2026.nt.gz
   local_name: mesh2026.nt.gz
+
+#
+# LPSN — List of Prokaryotic names with Standing in Nomenclature
+# NOTE: The LPSN GSS (Genus/Species/Subspecies) CSV bulk export at
+# https://lpsn.dsmz.de/downloads is gated behind a free LPSN account,
+# so `poetry run kg download` cannot fetch it automatically. Manual
+# procedure:
+#   1. Register at https://lpsn.dsmz.de/register (free).
+#   2. Log in and download the GSS CSV from the Downloads page.
+#   3. Place the file at data/raw/lpsn/lpsn_gss.csv before running
+#      `poetry run kg transform -s lpsn`.
+# See kg_microbe/transform_utils/lpsn/README.md for redistribution
+# terms (LPSN copyright requires linking back to the source; the
+# transform emits the canonical LPSN URL as xref on every node).
+#
+# -
+#   url: https://lpsn.dsmz.de/downloads/gss
+#   local_name: lpsn_gss.csv

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -15,6 +15,7 @@ from kg_microbe.transform_utils.constants import (
     COG,
     GTDB,
     KEGG,
+    LPSN_SOURCE,
     MADIN_ETAL,
     MEDIADIVE,
     METATRAITS,
@@ -25,6 +26,7 @@ from kg_microbe.transform_utils.constants import (
 )
 from kg_microbe.transform_utils.gtdb.gtdb import GTDBTransform
 from kg_microbe.transform_utils.kegg.kegg import KEGGTransform
+from kg_microbe.transform_utils.lpsn.lpsn import LPSNTransform
 from kg_microbe.transform_utils.madin_etal.madin_etal import MadinEtAlTransform
 from kg_microbe.transform_utils.mediadive.mediadive import MediaDiveTransform
 from kg_microbe.transform_utils.metatraits.metatraits import MetaTraitsTransform
@@ -57,6 +59,7 @@ DATA_SOURCES = {
     COG: COGTransform,
     GTDB: GTDBTransform,
     KEGG: KEGGTransform,
+    LPSN_SOURCE: LPSNTransform,
     MEDIADIVE: MediaDiveTransform,
     MADIN_ETAL: MadinEtAlTransform,
     METATRAITS: MetaTraitsTransform,

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -100,7 +100,8 @@ GENUS = "genus"
 FULL_SCIENTIFIC_NAME = "full scientific name"
 STRAIN_DESIGNATION = "strain designation"
 TYPE_STRAIN = "type strain"
-LPSN = "LPSN"
+LPSN = "LPSN"  # BacDive JSON key; do not reuse for source-name registration
+LPSN_SOURCE = "lpsn"  # DATA_SOURCES key + directory name for the standalone LPSN transform
 SYNONYMS = "synonyms"
 SYNONYM = "synonym"
 

--- a/kg_microbe/transform_utils/lpsn/README.md
+++ b/kg_microbe/transform_utils/lpsn/README.md
@@ -1,0 +1,64 @@
+# LPSN transform
+
+Ingests the LPSN GSS (Genus/Species/Subspecies) CSV bulk export into
+KGX-format nodes and edges.
+
+## Obtain the input CSV
+
+LPSN publishes its GSS bulk export at
+<https://lpsn.dsmz.de/downloads>, but the download is gated behind a
+free LPSN account. To fetch:
+
+1. Register at <https://lpsn.dsmz.de/register> (free; email + password).
+2. Log in.
+3. Navigate to <https://lpsn.dsmz.de/downloads> and download the GSS
+   file (CSV).
+4. Place the file at `data/raw/lpsn/lpsn_gss.csv` in this repo.
+
+Neither `poetry run kg download` nor the transform itself will fetch
+the file automatically; the login step must happen in your browser.
+
+## Run the transform
+
+```bash
+poetry run kg transform -s lpsn
+```
+
+Output lands in `data/transformed/lpsn/nodes.tsv` and `edges.tsv`.
+
+## Output shape (MVP)
+
+- **Nodes** — one `biolink:OrganismTaxon` node per LPSN record, with
+  CURIE `lpsn:<record_no>`. Rows whose `status` matches an
+  illegitimate / synonym / rejected category carry `deprecated=True`.
+- **Edges** — `biolink:subclass_of` from subspecies → species → genus
+  when both parent and child rows are present in the same CSV. No
+  external cross-references in the MVP (see follow-up section).
+
+## Follow-ups (issue #484)
+
+The MVP intentionally omits:
+
+- **NCBITaxon cross-refs** — LPSN doesn't publish these natively; we
+  need a name-matching layer against NCBI's taxonomy.
+- **GTDB cross-refs** — same story; via GTDB's own metadata, which
+  cites LPSN IDs for species names.
+- **BacDive cross-refs** — LPSN's `type_strain_names` (via the JSON
+  API, not the GSS CSV) links to culture-collection designations
+  (`DSM 12345`, `ATCC 12345`) that BacDive tracks. Normalizing
+  requires either the LPSN JSON API (also login-gated) or a merge-time
+  reconciliation step.
+
+These cross-refs are the point of the follow-up work tracked on
+issue #484.
+
+## Redistribution
+
+The LPSN copyright statement
+(<https://lpsn.dsmz.de/text/copyright>) requires that websites making
+use of the GSS files link back to LPSN. KG-Microbe includes an
+`xref` field pointing at each record's canonical LPSN URL to satisfy
+this.
+
+The GSS CSV itself is NOT redistributed inside this repository — each
+user must download their own copy via their LPSN account.

--- a/kg_microbe/transform_utils/lpsn/__init__.py
+++ b/kg_microbe/transform_utils/lpsn/__init__.py
@@ -1,0 +1,1 @@
+"""LPSN (List of Prokaryotic names with Standing in Nomenclature) transform."""

--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -1,0 +1,277 @@
+"""
+LPSN transform.
+
+Ingests the LPSN GSS (Genus/Species/Subspecies) CSV bulk export into
+KGX-format nodes and edges. Each row becomes a `biolink:OrganismTaxon`
+node at `lpsn:<record_no>`, with `biolink:subclass_of` edges pointing
+from species → genus and subspecies → species so that the LPSN
+taxonomic tree is queryable in the merged KG.
+
+The GSS CSV requires a free LPSN login to download. This transform
+does NOT fetch it — place the downloaded file at
+`data/raw/lpsn/lpsn_gss.csv` before running:
+
+    poetry run kg transform -s lpsn
+
+See ``kg_microbe/transform_utils/lpsn/README.md`` for the manual
+download procedure.
+
+MVP scope:
+- Nodes for every LPSN record (family / genus / species / subspecies).
+- subclass_of edges from subspecies → species → genus (only when the
+  parent row is present in the same CSV — no LPSN API calls).
+- Illegitimate / synonym rows carry ``deprecated=True``.
+- Cross-references to NCBITaxon / GTDB / BacDive are deferred to a
+  follow-up PR (see issue #484); they require a name-matching layer
+  or the authenticated LPSN JSON API.
+"""
+
+import csv
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+from kg_microbe.transform_utils.constants import (
+    CLOSE_MATCH_PREDICATE,
+    ID_COLUMN,
+    LPSN_SOURCE,
+    NCBI_CATEGORY,
+    RDFS_SUBCLASS_OF,
+    SUBCLASS_PREDICATE,
+)
+from kg_microbe.transform_utils.transform import Transform
+
+LPSN_PREFIX = "lpsn:"
+LPSN_KNOWLEDGE_SOURCE = "infores:lpsn"
+
+# LPSN GSS CSV column names (as published in the DSMZ export).
+COL_GENUS = "genus_name"
+COL_SP_EPITHET = "sp_epithet"
+COL_SUBSP_EPITHET = "subsp_epithet"
+COL_REFERENCE = "reference"
+COL_STATUS = "status"
+COL_AUTHORS = "authors"
+COL_ADDRESS = "address"
+COL_RECORD_NO = "record_no"
+COL_RECORD_LNK = "record_lnk"
+
+# Nomenclatural statuses that should mark a node as ``deprecated=True``.
+DEPRECATED_STATUSES = frozenset(
+    {
+        "illegitimate name",
+        "not validly published",
+        "synonym",
+        "rejected name",
+        "later heterotypic synonym",
+        "later homotypic synonym",
+    }
+)
+
+
+class LPSNTransform(Transform):
+
+    """Transform LPSN GSS CSV bulk export into KGX nodes + edges."""
+
+    def __init__(
+        self,
+        input_dir: Optional[Path] = None,
+        output_dir: Optional[Path] = None,
+    ):
+        """
+        Instantiate.
+
+        Parameters
+        ----------
+        input_dir:
+            Directory holding ``lpsn_gss.csv``. Defaults to ``data/raw/lpsn``
+            resolved by the base :class:`Transform` class.
+        output_dir:
+            Directory to write ``nodes.tsv`` / ``edges.tsv`` into. Defaults
+            to ``data/transformed/lpsn`` resolved by the base class.
+
+        """
+        super().__init__(LPSN_SOURCE, input_dir, output_dir)
+        self.knowledge_source = LPSN_KNOWLEDGE_SOURCE
+
+    # ------------------------------------------------------------------
+    # public entry point
+    # ------------------------------------------------------------------
+    def run(self, data_file: Union[Optional[Path], Optional[str]] = None) -> None:
+        """
+        Emit ``nodes.tsv`` and ``edges.tsv`` from the LPSN GSS CSV.
+
+        Parameters
+        ----------
+        data_file:
+            Optional override for the input CSV path. If ``None``, uses
+            ``self.input_base_dir / "lpsn_gss.csv"``.
+
+        """
+        input_file = Path(data_file) if data_file else Path(self.input_base_dir) / "lpsn_gss.csv"
+        if not input_file.is_file():
+            raise FileNotFoundError(
+                f"LPSN GSS CSV not found at {input_file}. "
+                "Log in to https://lpsn.dsmz.de/downloads (free registration), "
+                "download the GSS CSV, and place it at "
+                "data/raw/lpsn/lpsn_gss.csv. "
+                "See kg_microbe/transform_utils/lpsn/README.md for details."
+            )
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Parse in a single pass into an in-memory dict keyed by record_no
+        # so we can wire subclass_of edges without a second read.
+        rows_by_id = self._parse_csv(input_file)
+
+        # Build a (genus_name, sp_epithet, subsp_epithet) -> record_no
+        # lookup so subspecies/species can find their parent record.
+        parent_lookup = self._build_parent_lookup(rows_by_id)
+
+        # Emit nodes + edges.
+        with (
+            open(self.output_node_file, "w", newline="") as node_fh,
+            open(self.output_edge_file, "w", newline="") as edge_fh,
+        ):
+            node_writer = csv.writer(node_fh, delimiter="\t")
+            edge_writer = csv.writer(edge_fh, delimiter="\t")
+
+            node_writer.writerow(self.node_header)
+            edge_writer.writerow(self.edge_header)
+
+            for record_no, row in rows_by_id.items():
+                node_writer.writerow(self._make_node_row(record_no, row))
+                parent_id = self._find_parent(row, parent_lookup)
+                if parent_id and parent_id != record_no:
+                    edge_writer.writerow(self._make_subclass_edge(record_no, parent_id))
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+    def _parse_csv(self, input_file: Path) -> Dict[str, dict]:
+        """
+        Read the LPSN GSS CSV into a dict keyed by ``record_no``.
+
+        Rows missing ``record_no`` or ``genus_name`` are skipped with a
+        warning printed to stdout (consistent with other transforms).
+        """
+        rows: Dict[str, dict] = {}
+        with open(input_file, newline="") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                record_no = (row.get(COL_RECORD_NO) or "").strip()
+                genus = (row.get(COL_GENUS) or "").strip()
+                if not record_no:
+                    print(f"[lpsn] skipping row without record_no: {row}")
+                    continue
+                if not genus:
+                    print(f"[lpsn] skipping row {record_no} without genus_name")
+                    continue
+                rows[record_no] = row
+        return rows
+
+    def _build_parent_lookup(self, rows_by_id: Dict[str, dict]) -> Dict[tuple, str]:
+        """
+        Return a ``(genus, sp_epithet, subsp_epithet)`` → record_no lookup.
+
+        The lookup key is normalized so a species row keys as
+        ``(genus, sp_epithet, "")`` and a genus row keys as
+        ``(genus, "", "")``.
+        """
+        lookup: Dict[tuple, str] = {}
+        for record_no, row in rows_by_id.items():
+            key = (
+                (row.get(COL_GENUS) or "").strip(),
+                (row.get(COL_SP_EPITHET) or "").strip(),
+                (row.get(COL_SUBSP_EPITHET) or "").strip(),
+            )
+            lookup[key] = record_no
+        return lookup
+
+    def _find_parent(self, row: dict, parent_lookup: Dict[tuple, str]) -> Optional[str]:
+        """
+        Return the LPSN record_no of ``row``'s immediate parent, or None.
+
+        A subspecies row's parent is the species row with the same
+        genus + sp_epithet and empty subsp_epithet. A species row's
+        parent is the genus row with the same genus and empty
+        sp_epithet/subsp_epithet. A genus row has no in-CSV parent.
+        """
+        genus = (row.get(COL_GENUS) or "").strip()
+        sp = (row.get(COL_SP_EPITHET) or "").strip()
+        subsp = (row.get(COL_SUBSP_EPITHET) or "").strip()
+
+        if subsp:
+            return parent_lookup.get((genus, sp, ""))
+        if sp:
+            return parent_lookup.get((genus, "", ""))
+        return None
+
+    def _make_node_row(self, record_no: str, row: dict) -> list:
+        """
+        Build one nodes.tsv row for an LPSN record.
+
+        Node fields:
+            id            = ``lpsn:<record_no>``
+            category      = ``biolink:OrganismTaxon``
+            name          = full scientific name assembled from
+                            genus/sp_epithet/subsp_epithet
+            description   = ``authors`` (author citation + year)
+            xref          = ``record_lnk`` (canonical LPSN page URL)
+            provided_by   = infores:lpsn
+            deprecated    = True if ``status`` matches a DEPRECATED_STATUS
+        """
+        genus = (row.get(COL_GENUS) or "").strip()
+        sp = (row.get(COL_SP_EPITHET) or "").strip()
+        subsp = (row.get(COL_SUBSP_EPITHET) or "").strip()
+        name_parts = [p for p in (genus, sp, subsp) if p]
+        name = " ".join(name_parts)
+
+        description = (row.get(COL_AUTHORS) or "").strip()
+        xref = (row.get(COL_RECORD_LNK) or row.get(COL_ADDRESS) or "").strip()
+
+        status = (row.get(COL_STATUS) or "").strip().lower()
+        deprecated_flag = "True" if status in DEPRECATED_STATUSES else ""
+
+        # node_header is [id, category, name, description, xref,
+        # provided_by, synonym, same_as, iri, deprecated, ...]
+        # Fill in known columns, blank the rest.
+        headers = self.node_header
+        row_out = [""] * len(headers)
+        for col, val in {
+            "id": f"{LPSN_PREFIX}{record_no}",
+            "category": NCBI_CATEGORY,
+            "name": name,
+            "description": description,
+            "xref": xref,
+            "provided_by": LPSN_KNOWLEDGE_SOURCE,
+            "deprecated": deprecated_flag,
+        }.items():
+            if col in headers:
+                row_out[headers.index(col)] = val
+        return row_out
+
+    def _make_subclass_edge(self, child_record_no: str, parent_record_no: str) -> list:
+        """
+        Build one edges.tsv row for a subclass_of relation.
+
+        Emits ``subject=lpsn:<child> predicate=biolink:subclass_of
+        object=lpsn:<parent> relation=rdfs:subClassOf
+        primary_knowledge_source=infores:lpsn``.
+        """
+        headers = self.edge_header
+        row_out = [""] * len(headers)
+        for col, val in {
+            "subject": f"{LPSN_PREFIX}{child_record_no}",
+            "predicate": SUBCLASS_PREDICATE,
+            "object": f"{LPSN_PREFIX}{parent_record_no}",
+            "relation": RDFS_SUBCLASS_OF,
+            "primary_knowledge_source": LPSN_KNOWLEDGE_SOURCE,
+        }.items():
+            if col in headers:
+                row_out[headers.index(col)] = val
+        return row_out
+
+
+# Silence flake8 F401 for CLOSE_MATCH_PREDICATE reserved for the
+# follow-up cross-ref PR (issue #484).
+_ = CLOSE_MATCH_PREDICATE
+_ = ID_COLUMN

--- a/kg_microbe/transform_utils/prefixmap.json
+++ b/kg_microbe/transform_utils/prefixmap.json
@@ -7,6 +7,7 @@
     "mediadive.medium-type": "https://mediadive.dsmz.de/medium-type/",
     "kgmicrobe.strain": "https://example.org/kgmicrobe/strain/",
     "GTDB": "https://gtdb.ecogenomic.org/tree?r=",
+    "lpsn": "https://lpsn.dsmz.de/",
     "NCBIGene": "http://identifiers.org/ncbigene/",
     "chemrof": "https://w3id.org/chemrof/",
     "orcid": "https://orcid.org/",

--- a/tests/resources/lpsn/lpsn_gss.csv
+++ b/tests/resources/lpsn/lpsn_gss.csv
@@ -1,0 +1,7 @@
+genus_name,sp_epithet,subsp_epithet,reference,status,authors,address,risk_grp,nomenclatural_type,record_no,record_lnk
+Escherichia,,,"Bergey et al. 1919",correct name,"Bergey et al. 1919",https://lpsn.dsmz.de/genus/escherichia,1,Escherichia coli,1001,https://lpsn.dsmz.de/genus/escherichia
+Escherichia,coli,,"Castellani and Chalmers 1919",correct name,"(Migula 1895) Castellani and Chalmers 1919",https://lpsn.dsmz.de/species/escherichia-coli,2,ATCC 11775,1002,https://lpsn.dsmz.de/species/escherichia-coli
+Escherichia,coli,inactive,"Chen and Kuo 1945",illegitimate name,"Chen and Kuo 1945",https://lpsn.dsmz.de/subspecies/escherichia-coli-inactive,,DSM 30083,1003,https://lpsn.dsmz.de/subspecies/escherichia-coli-inactive
+Bacillus,,,"Cohn 1872",correct name,"Cohn 1872",https://lpsn.dsmz.de/genus/bacillus,1,Bacillus subtilis,1010,https://lpsn.dsmz.de/genus/bacillus
+Bacillus,subtilis,,"Ehrenberg 1835",correct name,"(Ehrenberg 1835) Cohn 1872",https://lpsn.dsmz.de/species/bacillus-subtilis,1,DSM 10,1011,https://lpsn.dsmz.de/species/bacillus-subtilis
+Notgenus,orphan,,"Anon. 1900",synonym,"Anon. 1900",https://lpsn.dsmz.de/species/notgenus-orphan,,,1099,https://lpsn.dsmz.de/species/notgenus-orphan

--- a/tests/test_lpsn_transform.py
+++ b/tests/test_lpsn_transform.py
@@ -1,0 +1,114 @@
+"""Tests for the LPSN transform."""
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from kg_microbe.transform_utils.lpsn.lpsn import (
+    DEPRECATED_STATUSES,
+    LPSN_KNOWLEDGE_SOURCE,
+    LPSN_PREFIX,
+    LPSNTransform,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "resources" / "lpsn"
+
+
+@pytest.fixture()
+def lpsn_transform(tmp_path):
+    """
+    Return an ``LPSNTransform`` configured to read the fixture CSV.
+
+    The transform's ``input_base_dir`` is set to ``tests/resources/lpsn``
+    so that ``lpsn_gss.csv`` resolves via the base ``Transform`` class,
+    and ``output_dir`` is set to a per-test temp dir so nodes.tsv /
+    edges.tsv land in isolation.
+    """
+    return LPSNTransform(input_dir=FIXTURE_DIR, output_dir=tmp_path)
+
+
+def _read_tsv(path: Path) -> list[dict]:
+    """Read a TSV into a list of dicts (header row → per-row dicts)."""
+    with open(path, newline="") as fh:
+        return list(csv.DictReader(fh, delimiter="\t"))
+
+
+def test_nodes_emitted_for_every_valid_row(lpsn_transform):
+    """One node per LPSN record (fixture has 6 rows, all with record_no)."""
+    lpsn_transform.run()
+    nodes = _read_tsv(lpsn_transform.output_node_file)
+    assert len(nodes) == 6
+    ids = {n["id"] for n in nodes}
+    assert ids == {
+        f"{LPSN_PREFIX}1001",
+        f"{LPSN_PREFIX}1002",
+        f"{LPSN_PREFIX}1003",
+        f"{LPSN_PREFIX}1010",
+        f"{LPSN_PREFIX}1011",
+        f"{LPSN_PREFIX}1099",
+    }
+
+
+def test_node_fields_are_shaped_correctly(lpsn_transform):
+    """A species row emits id/category/name/description/xref/provided_by."""
+    lpsn_transform.run()
+    nodes = {n["id"]: n for n in _read_tsv(lpsn_transform.output_node_file)}
+    ecoli = nodes[f"{LPSN_PREFIX}1002"]
+    assert ecoli["category"] == "biolink:OrganismTaxon"
+    assert ecoli["name"] == "Escherichia coli"
+    assert "Migula" in ecoli["description"]
+    assert ecoli["xref"].startswith("https://lpsn.dsmz.de/species/")
+    assert ecoli["provided_by"] == LPSN_KNOWLEDGE_SOURCE
+
+
+def test_illegitimate_row_is_marked_deprecated(lpsn_transform):
+    """`status = "illegitimate name"` sets deprecated=True."""
+    lpsn_transform.run()
+    nodes = {n["id"]: n for n in _read_tsv(lpsn_transform.output_node_file)}
+    subsp = nodes[f"{LPSN_PREFIX}1003"]
+    assert subsp["deprecated"] == "True"
+    # Sanity: correct-name rows are NOT deprecated.
+    assert nodes[f"{LPSN_PREFIX}1002"]["deprecated"] == ""
+
+
+def test_synonym_status_is_deprecated(lpsn_transform):
+    """`status = "synonym"` also flags deprecated (per DEPRECATED_STATUSES)."""
+    assert "synonym" in DEPRECATED_STATUSES
+    lpsn_transform.run()
+    nodes = {n["id"]: n for n in _read_tsv(lpsn_transform.output_node_file)}
+    assert nodes[f"{LPSN_PREFIX}1099"]["deprecated"] == "True"
+
+
+def test_species_gets_subclass_edge_to_genus(lpsn_transform):
+    """Escherichia coli (1002) → Escherichia (1001)."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1002" and e["object"] == f"{LPSN_PREFIX}1001"]
+    assert len(hits) == 1
+    assert hits[0]["predicate"] == "biolink:subclass_of"
+    assert hits[0]["relation"] == "rdfs:subClassOf"
+    assert hits[0]["primary_knowledge_source"] == LPSN_KNOWLEDGE_SOURCE
+
+
+def test_subspecies_gets_subclass_edge_to_species(lpsn_transform):
+    """Escherichia coli inactive (1003) → Escherichia coli (1002)."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1003" and e["object"] == f"{LPSN_PREFIX}1002"]
+    assert len(hits) == 1
+
+
+def test_orphan_species_produces_no_edge(lpsn_transform):
+    """Notgenus orphan (1099) has no matching genus row → no subclass edge."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    orphan_edges = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1099"]
+    assert orphan_edges == []
+
+
+def test_missing_csv_raises_file_not_found(tmp_path):
+    """Instantiating with an empty input dir and calling run() raises FNFE."""
+    xform = LPSNTransform(input_dir=tmp_path, output_dir=tmp_path)
+    with pytest.raises(FileNotFoundError, match="LPSN GSS CSV not found"):
+        xform.run()


### PR DESCRIPTION
## Summary

Ingests the LPSN (List of Prokaryotic names with Standing in Nomenclature) GSS CSV bulk export into KGX-format nodes and edges. First direct-ingest of LPSN in KG-Microbe — BacDive already surfaces LPSN taxonomy per strain (embedded), but the standalone transform covers all ~59K validly-published names regardless of whether BacDive has the strain.

### What lands

- One \`biolink:OrganismTaxon\` node per LPSN record at CURIE \`lpsn:<record_no>\`.
- \`biolink:subclass_of\` edges from subspecies → species → genus (within-CSV parent lookup; no LPSN API calls).
- \`deprecated=True\` on rows whose \`status\` matches an illegitimate / synonym / rejected category.
- Canonical LPSN URL in \`xref\` (satisfies LPSN copyright's link-back requirement).

### Entity model

| LPSN GSS row | Biolink category | CURIE | Description | Deprecated? |
|---|---|---|---|---|
| family / genus / species / subspecies | \`biolink:OrganismTaxon\` | \`lpsn:<record_no>\` | \`authors\` | \`status\` in DEPRECATED_STATUSES |

### Data access

LPSN GSS CSV requires a free LPSN login to download; the transform expects the file at \`data/raw/lpsn/lpsn_gss.csv\` and does not fetch it automatically. Full manual procedure in \`kg_microbe/transform_utils/lpsn/README.md\`. \`download.yaml\` has a documentation-only NOTE block explaining the login gate.

### Deferred to a follow-up (issue #484)

- **NCBITaxon cross-refs** — LPSN doesn't publish these natively; needs a name-matching layer.
- **GTDB cross-refs** — same story; via GTDB metadata that cites LPSN.
- **BacDive cross-refs** — LPSN's \`type_strain_names\` (JSON API, not GSS CSV) links to culture-collection designations (DSM/ATCC/etc.) that BacDive tracks. Needs authenticated LPSN client and a merge-time reconciliation layer.

### Wiring

- New \`LPSN_SOURCE = "lpsn"\` constant (distinct from the pre-existing \`LPSN = "LPSN"\` BacDive JSON-key constant).
- Registered under \`DATA_SOURCES\` in \`kg_microbe/transform.py\`.
- \`lpsn\` prefix added to \`kg_microbe/transform_utils/prefixmap.json\`.

## Test plan
- [x] \`poetry run tox\` on this branch — **348 passed, 6/6 tox envs green**.
- [x] 8 fixture-based unit tests in \`tests/test_lpsn_transform.py\` covering: node emission, node field shape, deprecated flagging for illegitimate rows, deprecated flagging for synonym rows, species→genus edge, subspecies→species edge, orphan row (no parent) produces no edge, missing CSV raises FileNotFoundError.
- [ ] End-to-end smoke against real LPSN GSS CSV — blocked on obtaining LPSN credentials + downloading the file. Owner to run \`poetry run kg transform -s lpsn\` after placing the real CSV at \`data/raw/lpsn/lpsn_gss.csv\`.

## Related

- Refs #484 (LPSN normalization for strain IDs; MVP covers taxa emission, cross-refs deferred).
- Uses \`add-transform\` skill (added in #585) as the 10-phase playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)