### PR TITLE
LPSN → GTDB cross-refs — closes the last cross-ref target on #484

### DIFF
--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -118,6 +118,51 @@ DEPRECATED_STATUSES = frozenset(
 )
 
 
+class _GTDBRankNameIndex:
+
+    """
+    Pre-load GTDB nodes.tsv into a ``(rank_prefix, name) -> [CURIE, ...]`` map.
+
+    Wraps the map behind a single ``curies_by_rank_name(rank, name)``
+    method so callers (and tests) inject either a real load or a fake
+    dict without noticing the difference.
+
+    GTDB CURIEs look like ``GTDB:s__Escherichia_coli``; we split on the
+    two-letter rank prefix and restore spaces, storing
+    ``("s__", "Escherichia coli")`` → ``["GTDB:s__Escherichia_coli"]``.
+    Multi-character names with underscores in them
+    (``s__Escherichia_flexneri_boydii`` → ``"Escherichia flexneri boydii"``)
+    end up under a longer normalized name that LPSN's two-word species
+    names won't match, which naturally filters out GTDB's placeholder
+    variants (``s__Escherichia_coli_E``, ``_F`` etc.) from LPSN's
+    canonical ``Escherichia coli``.
+    """
+
+    def __init__(self, gtdb_nodes_path: Path):
+        """Load ``data/transformed/gtdb/nodes.tsv`` into the index."""
+        self._map: Dict[tuple, list] = {}
+        with open(gtdb_nodes_path, newline="") as fh:
+            reader = csv.DictReader(fh, delimiter="\t")
+            for row in reader:
+                curie = (row.get("id") or "").strip()
+                if not curie.startswith("GTDB:"):
+                    continue
+                body = curie[len("GTDB:") :]
+                # A GTDB body starts with the rank code and a double
+                # underscore ("s__", "g__", "f__", ...). Guard against
+                # anything shorter than 4 chars (rank + "__" + 1 char).
+                if len(body) < 4 or body[1:3] != "__":
+                    continue
+                rank = body[:3]
+                name = body[3:].replace("_", " ")
+                self._map.setdefault((rank, name), []).append(curie)
+        print(f"[lpsn] GTDB index loaded: {len(self._map):,} distinct (rank, name) keys")
+
+    def curies_by_rank_name(self, rank: str, name: str) -> list:
+        """Return the GTDB CURIEs matching ``(rank, name)``, empty list if none."""
+        return list(self._map.get((rank, name), []))
+
+
 class _NCBILabelIndex:
 
     """
@@ -207,6 +252,7 @@ class LPSNTransform(Transform):
         input_dir: Optional[Path] = None,
         output_dir: Optional[Path] = None,
         ncbi_impl: Any = None,
+        gtdb_index: Any = None,
     ):
         """
         Instantiate.
@@ -221,22 +267,46 @@ class LPSNTransform(Transform):
             Defaults to ``data/transformed/lpsn`` resolved by the base
             class.
         ncbi_impl:
