### PR TITLE
LPSN: emit close_match edges to culture-collection strain CURIEs

### DIFF
--- a/kg_microbe/transform_utils/lpsn/README.md
+++ b/kg_microbe/transform_utils/lpsn/README.md
@@ -26,31 +26,40 @@ poetry run kg transform -s lpsn
 
 Output lands in `data/transformed/lpsn/nodes.tsv` and `edges.tsv`.
 
-## Output shape (MVP)
+## Output shape
 
 - **Nodes** — one `biolink:OrganismTaxon` node per LPSN record, with
   CURIE `lpsn:<record_no>`. Rows whose `status` matches an
   illegitimate / synonym / rejected category carry `deprecated=True`.
-- **Edges** — `biolink:subclass_of` from subspecies → species → genus
-  when both parent and child rows are present in the same CSV. No
-  external cross-references in the MVP (see follow-up section).
+- **`subclass_of` edges** — from subspecies → species → genus when
+  both parent and child rows are present in the same CSV.
+- **`close_match` edges** — from each species / subspecies row to
+  every culture-collection deposit named in `nomenclatural_type`.
+  Deposits are parsed from strings like
+  `"ATCC 11775 = DSM 30083 = JCM 1649"` and normalized to
+  `kgmicrobe.strain:<code>` CURIEs, matching the strain CURIEs BacDive
+  emits from the same culture-collection numbers. The merge step then
+  reconciles both sides, giving BacDive strains a route to the
+  authoritative LPSN taxon and vice-versa. Addresses the
+  "normalize strain IDs" ask in issue #484 via the culture-collection
+  path.
 
-## Follow-ups (issue #484)
+  Recognized culture-collection prefixes: `ATCC`, `DSM`, `JCM`, `LMG`,
+  `NCTC`, `NRRL`, `NBRC`, `CCUG`, `CCTM`, `CIP`, `IAM`, `IFO`, `KCTC`.
+  Additional prefixes can be added to the `_CULTURE_CODE` regex in
+  `lpsn.py` as needed.
 
-The MVP intentionally omits:
+## Still deferred (issue #484)
 
-- **NCBITaxon cross-refs** — LPSN doesn't publish these natively; we
-  need a name-matching layer against NCBI's taxonomy.
-- **GTDB cross-refs** — same story; via GTDB's own metadata, which
-  cites LPSN IDs for species names.
-- **BacDive cross-refs** — LPSN's `type_strain_names` (via the JSON
-  API, not the GSS CSV) links to culture-collection designations
-  (`DSM 12345`, `ATCC 12345`) that BacDive tracks. Normalizing
-  requires either the LPSN JSON API (also login-gated) or a merge-time
-  reconciliation step.
-
-These cross-refs are the point of the follow-up work tracked on
-issue #484.
+- **NCBITaxon cross-refs** — LPSN doesn't publish NCBI IDs natively;
+  needs a name-matching layer against NCBI's taxonomy (would use OAK's
+  NCBITaxon adapter — same pattern as BacDive's transform).
+- **GTDB cross-refs** — via GTDB's metadata, which cites LPSN IDs for
+  species names; or via GTDB2NCBI on top of the NCBITaxon layer.
+- **Full LPSN JSON API ingest** — richer than the GSS CSV
+  (nomenclatural status details, publication DOI/PMID,
+  `lpsn_correct_name_id` for reclassifications, `lpsn_parent_id` for
+  the full taxonomic tree, 16S sequences).
 
 ## Redistribution
 

