### PR TITLE
LPSN: NCBITaxon cross-refs via bulk-loaded label index

### DIFF
--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -16,20 +16,30 @@ does NOT fetch it — place the downloaded file at
 See ``kg_microbe/transform_utils/lpsn/README.md`` for the manual
 download procedure.
 
-MVP scope:
+Scope:
 - Nodes for every LPSN record (family / genus / species / subspecies).
 - subclass_of edges from subspecies → species → genus (only when the
   parent row is present in the same CSV — no LPSN API calls).
+- close_match edges to `kgmicrobe.strain:*` for every culture-collection
+  deposit named in ``nomenclatural_type``.
+- close_match edges to `NCBITaxon:*` for every species / subspecies row
+  whose ``full_name`` resolves to exactly one NCBITaxon via the local
+  NCBI adapter. Skipped when the adapter is absent
+  (``data/raw/ncbitaxon.owl`` not on disk) or when the name is ambiguous
+  (multiple NCBI hits — typically homonyms in other kingdoms).
+- same_as edges from historical names → correct-name LPSN taxon.
 - Illegitimate / synonym rows carry ``deprecated=True``.
-- Cross-references to NCBITaxon / GTDB / BacDive are deferred to a
-  follow-up PR (see issue #484); they require a name-matching layer
-  or the authenticated LPSN JSON API.
+
+Deferred to a follow-up PR (issue #484):
+- GTDB cross-refs (via ``data/transformed/gtdb/nodes.tsv`` name-matching).
+- Full LPSN JSON API ingest (publication DOI/PMID, ``lpsn_parent_id``
+  for the full taxonomic tree, 16S sequences).
 """
 
 import csv
 import re
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from kg_microbe.transform_utils.constants import (
     CLOSE_MATCH_PREDICATE,
@@ -38,6 +48,7 @@ from kg_microbe.transform_utils.constants import (
     ID_COLUMN,
     LPSN_SOURCE,
     NCBI_CATEGORY,
+    NCBITAXON_SOURCE,
     RDFS_SUBCLASS_OF,
     SAME_AS_PREDICATE,
     STRAIN_PREFIX,
@@ -102,6 +113,44 @@ DEPRECATED_STATUSES = frozenset(
 )
 
 
+class _NCBILabelIndex:
+
+    """
+    Pre-load NCBITaxon labels once, then answer ``curies_by_label`` in O(1).
+
+    Wraps a plain ``dict[label] -> list[CURIE]`` behind the same one-method
+    API OAK's SqlImplementation exposes so callers (and tests) can inject
+    either without noticing the difference.
+
+    Built via a direct SQL query on the semsql ``statements`` table so
+    the load is ~2 s for the full 2.7 M-row NCBITaxon dump, vs. hours if
+    we let OAK's ORM issue one query per LPSN row (the naive path we
+    tried first — see PR body for the perf bench).
+    """
+
+    def __init__(self, db_path):
+        """Populate the in-memory index from ``db_path`` (semsql SQLite DB)."""
+        import sqlite3
+
+        self._map: Dict[str, list] = {}
+        con = sqlite3.connect(db_path)
+        try:
+            cur = con.execute(
+                "SELECT subject, value FROM statements WHERE predicate = 'rdfs:label' AND subject LIKE 'NCBITaxon:%'"
+            )
+            for curie, label in cur:
+                if label is None:
+                    continue
+                self._map.setdefault(label, []).append(curie)
+        finally:
+            con.close()
+        print(f"[lpsn] loaded {len(self._map):,} NCBITaxon labels for cross-ref lookup")
+
+    def curies_by_label(self, label: str) -> list:
+        """Return the list of NCBITaxon CURIEs whose label equals ``label``."""
+        return list(self._map.get(label, []))
+
+
 class LPSNTransform(Transform):
 
     """Transform LPSN GSS CSV bulk export into KGX nodes + edges."""
@@ -110,6 +159,7 @@ class LPSNTransform(Transform):
         self,
         input_dir: Optional[Path] = None,
         output_dir: Optional[Path] = None,
+        ncbi_impl: Any = None,
     ):
         """
         Instantiate.
@@ -117,15 +167,60 @@ class LPSNTransform(Transform):
         Parameters
         ----------
         input_dir:
-            Directory holding ``lpsn_gss.csv``. Defaults to ``data/raw/lpsn``
-            resolved by the base :class:`Transform` class.
+            Directory holding ``lpsn_gss.csv``. Defaults to
+            ``data/raw`` resolved by the base :class:`Transform` class.
         output_dir:
-            Directory to write ``nodes.tsv`` / ``edges.tsv`` into. Defaults
-            to ``data/transformed/lpsn`` resolved by the base class.
+            Directory to write ``nodes.tsv`` / ``edges.tsv`` into.
+            Defaults to ``data/transformed/lpsn`` resolved by the base
+            class.
+        ncbi_impl:
+            An OAK adapter for the NCBITaxon ontology, used to enrich
+            LPSN species / subspecies rows with ``biolink:close_match``
+            edges to the corresponding ``NCBITaxon:*`` CURIE. When
+            ``None`` (the default), the constructor auto-loads a SQLite
+            adapter over ``NCBITAXON_SOURCE`` if that file exists on
+            disk; otherwise NCBITaxon enrichment is silently skipped
+            (so the transform can still run on machines that haven't
+            downloaded the ~2 GB NCBITaxon dump). Tests inject a mock
+            here to keep the fixture self-contained.
 
         """
         super().__init__(LPSN_SOURCE, input_dir, output_dir)
         self.knowledge_source = LPSN_KNOWLEDGE_SOURCE
+        self.ncbi_impl = ncbi_impl if ncbi_impl is not None else self._load_ncbi_adapter()
+        # Track cross-ref outcomes for the end-of-run summary.
+        self._ncbi_stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
+
+    @staticmethod
+    def _load_ncbi_adapter() -> Any:
+        """
+        Return a fast in-memory NCBITaxon label index, or None.
+
+        NCBITaxon has ~2.7 M labels. OAK's SqlImplementation issues one
+        SQL round-trip per ``curies_by_label`` call (~50 ms), which
+        blows up to hours for 34 K LPSN lookups. Instead, we build the
+        label → CURIE map once via a direct SQL query on the semsql
+        ``statements`` table (~2 s for the full 2.7 M-row build). The
+        wrapper class exposes the same one-method API OAK does so tests
+        can inject mocks unchanged.
+
+        Returns ``None`` — leaving NCBITaxon enrichment silently
+        disabled — if either the OWL file at ``NCBITAXON_SOURCE`` or
+        the paired semsql SQLite DB is absent. Absence is expected on
+        fresh checkouts and in CI, so this is not fatal.
+        """
+        if not NCBITAXON_SOURCE.exists():
+            print(
+                f"[lpsn] {NCBITAXON_SOURCE} not found; NCBITaxon cross-refs skipped. "
+                "Run `poetry run kg download` to fetch NCBITaxon."
+            )
+            return None
+        # semsql layout: the .db file lives next to the .owl file.
+        db_path = NCBITAXON_SOURCE.with_suffix(".db")
+        if not db_path.exists():
+            print(f"[lpsn] {db_path} not found (needed for fast label lookup); NCBITaxon cross-refs skipped.")
+            return None
+        return _NCBILabelIndex(db_path)
 
     # ------------------------------------------------------------------
     # public entry point
@@ -203,6 +298,24 @@ class LPSNTransform(Transform):
                 if (row.get(COL_SP_EPITHET) or "").strip():
                     for strain_curie in self._extract_strain_curies(row):
                         edge_writer.writerow(self._make_close_match_edge(record_no, strain_curie))
+                    # NCBITaxon name-match cross-ref. Species and subspecies
+                    # rank only — LPSN's bacterial genera collide with insect
+                    # / mineral genera of the same name in NCBI's
+                    # multi-kingdom taxonomy (e.g. ``Bacillus`` is a walking
+                    # stick as well as a firmicute), so genus-rank matching
+                    # is deferred to a future PR with a rank-aware resolver.
+                    ncbi_curie = self._lookup_ncbi(row)
+                    if ncbi_curie:
+                        edge_writer.writerow(self._make_close_match_edge(record_no, ncbi_curie))
+
+        # End-of-run summary — useful diff signal when the NCBITaxon dump
+        # is refreshed and match rates shift.
+        print(
+            f"[lpsn] NCBITaxon cross-refs: "
+            f"{self._ncbi_stats['matched']:,} matched, "
+            f"{self._ncbi_stats['unmatched']:,} unmatched, "
+            f"{self._ncbi_stats['ambiguous']:,} ambiguous"
+        )
 
     # ------------------------------------------------------------------
     # internals
@@ -376,6 +489,42 @@ class LPSNTransform(Transform):
                 seen.add(curie)
                 curies.append(curie)
         return curies
+
+    def _lookup_ncbi(self, row: dict) -> Optional[str]:
+        """
+        Return the single matching ``NCBITaxon:X`` CURIE for ``row``, or None.
+
+        Uses the OAK adapter's ``curies_by_label`` on the assembled
+        scientific name (``genus + sp_epithet [+ subsp_epithet]``).
+        Emits at most one edge per row, and only when the lookup
+        returns exactly one CURIE. Zero-hit and multi-hit rows are
+        counted for the end-of-run summary but do NOT produce an edge:
+
+        - Zero hits: NCBITaxon doesn't index this name (recently
+          published, orphaned, or NCBI hasn't harmonized yet).
+        - Multi-hit: ambiguous / homonym across kingdoms (rare for
+          full species names, more common for genera — one reason
+          the caller restricts this to species/subspecies rank).
+        """
+        if self.ncbi_impl is None:
+            return None
+
+        genus = (row.get(COL_GENUS) or "").strip()
+        sp = (row.get(COL_SP_EPITHET) or "").strip()
+        subsp = (row.get(COL_SUBSP_EPITHET) or "").strip()
+        name = " ".join(p for p in (genus, sp, subsp) if p)
+        if not name:
+            return None
+
+        hits = list(self.ncbi_impl.curies_by_label(name))
+        if len(hits) == 1:
+            self._ncbi_stats["matched"] += 1
+            return hits[0]
+        if not hits:
+            self._ncbi_stats["unmatched"] += 1
+        else:
+            self._ncbi_stats["ambiguous"] += 1
+        return None
 
     def _make_same_as_edge(self, record_no: str, correct_record_no: str) -> list:
         """

--- a/tests/test_lpsn_transform.py
+++ b/tests/test_lpsn_transform.py
@@ -15,17 +15,31 @@ from kg_microbe.transform_utils.lpsn.lpsn import (
 FIXTURE_DIR = Path(__file__).parent / "resources"
 
 
+class _NoNCBI:
+
+    """OAK-adapter stub used when a test wants NCBITaxon enrichment disabled."""
+
+    def curies_by_label(self, label):
+        """Return an empty list — every LPSN name is treated as unmatched."""
+        return []
+
+
 @pytest.fixture()
 def lpsn_transform(tmp_path):
     """
     Return an ``LPSNTransform`` configured to read the fixture CSV.
 
-    The transform's ``input_base_dir`` is set to ``tests/resources/lpsn``
-    so that ``lpsn_gss.csv`` resolves via the base ``Transform`` class,
-    and ``output_dir`` is set to a per-test temp dir so nodes.tsv /
+    The transform's ``input_base_dir`` is set to ``tests/resources`` so
+    ``lpsn_gss.csv`` resolves via the base ``Transform`` class, and
+    ``output_dir`` is set to a per-test temp dir so nodes.tsv /
     edges.tsv land in isolation.
+
+    A no-op NCBITaxon adapter is injected so the default fixture never
+    depends on the local ``data/raw/ncbitaxon.owl`` (~13 GB) being on
+    disk. Tests that specifically exercise the NCBI cross-ref path use
+    ``lpsn_transform_with_ncbi`` instead.
     """
-    return LPSNTransform(input_dir=FIXTURE_DIR, output_dir=tmp_path)
+    return LPSNTransform(input_dir=FIXTURE_DIR, output_dir=tmp_path, ncbi_impl=_NoNCBI())
 
 
 def _read_tsv(path: Path) -> list[dict]:
@@ -202,3 +216,94 @@ def test_row_with_no_nomenclatural_type_emits_no_close_match(lpsn_transform):
         e for e in edges if e["subject"] == f"{LPSN_PREFIX}1099" and e["predicate"] == "biolink:close_match"
     ]
     assert close_matches == []
+
+
+# --------------------------------------------------------------------------
+# NCBITaxon cross-refs
+# --------------------------------------------------------------------------
+
+
+class _FakeNCBI:
+
+    """Minimal stub of the subset of OAK's adapter API that LPSN uses."""
+
+    def __init__(self, mapping):
+        """Store the ``{scientific_name: [CURIE, ...]}`` lookup table."""
+        self._map = mapping
+
+    def curies_by_label(self, label):
+        """Return the CURIE list for ``label`` (empty list if unknown)."""
+        return list(self._map.get(label, []))
+
+
+@pytest.fixture()
+def lpsn_transform_with_ncbi(tmp_path):
+    """
+    LPSNTransform wired to a fake NCBI adapter with three canned answers.
+
+    - ``Escherichia coli`` → single hit ``NCBITaxon:562`` (should emit an edge)
+    - ``Escherichia coli inactive`` → **two** hits (ambiguous — no edge)
+    - ``Bacillus subtilis`` → zero hits (unmatched — no edge)
+    """
+    fake = _FakeNCBI(
+        {
+            "Escherichia coli": ["NCBITaxon:562"],
+            "Escherichia coli inactive": ["NCBITaxon:99999", "NCBITaxon:99998"],
+            # Bacillus subtilis intentionally absent.
+        }
+    )
+    return LPSNTransform(input_dir=FIXTURE_DIR, output_dir=tmp_path, ncbi_impl=fake)
+
+
+def test_single_hit_emits_ncbitaxon_close_match(lpsn_transform_with_ncbi):
+    """E. coli (1002) → NCBITaxon:562 close_match edge."""
+    lpsn_transform_with_ncbi.run()
+    edges = _read_tsv(lpsn_transform_with_ncbi.output_edge_file)
+    hits = [
+        e
+        for e in edges
+        if e["subject"] == f"{LPSN_PREFIX}1002"
+        and e["object"] == "NCBITaxon:562"
+        and e["predicate"] == "biolink:close_match"
+    ]
+    assert len(hits) == 1
+    assert hits[0]["relation"] == "skos:closeMatch"
+    assert hits[0]["primary_knowledge_source"] == LPSN_KNOWLEDGE_SOURCE
+
+
+def test_ambiguous_hit_emits_no_edge(lpsn_transform_with_ncbi):
+    """Subspecies 1003's fake mapping returns 2 hits → no edge."""
+    lpsn_transform_with_ncbi.run()
+    edges = _read_tsv(lpsn_transform_with_ncbi.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1003" and e["object"].startswith("NCBITaxon:")]
+    assert hits == []
+    assert lpsn_transform_with_ncbi._ncbi_stats["ambiguous"] == 1
+
+
+def test_unmatched_row_emits_no_edge(lpsn_transform_with_ncbi):
+    """B. subtilis (1011) has no fake mapping → no edge, counted as unmatched."""
+    lpsn_transform_with_ncbi.run()
+    edges = _read_tsv(lpsn_transform_with_ncbi.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1011" and e["object"].startswith("NCBITaxon:")]
+    assert hits == []
+    # unmatched count includes 1011 + 1099 (both species-rank rows with no fake
+    # mapping): the orphan Notgenus (1099) is also species-rank so it counts.
+    assert lpsn_transform_with_ncbi._ncbi_stats["unmatched"] >= 1
+
+
+def test_ncbi_disabled_when_adapter_absent(lpsn_transform):
+    """The default fixture (no ncbi_impl) emits no NCBITaxon edges at all."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    ncbi_edges = [e for e in edges if e["object"].startswith("NCBITaxon:")]
+    assert ncbi_edges == []
+
+
+def test_genus_row_gets_no_ncbi_edge(lpsn_transform_with_ncbi):
+    """Genus rows skip NCBI matching (homonym risk in multi-kingdom NCBI)."""
+    lpsn_transform_with_ncbi.run()
+    edges = _read_tsv(lpsn_transform_with_ncbi.output_edge_file)
+    # Genus 1001 is Escherichia — even if the fake mapping had it, the
+    # sp_epithet-gated branch skips genera. Confirm no NCBI edge for 1001.
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1001" and e["object"].startswith("NCBITaxon:")]
+    assert hits == []


### PR DESCRIPTION
## Summary

Extend the LPSN transform to emit \`biolink:close_match\` edges from every species / subspecies row to the corresponding \`NCBITaxon:<id>\` whose scientific name matches exactly. LPSN taxa are now reachable from any NCBI-indexed downstream analysis in one hop, closing one of the three cross-ref gaps flagged in #484.

## Perf: naive → bulk index (2,700× faster)

First implementation used OAK's \`SqlImplementation\` and called \`curies_by_label\` once per LPSN row. That's ~50 ms per lookup on the 13 GB semsql SQLite DB and projects to 30+ hours for 34K rows. The run I actually kicked off took 12+ minutes to process 3% of rows before I killed it.

Refactored to \`_NCBILabelIndex\`, a tiny wrapper class that runs a single direct SQL query on the semsql \`statements\` table (\`predicate = 'rdfs:label' AND subject LIKE 'NCBITaxon:%'\`), buckets the results into a \`dict[label] -> list[CURIE]\`, and answers \`curies_by_label(name)\` in O(1). Same one-method API as OAK so callers and tests inject either without noticing.

Bench:
- 2.7 M labels loaded in ~2 s
- Full 34K-row LPSN run: 12.7 s wall clock end-to-end (vs. hours before)

## Ambiguity policy

Only species / subspecies rows are matched. Genera skipped because NCBI uses disambiguated labels for multi-kingdom homonyms (e.g. \`"Bacillus <firmicutes>"\` vs \`"Bacillus <walking sticks>"\`), so a bare \`"Bacillus"\` lookup returns zero hits. Species names are unique in NCBI (0 ambiguous across 2.7 M labels in the 2026 snapshot, verified at build time), so exact-name matching is safe.

## Real-data verification (2026-07-03 GSS + 2026 NCBITaxon)

| NCBI outcome | Count | % of species+subspecies |
|---|---:|---:|
| Matched | **22,383** | **75.4%** |
| Unmatched | 7,314 | 24.6% |
| Ambiguous | 0 | 0% |

**Edge totals now:**
| Predicate + object | Count |
|---|---:|
| \`biolink:close_match\` → \`kgmicrobe.strain:*\` | 73,184 |
| \`biolink:subclass_of\` → \`lpsn:*\` | 29,695 |
| \`biolink:close_match\` → \`NCBITaxon:*\` | **22,383** (new) |
| \`biolink:same_as\` → \`lpsn:*\` (correct name) | 7,270 |
| **Total edges** | **132,532** |

\`kg-model-review --transform lpsn\`: **0 ERRORs, 0 WARNINGs**.

## Test plan
- [x] \`poetry run tox\` — 359 passed, all 6 envs green.
- [x] 19 fixture-based tests (5 new): single-hit / 2-hit / 0-hit / adapter-absent / genus-skip.
- [x] Real-data end-to-end run: 12.7 s wall clock, 22,383 NCBI edges emitted.
- [x] kg-model-review on real outputs: 0 ERR / 0 WARN.

## Related

Builds on #586 / #587 / #588. Refs #484.

Still deferred (own follow-up PRs): **GTDB cross-refs**, **full LPSN JSON API ingest**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)