-            An OAK adapter for the NCBITaxon ontology, used to enrich
-            LPSN species / subspecies rows with ``biolink:close_match``
-            edges to the corresponding ``NCBITaxon:*`` CURIE. When
-            ``None`` (the default), the constructor auto-loads a SQLite
-            adapter over ``NCBITAXON_SOURCE`` if that file exists on
-            disk; otherwise NCBITaxon enrichment is silently skipped
-            (so the transform can still run on machines that haven't
-            downloaded the ~2 GB NCBITaxon dump). Tests inject a mock
-            here to keep the fixture self-contained.
+            NCBITaxon name → CURIE lookup. See ``_load_ncbi_adapter``.
+        gtdb_index:
+            GTDB (rank, normalized_name) → CURIE lookup. When
+            ``None`` (the default), the constructor auto-loads
+            ``data/transformed/gtdb/nodes.tsv`` if that file exists;
+            otherwise GTDB enrichment is silently skipped (so a fresh
+            checkout that hasn't run the GTDB transform yet still
+            produces a valid — GTDB-less — LPSN output). Tests inject a
+            mock here to keep the fixture self-contained.
 
         """
         super().__init__(LPSN_SOURCE, input_dir, output_dir)
         self.knowledge_source = LPSN_KNOWLEDGE_SOURCE
         self.ncbi_impl = ncbi_impl if ncbi_impl is not None else self._load_ncbi_adapter()
+        self.gtdb_index = gtdb_index if gtdb_index is not None else self._load_gtdb_index()
         # Track cross-ref outcomes for the end-of-run summary.
         self._ncbi_stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
+        self._gtdb_stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
+
+    @staticmethod
+    def _load_gtdb_index() -> Any:
+        """
+        Return a ``_GTDBRankNameIndex`` over ``data/transformed/gtdb/nodes.tsv``, or None.
+
+        GTDB CURIEs carry the rank as a leading two-letter code
+        (``d__``, ``p__``, ``c__``, ``o__``, ``f__``, ``g__``,
+        ``s__``) and the name with spaces replaced by underscores.
+        The index normalizes both sides — strip prefix, restore
+        spaces — so LPSN's ``full_name`` (e.g. ``"Escherichia coli"``)
+        looks up directly against the correct rank slot without
+        collisions between species and genera of the same name.
+        """
+        default_path = Path("data/transformed/gtdb/nodes.tsv")
+        if not default_path.is_file():
+            print(
+                f"[lpsn] {default_path} not found; GTDB cross-refs skipped. "
+                "Run `poetry run kg transform -s gtdb` to enable them."
+            )
+            return None
+        return _GTDBRankNameIndex(default_path)
 
     @staticmethod
     def _load_ncbi_adapter() -> Any:
@@ -357,14 +427,32 @@ class LPSNTransform(Transform):
                 ncbi_curie = self._lookup_ncbi(row)
                 if ncbi_curie:
                     edge_writer.writerow(self._make_close_match_edge(record_no, ncbi_curie))
+                # GTDB cross-ref: rank-aware name match against a
+                # pre-loaded (rank, name) index of data/transformed/gtdb/
+                # nodes.tsv. GTDB is bacteria+archaea only so no subtree
+                # filter is needed, but rank pairing matters (LPSN genus
+                # → GTDB g__, LPSN species → GTDB s__). Subspecies rows
+                # are skipped because GTDB has no subspecies rank; the
+                # subclass_of chain from LPSN subspecies → species → GTDB
+                # gives downstream queries the same reachability in two
+                # hops.
+                gtdb_curie = self._lookup_gtdb(row)
+                if gtdb_curie:
+                    edge_writer.writerow(self._make_close_match_edge(record_no, gtdb_curie))
 
-        # End-of-run summary — useful diff signal when the NCBITaxon dump
-        # is refreshed and match rates shift.
+        # End-of-run summary — useful diff signal when NCBI / GTDB
+        # dumps are refreshed and match rates shift.
         print(
             f"[lpsn] NCBITaxon cross-refs: "
             f"{self._ncbi_stats['matched']:,} matched, "
             f"{self._ncbi_stats['unmatched']:,} unmatched, "
             f"{self._ncbi_stats['ambiguous']:,} ambiguous"
+        )
+        print(
+            f"[lpsn] GTDB cross-refs:      "
+            f"{self._gtdb_stats['matched']:,} matched, "
+            f"{self._gtdb_stats['unmatched']:,} unmatched, "
+            f"{self._gtdb_stats['ambiguous']:,} ambiguous"
         )
 
     # ------------------------------------------------------------------
@@ -574,6 +662,54 @@ class LPSNTransform(Transform):
             self._ncbi_stats["unmatched"] += 1
         else:
             self._ncbi_stats["ambiguous"] += 1
+        return None
+
+    def _lookup_gtdb(self, row: dict) -> Optional[str]:
+        """
+        Return the single matching ``GTDB:*`` CURIE for ``row``, or None.
+
+        Uses the pre-loaded (rank, name) index. Only genus and species
+        rows are attempted:
+
+        - LPSN genus row (``sp_epithet`` empty) → GTDB ``g__``
+        - LPSN species row (``sp_epithet`` set, ``subsp_epithet`` empty)
+          → GTDB ``s__``
+        - LPSN subspecies rows (``subsp_epithet`` set) → SKIPPED. GTDB
+          has no subspecies rank; the LPSN subclass_of chain from
+          subspecies → species → GTDB gives downstream queries the same
+          reachability in two hops without introducing spurious
+          equivalences.
+
+        Emits at most one edge per row, and only when the lookup returns
+        exactly one CURIE. Zero-hit and multi-hit rows are counted for
+        the end-of-run summary but do NOT produce an edge (GTDB
+        placeholder variants like ``s__Escherichia_coli_E`` naturally
+        fall out of the exact-name match — see ``_GTDBRankNameIndex``).
+        """
+        if self.gtdb_index is None:
+            return None
+
+        genus = (row.get(COL_GENUS) or "").strip()
+        sp = (row.get(COL_SP_EPITHET) or "").strip()
+        subsp = (row.get(COL_SUBSP_EPITHET) or "").strip()
+
+        if subsp:
+            return None  # no GTDB rank for subspecies
+        if sp:
+            rank, name = "s__", f"{genus} {sp}"
+        elif genus:
+            rank, name = "g__", genus
+        else:
+            return None
+
+        hits = self.gtdb_index.curies_by_rank_name(rank, name)
+        if len(hits) == 1:
+            self._gtdb_stats["matched"] += 1
+            return hits[0]
+        if not hits:
+            self._gtdb_stats["unmatched"] += 1
+        else:
+            self._gtdb_stats["ambiguous"] += 1
         return None
 
     def _make_same_as_edge(self, record_no: str, correct_record_no: str) -> list:

--- a/tests/test_lpsn_transform.py
+++ b/tests/test_lpsn_transform.py
@@ -24,6 +24,28 @@ class _NoNCBI:
         return []
 
 
+class _NoGTDB:
+
+    """GTDB-index stub used when a test wants GTDB enrichment disabled."""
+
+    def curies_by_rank_name(self, rank, name):
+        """Return an empty list — every LPSN name is treated as unmatched."""
+        return []
+
+
+class _FakeGTDB:
+
+    """Simple GTDB-index fake keyed on ``(rank, name)`` tuples."""
+
+    def __init__(self, mapping):
+        """Store the mapping and answer ``curies_by_rank_name`` from it."""
+        self._map = mapping
+
+    def curies_by_rank_name(self, rank, name):
+        """Return the CURIE list for ``(rank, name)`` (empty if unknown)."""
+        return list(self._map.get((rank, name), []))
+
+
 @pytest.fixture()
 def lpsn_transform(tmp_path):
     """