--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -27,15 +27,18 @@ MVP scope:
 """
 
 import csv
+import re
 from pathlib import Path
 from typing import Dict, Optional, Union
 
 from kg_microbe.transform_utils.constants import (
     CLOSE_MATCH_PREDICATE,
+    CLOSE_MATCH_RELATION,
     ID_COLUMN,
     LPSN_SOURCE,
     NCBI_CATEGORY,
     RDFS_SUBCLASS_OF,
+    STRAIN_PREFIX,
     SUBCLASS_PREDICATE,
 )
 from kg_microbe.transform_utils.transform import Transform
@@ -51,8 +54,22 @@ COL_REFERENCE = "reference"
 COL_STATUS = "status"
 COL_AUTHORS = "authors"
 COL_ADDRESS = "address"
+COL_NOMENCLATURAL_TYPE = "nomenclatural_type"
 COL_RECORD_NO = "record_no"
 COL_RECORD_LNK = "record_lnk"
+
+# Split ``nomenclatural_type`` on the standard separators used across
+# culture-collection deposit lists in LPSN. Real strings look like
+# "ATCC 11775 = DSM 30083 = JCM 1649 = NCTC 9001".
+_TYPE_STRAIN_SPLIT = re.compile(r"\s*(?:=|;|,)\s*")
+
+# A single culture-collection designation looks like "<PREFIX><whitespace/dashes><digits/letters>",
+# e.g. "ATCC 11775", "DSM-30083", "NCTC 9001". This regex extracts those tokens
+# from a raw ``nomenclatural_type`` value that may have additional prose.
+_CULTURE_CODE = re.compile(
+    r"\b(?:ATCC|DSM|JCM|LMG|NCTC|NRRL|NBRC|CCUG|CCTM|CIP|IAM|IFO|KCTC)"
+    r"[\s\-:]*[A-Z]*[\s\-]*[0-9]+[A-Za-z0-9\-]*"
+)
 
 # Nomenclatural statuses that should mark a node as ``deprecated=True``.
 DEPRECATED_STATUSES = frozenset(
@@ -142,6 +159,13 @@ class LPSNTransform(Transform):
                 parent_id = self._find_parent(row, parent_lookup)
                 if parent_id and parent_id != record_no:
                     edge_writer.writerow(self._make_subclass_edge(record_no, parent_id))
+                # Only species and subspecies rows carry a culture-collection
+                # type-strain designation worth cross-referencing. Genus rows'
+                # ``nomenclatural_type`` is the type species (a name, not a
+                # strain deposit) and is skipped.
+                if (row.get(COL_SP_EPITHET) or "").strip():
+                    for strain_curie in self._extract_strain_curies(row):
+                        edge_writer.writerow(self._make_close_match_edge(record_no, strain_curie))
 
     # ------------------------------------------------------------------
     # internals
@@ -270,8 +294,71 @@ class LPSNTransform(Transform):
                 row_out[headers.index(col)] = val
         return row_out
 
+    def _extract_strain_curies(self, row: dict) -> list:
+        """
+        Turn ``row[nomenclatural_type]`` into a list of ``kgmicrobe.strain:*`` CURIEs.
 
