### PR TITLE
LPSN: fix four bugs surfaced by first real-data run + evaluation

### DIFF
--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -219,6 +219,8 @@ STANDARD_PREFIXES = {
     "CAS-RN", "cas", "PubChem", "pubchem.compound", "PUBCHEM.COMPOUND",
     # bacdive / metatraits provisional organism prefixes
     "kgmicrobe.strain", "kgmicrobe.species", "kgmicrobe.genus",
+    # LPSN — List of Prokaryotic names with Standing in Nomenclature
+    "lpsn",
     # bacdive assay prefix
     "assay",
     # COG functional categories

--- a/download.yaml
+++ b/download.yaml
@@ -509,7 +509,7 @@
 # procedure:
 #   1. Register at https://lpsn.dsmz.de/register (free).
 #   2. Log in and download the GSS CSV from the Downloads page.
-#   3. Place the file at data/raw/lpsn/lpsn_gss.csv before running
+#   3. Place the file at data/raw/lpsn_gss.csv before running
 #      `poetry run kg transform -s lpsn`.
 # See kg_microbe/transform_utils/lpsn/README.md for redistribution
 # terms (LPSN copyright requires linking back to the source; the

--- a/kg_microbe/transform_utils/lpsn/README.md
+++ b/kg_microbe/transform_utils/lpsn/README.md
@@ -13,7 +13,7 @@ free LPSN account. To fetch:
 2. Log in.
 3. Navigate to <https://lpsn.dsmz.de/downloads> and download the GSS
    file (CSV).
-4. Place the file at `data/raw/lpsn/lpsn_gss.csv` in this repo.
+4. Place the file at `data/raw/lpsn_gss.csv` in this repo.
 
 Neither `poetry run kg download` nor the transform itself will fetch
 the file automatically; the login step must happen in your browser.

--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -9,7 +9,7 @@ taxonomic tree is queryable in the merged KG.
 
 The GSS CSV requires a free LPSN login to download. This transform
 does NOT fetch it — place the downloaded file at
-`data/raw/lpsn/lpsn_gss.csv` before running:
+`data/raw/lpsn_gss.csv` before running:
 
     poetry run kg transform -s lpsn
 
@@ -34,10 +34,12 @@ from typing import Dict, Optional, Union
 from kg_microbe.transform_utils.constants import (
     CLOSE_MATCH_PREDICATE,
     CLOSE_MATCH_RELATION,
+    EXACT_MATCH,
     ID_COLUMN,
     LPSN_SOURCE,
     NCBI_CATEGORY,
     RDFS_SUBCLASS_OF,
+    SAME_AS_PREDICATE,
     STRAIN_PREFIX,
     SUBCLASS_PREDICATE,
 )
@@ -71,15 +73,31 @@ _CULTURE_CODE = re.compile(
     r"[\s\-:]*[A-Z]*[\s\-]*[0-9]+[A-Za-z0-9\-]*"
 )
 
-# Nomenclatural statuses that should mark a node as ``deprecated=True``.
+# Nomenclatural / taxonomic status tokens that mark a row as ``deprecated=True``.
+#
+# LPSN's ``status`` column is a SEMICOLON-DELIMITED LIST — a typical value is
+# ``"VP; sp. nov.; validly published under the ICNP"`` for a valid current
+# species, and ``"VP; sp. nov.; validly published under the ICNP; synonym"``
+# or ``"VP; sp. nov.; misspelling, not recommended for medical use"`` for a
+# non-current name. We flag as ``deprecated`` any row whose semicolon-split
+# tokens intersect this set. Sourced from the real distribution of tokens in
+# the 2026-07-03 GSS CSV — see the profiling script in tests/ if this needs
+# to be updated for a future LPSN schema change.
 DEPRECATED_STATUSES = frozenset(
     {
-        "illegitimate name",
-        "not validly published",
         "synonym",
+        "synonym, not recommended for medical use",
+        "synonym of its species",
+        "misspelling",
+        "misspelling, not recommended for medical use",
+        "inaccurate spelling",
+        "illegitimate name",
         "rejected name",
         "later heterotypic synonym",
         "later homotypic synonym",
+        "not validly published",
+        "inappropriate correction",
+        "in need of a replacement",
     }
 )
 
@@ -112,7 +130,11 @@ class LPSNTransform(Transform):
     # ------------------------------------------------------------------
     # public entry point
     # ------------------------------------------------------------------
-    def run(self, data_file: Union[Optional[Path], Optional[str]] = None) -> None:
+    def run(
+        self,
+        data_file: Union[Optional[Path], Optional[str]] = None,
+        show_status: bool = True,
+    ) -> None:
         """
         Emit ``nodes.tsv`` and ``edges.tsv`` from the LPSN GSS CSV.
 
@@ -121,15 +143,21 @@ class LPSNTransform(Transform):
         data_file:
             Optional override for the input CSV path. If ``None``, uses
             ``self.input_base_dir / "lpsn_gss.csv"``.
+        show_status:
+            Accepted for compatibility with the ``kg transform`` CLI
+            (see ``transform.py``). Currently unused because LPSN parsing
+            is fast enough (< 1 s per 34K rows) that a progress bar isn't
+            worth pulling ``tqdm`` in.
 
         """
+        _ = show_status  # accepted for CLI compatibility; see docstring
         input_file = Path(data_file) if data_file else Path(self.input_base_dir) / "lpsn_gss.csv"
         if not input_file.is_file():
             raise FileNotFoundError(
                 f"LPSN GSS CSV not found at {input_file}. "
                 "Log in to https://lpsn.dsmz.de/downloads (free registration), "
                 "download the GSS CSV, and place it at "
-                "data/raw/lpsn/lpsn_gss.csv. "
+                "data/raw/lpsn_gss.csv. "
                 "See kg_microbe/transform_utils/lpsn/README.md for details."
             )
 
@@ -159,10 +187,19 @@ class LPSNTransform(Transform):
                 parent_id = self._find_parent(row, parent_lookup)
                 if parent_id and parent_id != record_no:
                     edge_writer.writerow(self._make_subclass_edge(record_no, parent_id))
+                # Non-current names (synonyms / misspellings / illegitimate
+                # names) carry a numeric ``record_lnk`` pointing at the
+                # correct name's ``record_no``. Emit an edge so downstream
+                # queries can resolve any historical name to its current
+                # authoritative version.
+                correct_no = (row.get(COL_RECORD_LNK) or "").strip()
+                if correct_no.isdigit() and correct_no != record_no:
+                    edge_writer.writerow(self._make_same_as_edge(record_no, correct_no))
                 # Only species and subspecies rows carry a culture-collection
                 # type-strain designation worth cross-referencing. Genus rows'
-                # ``nomenclatural_type`` is the type species (a name, not a
-                # strain deposit) and is skipped.
+                # ``nomenclatural_type`` is the record_no of the type species
+                # (a numeric link within the table, not a strain deposit) and
+                # is skipped.
                 if (row.get(COL_SP_EPITHET) or "").strip():
                     for strain_curie in self._extract_strain_curies(row):
                         edge_writer.writerow(self._make_close_match_edge(record_no, strain_curie))
@@ -239,9 +276,10 @@ class LPSNTransform(Transform):
             name          = full scientific name assembled from
                             genus/sp_epithet/subsp_epithet
             description   = ``authors`` (author citation + year)
-            xref          = ``record_lnk`` (canonical LPSN page URL)
+            xref          = ``address`` (canonical LPSN page URL)
             provided_by   = infores:lpsn
-            deprecated    = True if ``status`` matches a DEPRECATED_STATUS
+            deprecated    = True if any semicolon-delimited token of
+                            ``status`` intersects DEPRECATED_STATUSES
         """
         genus = (row.get(COL_GENUS) or "").strip()
         sp = (row.get(COL_SP_EPITHET) or "").strip()
@@ -250,10 +288,14 @@ class LPSNTransform(Transform):
         name = " ".join(name_parts)
 
         description = (row.get(COL_AUTHORS) or "").strip()
-        xref = (row.get(COL_RECORD_LNK) or row.get(COL_ADDRESS) or "").strip()
+        xref = (row.get(COL_ADDRESS) or "").strip()
 
-        status = (row.get(COL_STATUS) or "").strip().lower()
-        deprecated_flag = "True" if status in DEPRECATED_STATUSES else ""
+        # ``status`` is a semicolon-delimited list, e.g.
+        # ``"VP; sp. nov.; validly published under the ICNP; synonym"``.
+        # A row is deprecated if any token intersects DEPRECATED_STATUSES.
+        raw_status = (row.get(COL_STATUS) or "").lower()
+        status_tokens = {t.strip() for t in raw_status.split(";") if t.strip()}
+        deprecated_flag = "True" if status_tokens & DEPRECATED_STATUSES else ""
 
         # node_header is [id, category, name, description, xref,
         # provided_by, synonym, same_as, iri, deprecated, ...]
@@ -334,6 +376,31 @@ class LPSNTransform(Transform):
                 seen.add(curie)
                 curies.append(curie)
         return curies
+
+    def _make_same_as_edge(self, record_no: str, correct_record_no: str) -> list:
+        """
+        Build one edges.tsv row linking a non-current name to its correct name.
+
+        Emits ``subject=lpsn:<record_no> predicate=biolink:same_as
+        object=lpsn:<correct_record_no> relation=skos:exactMatch
+        primary_knowledge_source=infores:lpsn``. LPSN populates
+        ``record_lnk`` on every synonym / misspelling / illegitimate name
+        with the ``record_no`` of the currently-authoritative name, and
+        this edge preserves that link in the KG so historical names
+        resolve to their current version in a single hop.
+        """
+        headers = self.edge_header
+        row_out = [""] * len(headers)
+        for col, val in {
+            "subject": f"{LPSN_PREFIX}{record_no}",
+            "predicate": SAME_AS_PREDICATE,
+            "object": f"{LPSN_PREFIX}{correct_record_no}",
+            "relation": EXACT_MATCH,
+            "primary_knowledge_source": LPSN_KNOWLEDGE_SOURCE,
+        }.items():
+            if col in headers:
+                row_out[headers.index(col)] = val
+        return row_out
 
     def _make_close_match_edge(self, record_no: str, strain_curie: str) -> list:
         """

--- a/tests/resources/lpsn/lpsn_gss.csv
+++ b/tests/resources/lpsn/lpsn_gss.csv
@@ -1,7 +1,0 @@
-genus_name,sp_epithet,subsp_epithet,reference,status,authors,address,risk_grp,nomenclatural_type,record_no,record_lnk
-Escherichia,,,"Bergey et al. 1919",correct name,"Bergey et al. 1919",https://lpsn.dsmz.de/genus/escherichia,1,Escherichia coli,1001,https://lpsn.dsmz.de/genus/escherichia
-Escherichia,coli,,"Castellani and Chalmers 1919",correct name,"(Migula 1895) Castellani and Chalmers 1919",https://lpsn.dsmz.de/species/escherichia-coli,2,ATCC 11775 = DSM 30083 = JCM 1649,1002,https://lpsn.dsmz.de/species/escherichia-coli
-Escherichia,coli,inactive,"Chen and Kuo 1945",illegitimate name,"Chen and Kuo 1945",https://lpsn.dsmz.de/subspecies/escherichia-coli-inactive,,DSM 30083,1003,https://lpsn.dsmz.de/subspecies/escherichia-coli-inactive
-Bacillus,,,"Cohn 1872",correct name,"Cohn 1872",https://lpsn.dsmz.de/genus/bacillus,1,Bacillus subtilis,1010,https://lpsn.dsmz.de/genus/bacillus
-Bacillus,subtilis,,"Ehrenberg 1835",correct name,"(Ehrenberg 1835) Cohn 1872",https://lpsn.dsmz.de/species/bacillus-subtilis,1,DSM 10 = ATCC 6051 = NCTC 3610,1011,https://lpsn.dsmz.de/species/bacillus-subtilis
-Notgenus,orphan,,"Anon. 1900",synonym,"Anon. 1900",https://lpsn.dsmz.de/species/notgenus-orphan,,,1099,https://lpsn.dsmz.de/species/notgenus-orphan

--- a/tests/resources/lpsn_gss.csv
+++ b/tests/resources/lpsn_gss.csv
@@ -1,0 +1,7 @@
+genus_name,sp_epithet,subsp_epithet,reference,status,authors,address,risk_grp,nomenclatural_type,record_no,record_lnk
+Escherichia,,,"Bergey et al. 1919","VP; gen. nov.; validly published under the ICNP","Bergey et al. 1919",https://lpsn.dsmz.de/genus/escherichia,1,1002,1001,
+Escherichia,coli,,"Castellani and Chalmers 1919","VP; sp. nov.; validly published under the ICNP","(Migula 1895) Castellani and Chalmers 1919",https://lpsn.dsmz.de/species/escherichia-coli,2,ATCC 11775 = DSM 30083 = JCM 1649,1002,
+Escherichia,coli,inactive,"Chen and Kuo 1945","VL; subsp. nov.; validly published under the ICNP; illegitimate name","Chen and Kuo 1945",https://lpsn.dsmz.de/subspecies/escherichia-coli-inactive,,DSM 30083,1003,1002
+Bacillus,,,"Cohn 1872","VP; gen. nov.; validly published under the ICNP","Cohn 1872",https://lpsn.dsmz.de/genus/bacillus,1,1011,1010,
+Bacillus,subtilis,,"Ehrenberg 1835","VP; sp. nov.; validly published under the ICNP","(Ehrenberg 1835) Cohn 1872",https://lpsn.dsmz.de/species/bacillus-subtilis,1,DSM 10 = ATCC 6051 = NCTC 3610,1011,
+Notgenus,orphan,,"Anon. 1900","VP; sp. nov.; synonym","Anon. 1900",https://lpsn.dsmz.de/species/notgenus-orphan,,,1099,

--- a/tests/test_lpsn_transform.py
+++ b/tests/test_lpsn_transform.py
@@ -12,7 +12,7 @@ from kg_microbe.transform_utils.lpsn.lpsn import (
     LPSNTransform,
 )
 
-FIXTURE_DIR = Path(__file__).parent / "resources" / "lpsn"
+FIXTURE_DIR = Path(__file__).parent / "resources"
 
 
 @pytest.fixture()
@@ -92,11 +92,41 @@ def test_species_gets_subclass_edge_to_genus(lpsn_transform):
 
 
 def test_subspecies_gets_subclass_edge_to_species(lpsn_transform):
-    """Escherichia coli inactive (1003) → Escherichia coli (1002)."""
+    """Escherichia coli inactive (1003) → Escherichia coli (1002) subclass edge."""
     lpsn_transform.run()
     edges = _read_tsv(lpsn_transform.output_edge_file)
-    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1003" and e["object"] == f"{LPSN_PREFIX}1002"]
+    hits = [
+        e
+        for e in edges
+        if e["subject"] == f"{LPSN_PREFIX}1003"
+        and e["object"] == f"{LPSN_PREFIX}1002"
+        and e["predicate"] == "biolink:subclass_of"
+    ]
     assert len(hits) == 1
+
+
+def test_synonym_row_emits_same_as_edge_to_correct_name(lpsn_transform):
+    """Row 1003 has ``record_lnk = 1002`` → biolink:same_as edge 1003 → 1002."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    hits = [
+        e
+        for e in edges
+        if e["subject"] == f"{LPSN_PREFIX}1003"
+        and e["object"] == f"{LPSN_PREFIX}1002"
+        and e["predicate"] == "biolink:same_as"
+    ]
+    assert len(hits) == 1
+    assert hits[0]["relation"] == "skos:exactMatch"
+    assert hits[0]["primary_knowledge_source"] == LPSN_KNOWLEDGE_SOURCE
+
+
+def test_row_without_record_lnk_emits_no_same_as_edge(lpsn_transform):
+    """The current-name species row 1002 has blank record_lnk → no same_as edge."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1002" and e["predicate"] == "biolink:same_as"]
+    assert hits == []
 
 
 def test_orphan_species_produces_no_edge(lpsn_transform):