@@ -39,7 +61,12 @@ def lpsn_transform(tmp_path):
     disk. Tests that specifically exercise the NCBI cross-ref path use
     ``lpsn_transform_with_ncbi`` instead.
     """
-    return LPSNTransform(input_dir=FIXTURE_DIR, output_dir=tmp_path, ncbi_impl=_NoNCBI())
+    return LPSNTransform(
+        input_dir=FIXTURE_DIR,
+        output_dir=tmp_path,
+        ncbi_impl=_NoNCBI(),
+        gtdb_index=_NoGTDB(),
+    )
 
 
 def _read_tsv(path: Path) -> list[dict]:
@@ -252,7 +279,12 @@ def lpsn_transform_with_ncbi(tmp_path):
             # Bacillus subtilis intentionally absent.
         }
     )
-    return LPSNTransform(input_dir=FIXTURE_DIR, output_dir=tmp_path, ncbi_impl=fake)
+    return LPSNTransform(
+        input_dir=FIXTURE_DIR,
+        output_dir=tmp_path,
+        ncbi_impl=fake,
+        gtdb_index=_NoGTDB(),
+    )
 
 
 def test_single_hit_emits_ncbitaxon_close_match(lpsn_transform_with_ncbi):
@@ -310,7 +342,12 @@ def test_genus_row_now_gets_ncbi_edge_when_synonym_matches(tmp_path):
     injected fake stands in for that pre-resolved behavior.
     """
     fake = _FakeNCBI({"Escherichia": ["NCBITaxon:561"]})