-# Silence flake8 F401 for CLOSE_MATCH_PREDICATE reserved for the
-# follow-up cross-ref PR (issue #484).
-_ = CLOSE_MATCH_PREDICATE
+        LPSN's ``nomenclatural_type`` for a species / subspecies row is one or
+        more culture-collection deposits separated by ``=`` / ``;`` / ``,``,
+        e.g. ``"ATCC 11775 = DSM 30083 = JCM 1649"``. Each deposit is
+        normalized with the same rule BacDive uses (see ``bacdive.py:2503``):
+        strip whitespace, replace spaces and colons with hyphens. That way
+        LPSN's cross-refs land on the same ``kgmicrobe.strain:<code>`` CURIEs
+        that BacDive is already emitting, so the merge step reconciles both
+        sides without extra plumbing.
+
+        Returns an empty list if the field is blank, whitespace, or contains
+        only a taxon name (no culture-collection prefix).
+        """
+        raw = (row.get(COL_NOMENCLATURAL_TYPE) or "").strip()
+        if not raw:
+            return []
+
+        curies: list = []
+        seen: set = set()
+        # First split on the standard deposit separators, then within each
+        # part scan for culture-collection tokens. A single part typically
+        # contains exactly one deposit; the second pass is defensive against
+        # rare "ATCC 11775 (T)" annotations or trailing prose.
+        for part in _TYPE_STRAIN_SPLIT.split(raw):
+            for match in _CULTURE_CODE.finditer(part):
+                token = match.group(0).strip()
+                cleaned = token.replace(" ", "-").replace(":", "-")
+                if len(cleaned) <= 3:
+                    # Same guard BacDive applies — tokens of 3 chars or fewer
+                    # are typos, not real deposits.
+                    continue
+                curie = f"{STRAIN_PREFIX}{cleaned}"
+                if curie in seen:
+                    continue
+                seen.add(curie)
+                curies.append(curie)
+        return curies
+
+    def _make_close_match_edge(self, record_no: str, strain_curie: str) -> list:
+        """
+        Build one edges.tsv row linking an LPSN taxon to a culture-collection strain.
+
+        Emits ``subject=lpsn:<record_no> predicate=biolink:close_match
+        object=kgmicrobe.strain:<code> relation=skos:closeMatch
+        primary_knowledge_source=infores:lpsn``. BacDive's transform emits
+        the same ``kgmicrobe.strain:*`` CURIE for every culture-collection
+        deposit it sees, so the merge step reconciles both sides.
+        """
+        headers = self.edge_header
+        row_out = [""] * len(headers)
+        for col, val in {
+            "subject": f"{LPSN_PREFIX}{record_no}",
+            "predicate": CLOSE_MATCH_PREDICATE,
+            "object": strain_curie,
+            "relation": CLOSE_MATCH_RELATION,
+            "primary_knowledge_source": LPSN_KNOWLEDGE_SOURCE,
+        }.items():
+            if col in headers:
+                row_out[headers.index(col)] = val
+        return row_out
+
+
+# Silence flake8 F401 for ID_COLUMN reserved for future enrichment
+# (NCBITaxon / GTDB cross-refs — see issue #484).
 _ = ID_COLUMN

--- a/tests/resources/lpsn/lpsn_gss.csv
+++ b/tests/resources/lpsn/lpsn_gss.csv
@@ -1,7 +1,7 @@
 genus_name,sp_epithet,subsp_epithet,reference,status,authors,address,risk_grp,nomenclatural_type,record_no,record_lnk
 Escherichia,,,"Bergey et al. 1919",correct name,"Bergey et al. 1919",https://lpsn.dsmz.de/genus/escherichia,1,Escherichia coli,1001,https://lpsn.dsmz.de/genus/escherichia
-Escherichia,coli,,"Castellani and Chalmers 1919",correct name,"(Migula 1895) Castellani and Chalmers 1919",https://lpsn.dsmz.de/species/escherichia-coli,2,ATCC 11775,1002,https://lpsn.dsmz.de/species/escherichia-coli
+Escherichia,coli,,"Castellani and Chalmers 1919",correct name,"(Migula 1895) Castellani and Chalmers 1919",https://lpsn.dsmz.de/species/escherichia-coli,2,ATCC 11775 = DSM 30083 = JCM 1649,1002,https://lpsn.dsmz.de/species/escherichia-coli
 Escherichia,coli,inactive,"Chen and Kuo 1945",illegitimate name,"Chen and Kuo 1945",https://lpsn.dsmz.de/subspecies/escherichia-coli-inactive,,DSM 30083,1003,https://lpsn.dsmz.de/subspecies/escherichia-coli-inactive
 Bacillus,,,"Cohn 1872",correct name,"Cohn 1872",https://lpsn.dsmz.de/genus/bacillus,1,Bacillus subtilis,1010,https://lpsn.dsmz.de/genus/bacillus
-Bacillus,subtilis,,"Ehrenberg 1835",correct name,"(Ehrenberg 1835) Cohn 1872",https://lpsn.dsmz.de/species/bacillus-subtilis,1,DSM 10,1011,https://lpsn.dsmz.de/species/bacillus-subtilis
+Bacillus,subtilis,,"Ehrenberg 1835",correct name,"(Ehrenberg 1835) Cohn 1872",https://lpsn.dsmz.de/species/bacillus-subtilis,1,DSM 10 = ATCC 6051 = NCTC 3610,1011,https://lpsn.dsmz.de/species/bacillus-subtilis
 Notgenus,orphan,,"Anon. 1900",synonym,"Anon. 1900",https://lpsn.dsmz.de/species/notgenus-orphan,,,1099,https://lpsn.dsmz.de/species/notgenus-orphan

--- a/tests/test_lpsn_transform.py
+++ b/tests/test_lpsn_transform.py
@@ -112,3 +112,63 @@ def test_missing_csv_raises_file_not_found(tmp_path):
     xform = LPSNTransform(input_dir=tmp_path, output_dir=tmp_path)
     with pytest.raises(FileNotFoundError, match="LPSN GSS CSV not found"):
         xform.run()
+
+
+def test_species_gets_close_match_edges_for_each_type_strain_deposit(lpsn_transform):
+    """
+    Emit one close_match edge per culture-collection deposit for a species row.
+
+    E. coli (1002) has ``ATCC 11775 = DSM 30083 = JCM 1649`` and should emit
+    one edge per deposit to the shared strain CURIE that BacDive
+    also uses (``kgmicrobe.strain:<code>``).
+    """
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    close_matches = [
+        e for e in edges if e["subject"] == f"{LPSN_PREFIX}1002" and e["predicate"] == "biolink:close_match"
+    ]
+    objects = {e["object"] for e in close_matches}
+    assert objects == {
+        "kgmicrobe.strain:ATCC-11775",
+        "kgmicrobe.strain:DSM-30083",
+        "kgmicrobe.strain:JCM-1649",
+    }
+    for e in close_matches:
+        assert e["relation"] == "skos:closeMatch"
+        assert e["primary_knowledge_source"] == LPSN_KNOWLEDGE_SOURCE
+
+
+def test_subspecies_gets_close_match_edge(lpsn_transform):
+    """Subspecies row (1003) with ``DSM 30083`` emits one close_match edge."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    close_matches = [
+        e for e in edges if e["subject"] == f"{LPSN_PREFIX}1003" and e["predicate"] == "biolink:close_match"
+    ]
+    assert len(close_matches) == 1
+    assert close_matches[0]["object"] == "kgmicrobe.strain:DSM-30083"
+
+
+def test_genus_row_does_not_emit_close_match(lpsn_transform):
+    """
+    Genus rows must not emit close_match edges.
+
+    Their ``nomenclatural_type`` carries the type species name, not a
+    culture-collection deposit.
+    """
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    close_matches = [
+        e for e in edges if e["subject"] == f"{LPSN_PREFIX}1001" and e["predicate"] == "biolink:close_match"
+    ]
+    assert close_matches == []
+
+
+def test_row_with_no_nomenclatural_type_emits_no_close_match(lpsn_transform):
+    """The synonym row (1099) has blank ``nomenclatural_type`` → no edges."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    close_matches = [
+        e for e in edges if e["subject"] == f"{LPSN_PREFIX}1099" and e["predicate"] == "biolink:close_match"
+    ]
+    assert close_matches == []


### PR DESCRIPTION
## Summary

Follow-up to #586. Extends the LPSN transform to emit \`biolink:close_match\` edges from each species / subspecies row to the culture-collection deposits named in its \`nomenclatural_type\` field.

**Parsing:** LPSN's \`nomenclatural_type\` for a species/subspecies row is one or more culture-collection deposits separated by \`=\` / \`;\` / \`,\`, e.g. \`"ATCC 11775 = DSM 30083 = JCM 1649"\`. Each deposit is extracted with a regex over the standard culture-collection prefixes (\`ATCC\`, \`DSM\`, \`JCM\`, \`LMG\`, \`NCTC\`, \`NRRL\`, \`NBRC\`, \`CCUG\`, \`CCTM\`, \`CIP\`, \`IAM\`, \`IFO\`, \`KCTC\`) and normalized with the same rule BacDive uses (\`bacdive.py:2503\` — replace spaces and colons with hyphens) so both sides land on the same \`kgmicrobe.strain:<code>\` CURIE.

**Result:** the merge step naturally reconciles LPSN taxa with BacDive strains that share culture-collection deposits, giving BacDive strains a route to the authoritative LPSN taxon and vice-versa. This is the culture-collection path for issue #484's "normalize strain IDs" ask.

## What this doesn't do (still deferred, tracked in #484)

- **NCBITaxon cross-refs** — needs a name-matching layer using OAK's NCBITaxon adapter (same pattern as BacDive's transform).
- **GTDB cross-refs** — via GTDB metadata that cites LPSN, or GTDB2NCBI on top of the NCBITaxon layer.
- **Full LPSN JSON API ingest** — richer than the GSS CSV (nomenclatural status details, publication DOI/PMID, \`lpsn_correct_name_id\` for reclassifications, \`lpsn_parent_id\` for the full tree, 16S sequences).

## Test plan
- [x] \`poetry run tox\` — all 6 envs pass locally (format, lint, codespell, docstr-coverage, py, coverage-clean); pytest reports 352 passed.
- [x] 4 new fixture-based tests covering: multi-deposit split on a species row, single-deposit subspecies row, genus-row exclusion (genus \`nomenclatural_type\` is a species name, not a strain deposit), blank \`nomenclatural_type\` handling.
- [ ] End-to-end smoke against real LPSN GSS CSV — still blocked on LPSN credentials + downloading the file to \`data/raw/lpsn/lpsn_gss.csv\`.

## Related

- Refs #484 (culture-collection path landed; NCBITaxon / GTDB / full API still pending).
- Builds on #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)