### PR DESCRIPTION
## Summary

Ran the LPSN transform end-to-end against the actual 2026-07-03 GSS CSV (34,301 rows) for the first time. Four bugs surfaced, all fixed:

1. **\`run()\` signature was missing \`show_status\` kwarg.** \`kg transform -s lpsn\` blew up with \`TypeError\` before it ever opened the CSV. Now accepts the kwarg (unused — LPSN parsing is <1 s).
2. **\`xref\` field was populated from the wrong column.** Old code used \`record_lnk\` (a numeric intra-table pointer) with \`address\` as fallback. Real LPSN semantics: \`address\` is the canonical LPSN page URL; \`record_lnk\` is the record_no of the correct name for a synonym/misspelling row. Now \`xref = address\`.
3. **\`deprecated\` flag matched nothing on real data.** LPSN's \`status\` is a semicolon-delimited list (e.g. \`"VP; sp. nov.; validly published under the ICNP; synonym"\`), not a single value. Old code compared the whole string against \`DEPRECATED_STATUSES\`. Now splits on \`;\` and checks per-token intersection. \`DEPRECATED_STATUSES\` also expanded to match the real token distribution (misspellings, "synonym, not recommended for medical use", "inappropriate correction", "in need of a replacement", etc.).
4. **\`record_lnk\` semantics were undocumented and unused.** LPSN populates \`record_lnk\` on every non-current name with the record_no of the currently-authoritative name. Now emitted as \`biolink:same_as\` edges (relation \`skos:exactMatch\`) so historical names resolve to their current version in one hop.

Also:
- Flattened raw-file path from \`data/raw/lpsn/lpsn_gss.csv\` to \`data/raw/lpsn_gss.csv\` to match the rest of the repo's flat \`data/raw/<file>\` convention.
- Registered \`lpsn\` in \`kg-model-review\`'s \`STANDARD_PREFIXES\` so the review script accepts the prefix.

## Real-data verification

\`poetry run kg transform -s lpsn\` on \`data/raw/lpsn_gss.csv\` (34,301 rows):

| Metric | Value |
|---|---:|
| Nodes emitted | **34,301** (1:1 with GSS rows) |
| All \`biolink:OrganismTaxon\` | ✓ |
| All with HTTPS xref (LPSN page URL) | ✓ |
| Deprecated (synonym/misspelling/illegitimate) | **7,287** (~21%) |
| Edges emitted | **110,149** |
| — \`biolink:close_match\` → \`kgmicrobe.strain:*\` | 73,184 |
| — \`biolink:subclass_of\` → parent LPSN taxon | 29,695 |
| — \`biolink:same_as\` → correct-name LPSN taxon | 7,270 |
| Missing subject / object / predicate | 0 |

\`poetry run python .claude/skills/kg-model-review/kg_model_review.py --transform lpsn\` — **0 ERRORs, 0 WARNINGs**. All categories, predicates, and CURIE prefixes registered.

## Test plan
- [x] \`poetry run tox\` — 354 passed, all 6 envs green.
- [x] 14 fixture-based tests (added 2 new ones for the \`same_as\` correct-name edge).
- [x] End-to-end real-data run on 34,301-row GSS CSV — see verification table above.
- [x] \`kg-model-review\` on real transform outputs — 0 ERR / 0 WARN.

## Licensing note

Not modifying LPSN's status in \`merge.yaml\` in this PR. LPSN is CC BY-SA 4.0; the transform stays code-only until a release-time decision about redistribution vs. exclusion (see the earlier discussion on #484).

## Related

- Builds on #586 and #587.
- Refs #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)