-    xform = LPSNTransform(input_dir=FIXTURE_DIR, output_dir=tmp_path, ncbi_impl=fake)
+    xform = LPSNTransform(
+        input_dir=FIXTURE_DIR,
+        output_dir=tmp_path,
+        ncbi_impl=fake,
+        gtdb_index=_NoGTDB(),
+    )
     xform.run()
     edges = _read_tsv(xform.output_edge_file)
     hits = [
@@ -321,3 +358,91 @@ def test_genus_row_now_gets_ncbi_edge_when_synonym_matches(tmp_path):
         and e["predicate"] == "biolink:close_match"
     ]
     assert len(hits) == 1
+
+
+# --------------------------------------------------------------------------
+# GTDB cross-refs
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def lpsn_transform_with_gtdb(tmp_path):
+    """
+    LPSNTransform wired to a fake GTDB index with canned answers.
+
+    Fixture rows and their fake GTDB answers:
+    - genus ``Escherichia`` (1001) → ``GTDB:g__Escherichia``
+    - species ``Escherichia coli`` (1002) → ``GTDB:s__Escherichia_coli``
+    - subspecies ``Escherichia coli inactive`` (1003) → SKIPPED (no rank)
+    - genus ``Bacillus`` (1010) → 2 hits (ambiguous, no edge)
+    - species ``Bacillus subtilis`` (1011) → 0 hits (unmatched)
+    - synonym ``Notgenus orphan`` (1099) → not in map (unmatched)
+    """
+    fake = _FakeGTDB(
+        {
+            ("g__", "Escherichia"): ["GTDB:g__Escherichia"],
+            ("s__", "Escherichia coli"): ["GTDB:s__Escherichia_coli"],
+            ("g__", "Bacillus"): ["GTDB:g__Bacillus", "GTDB:g__Bacillus_A"],
+            # Bacillus subtilis and Notgenus orphan intentionally absent.
+        }
+    )
+    return LPSNTransform(
+        input_dir=FIXTURE_DIR,
+        output_dir=tmp_path,
+        ncbi_impl=_NoNCBI(),
+        gtdb_index=fake,
+    )
+
+
+def test_species_gets_gtdb_close_match(lpsn_transform_with_gtdb):
+    """Species row → single-hit GTDB match emitted as biolink:close_match."""
+    lpsn_transform_with_gtdb.run()
+    edges = _read_tsv(lpsn_transform_with_gtdb.output_edge_file)
+    hits = [
+        e
+        for e in edges
+        if e["subject"] == f"{LPSN_PREFIX}1002"
+        and e["object"] == "GTDB:s__Escherichia_coli"
+        and e["predicate"] == "biolink:close_match"
+    ]
+    assert len(hits) == 1
+    assert hits[0]["relation"] == "skos:closeMatch"
+
+
+def test_genus_gets_gtdb_close_match(lpsn_transform_with_gtdb):
+    """Genus row → GTDB g__ match emitted."""
+    lpsn_transform_with_gtdb.run()
+    edges = _read_tsv(lpsn_transform_with_gtdb.output_edge_file)
+    hits = [
+        e
+        for e in edges
+        if e["subject"] == f"{LPSN_PREFIX}1001"
+        and e["object"] == "GTDB:g__Escherichia"
+        and e["predicate"] == "biolink:close_match"
+    ]
+    assert len(hits) == 1
+
+
+def test_subspecies_row_skips_gtdb(lpsn_transform_with_gtdb):
+    """LPSN subspecies rows never get GTDB edges (no subspecies rank in GTDB)."""
+    lpsn_transform_with_gtdb.run()
+    edges = _read_tsv(lpsn_transform_with_gtdb.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1003" and e["object"].startswith("GTDB:")]
+    assert hits == []
+
+
+def test_ambiguous_gtdb_hit_emits_no_edge(lpsn_transform_with_gtdb):
+    """Multi-hit GTDB lookup → no edge, ambiguous counter incremented."""
+    lpsn_transform_with_gtdb.run()
+    edges = _read_tsv(lpsn_transform_with_gtdb.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1010" and e["object"].startswith("GTDB:")]
+    assert hits == []
+    assert lpsn_transform_with_gtdb._gtdb_stats["ambiguous"] >= 1
+
+
+def test_gtdb_disabled_when_index_absent(lpsn_transform):
+    """The default fixture (no gtdb_index) emits no GTDB edges."""
+    lpsn_transform.run()
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    gtdb_edges = [e for e in edges if e["object"].startswith("GTDB:")]
+    assert gtdb_edges == []


### PR DESCRIPTION
## Summary

Extend the LPSN transform to emit \`biolink:close_match\` edges from every LPSN genus / species row to the corresponding GTDB CURIE whose scientific name matches exactly (rank-aware). Closes the last of the three cross-ref targets flagged in issue #484:

- ✅ BacDive strains (PR #587)
- ✅ NCBITaxon (PR #589, #590)
- ✅ **GTDB** ← this PR

## Design

Pre-load \`data/transformed/gtdb/nodes.tsv\` (~250K entries) into a \`(rank_prefix, normalized_name) → [GTDB_CURIE]\` index via a new \`_GTDBRankNameIndex\`. GTDB CURIEs like \`GTDB:s__Escherichia_coli\` split on the two-letter rank prefix and normalize by replacing underscores with spaces, keying the map on \`("s__", "Escherichia coli")\`. Load cost: <1 s for the full 250K-entry table.

At lookup time, LPSN species rows query the \`s__\` slot with their full_name; genus rows query the \`g__\` slot with the bare genus. Subspecies rows are skipped — GTDB has no subspecies rank; the LPSN subclass_of chain from subspecies → species → GTDB gives the same reachability in two hops without introducing spurious equivalences.

**Automatic variant filtering.** GTDB's phylogenetic placeholder variants like \`s__Escherichia_coli_E\` naturally fall out of the exact-name match because they normalize to a different name (\`Escherichia coli E\`) than LPSN's canonical \`Escherichia coli\`. Same-genus polyphyletic splits like \`g__Bacillus_A\` similarly fail to match \`Bacillus\`. That's why ambiguous rate is **zero** across 34K rows.

## Real-data verification (2026-07-03 GSS + local GTDB output)

| Metric | Value |
|---|---:|
| Matched | **19,362** |
| Unmatched | 14,029 |
| Ambiguous | **0** |
| Wall clock end-to-end | 17.2 s (+0.9 s vs. pre-GTDB) |

**Edge distribution now:**
| Predicate + object | Count |
|---|---:|
| \`close_match\` → \`kgmicrobe.strain:*\` | 73,184 |
| \`close_match\` → \`NCBITaxon:*\` | 26,590 |
| **\`close_match\` → \`GTDB:*\`** | **19,362** (new) |
| \`subclass_of\` → \`lpsn:*\` | 29,695 |
| \`same_as\` → \`lpsn:*\` (correct name) | 7,270 |
| **Total edges** | **156,101** (up from 132,532) |

\`kg-model-review --transform lpsn\`: **0 ERRORs, 0 WARNINGs**.

## Test plan
- [x] \`poetry run tox\` — 374 passed, all 6 envs green.
- [x] 24 fixture-based unit tests (5 new): species → GTDB s__ / genus → GTDB g__ / subspecies-skipped / ambiguous / index-absent.
- [x] Real-data end-to-end run: 17.2 s, 19,362 matches, 0 ambiguous.
- [x] \`kg-model-review\` on real outputs: 0 ERR / 0 WARN.

## Related

Builds on #586 / #587 / #588 / #589 / #590 / #591. Refs #484.

**The LPSN → cross-refs roadmap on #484 is now complete.** Remaining LPSN work per that issue:
- **Full LPSN JSON API ingest** — landed as \`lpsn_api\` in #591 (auth-gated, code-only until credentials + real end-to-end run).
- **Licensing decision** for CC BY-SA 4.0 before LPSN is added to any published \`merge.yaml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)