### PR TITLE
LPSN API: emit molecules → INSDC edges (TYGS-adjacent bridge to NCBI sequence records)

### DIFF
--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -221,6 +221,11 @@ STANDARD_PREFIXES = {
     "kgmicrobe.strain", "kgmicrobe.species", "kgmicrobe.genus",
     # LPSN — List of Prokaryotic names with Standing in Nomenclature
     "lpsn",
+    # INSDC (GenBank/EMBL/DDBJ) sequence accession umbrella, used by
+    # the lpsn_api transform's molecules bridge to NCBI sequence records.
+    "INSDC",
+    # DOI + PubMed CURIEs for publication provenance edges emitted by lpsn_api.
+    "doi", "PMID",
     # bacdive assay prefix
     "assay",
     # COG functional categories

--- a/kg_microbe/transform_utils/lpsn_api/README.md
+++ b/kg_microbe/transform_utils/lpsn_api/README.md
@@ -16,9 +16,14 @@ in LPSN's authenticated JSON API (per-record):
   `nomenclatural_status` / `lpsn_taxonomic_status` prose folded into
   each node's `description`.
 
-Intentionally out of scope (per issue #484): `molecules` (LPSN's 16S
-rRNA links). Natural follow-up if the merged KG grows a
-molecular-sequence layer.
+- **16S rRNA sequence provenance** — `molecules[]` → one
+  `biolink:close_match` edge from each LPSN taxon to every INSDC
+  (GenBank / EMBL / DDBJ) accession its type strain has registered,
+  plus a `biolink:NucleicAcidEntity` stub node per accession. Serves
+  as the TYGS-adjacent bridge to NCBI's sequence records — an LPSN
+  taxon that failed the direct name-match against NCBITaxon can still
+  reach it via `lpsn → INSDC → (NCBI sequence organism) → NCBITaxon`
+  in a downstream query.
 
 ## Prerequisites
 

--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -14,12 +14,14 @@ in LPSN's authenticated JSON API and not in the bulk CSV:
   (relation ``skos:exactMatch``) from a comb. nov. name to its basonym.
 - Node-level detail: ``is_legitimate`` (boolean) and richer
   ``nomenclatural_status`` (free-text) rolled into the description.
-
-INTENTIONALLY OUT OF SCOPE (per the "everything except molecules"
-decision on issue #484):
-
-- ``molecules``: LPSN's 16S rRNA sequence links (INSDC accessions). A
-  natural follow-up if the merged KG grows a molecular-sequence layer.
+- 16S rRNA sequence provenance: ``molecules`` → one
+  ``biolink:close_match`` edge from each LPSN taxon to every INSDC
+  (GenBank/EMBL/DDBJ) accession its type strain has registered, plus
+  a ``biolink:NucleicAcidEntity`` stub node per accession. Serves as
+  the TYGS-adjacent bridge to NCBI's sequence records — an LPSN taxon
+  that failed the direct name-match against NCBITaxon can still be
+  connected via ``lpsn → INSDC → (NCBI sequence organism) →
+  NCBITaxon`` in a downstream query.
 
 Access model
 ------------
@@ -83,10 +85,17 @@ JSON_BASONYM_ID = "basonym_id"
 JSON_IS_LEGITIMATE = "is_legitimate"
 JSON_NOMENCLATURAL_STATUS = "nomenclatural_status"
 JSON_LPSN_TAXONOMIC_STATUS = "lpsn_taxonomic_status"
+JSON_MOLECULES = "molecules"
 
-# CURIE prefixes for publication cross-refs.
+# CURIE prefixes for publication + sequence cross-refs.
 DOI_PREFIX = "doi:"
 PMID_PREFIX = "PMID:"
+INSDC_PREFIX = "INSDC:"
+
+# LPSN's ``molecules`` array uses one of these keys to store the
+# GenBank / EMBL / DDBJ accession per 16S rRNA record. The schema
+# hasn't been published as a formal spec, so we try each in order.
+INSDC_ACCESSION_KEYS = ("insdc_accession", "accession_number", "accession")
 
 # Cache directory relative to the transform's ``input_base_dir``
 # (typically ``data/raw/``).
@@ -335,6 +344,58 @@ class LPSNAPITransform(Transform):
                 self._edge(record_no, CLOSE_MATCH_PREDICATE, f"{PMID_PREFIX}{pmid}", "skos:closeMatch")
             )
             node_writer.writerow(self._stub_publication_node(f"{PMID_PREFIX}{pmid}"))
+
+        # 16S rRNA sequence provenance — the TYGS-adjacent bridge to
+        # NCBI. Every INSDC accession registered by this taxon's type
+        # strain becomes a close_match target so downstream queries can
+        # walk ``lpsn → INSDC → NCBI sequence organism → NCBITaxon``.
+        for accession in self._extract_insdc_accessions(record):
+            edge_writer.writerow(
+                self._edge(record_no, CLOSE_MATCH_PREDICATE, f"{INSDC_PREFIX}{accession}", "skos:closeMatch")
+            )
+            node_writer.writerow(self._stub_sequence_node(f"{INSDC_PREFIX}{accession}"))
+
+    def _extract_insdc_accessions(self, record: dict) -> list:
+        """
+        Return the deduplicated INSDC accessions on ``record[molecules]``.
+
+        LPSN's molecules[] is an array of dicts with per-sequence metadata.
+        The exact key holding the accession isn't published in a formal
+        schema, so we try INSDC_ACCESSION_KEYS in order and take the
+        first non-empty match on each molecule.
+        """
+        molecules = record.get(JSON_MOLECULES) or []
+        if not isinstance(molecules, list):
+            return []
+        seen: set = set()
+        out: list = []
+        for mol in molecules:
+            if not isinstance(mol, dict):
+                continue
+            for key in INSDC_ACCESSION_KEYS:
+                raw = mol.get(key)
+                if not raw:
+                    continue
+                acc = str(raw).strip()
+                if not acc or acc in seen:
+                    break
+                seen.add(acc)
+                out.append(acc)
+                break
+        return out
+
+    def _stub_sequence_node(self, curie: str) -> list:
+        """Build a minimal nodes.tsv row for an INSDC sequence stub target."""
+        headers = self.node_header
+        row = [""] * len(headers)
+        for col, val in {
+            "id": curie,
+            "category": "biolink:NucleicAcidEntity",
+            "provided_by": LPSN_KNOWLEDGE_SOURCE,
+        }.items():
+            if col in headers:
+                row[headers.index(col)] = val
+        return row
 
     def _make_enrichment_node(self, record_no: str, record: dict) -> list:
         """

--- a/kg_microbe/transform_utils/prefixmap.json
+++ b/kg_microbe/transform_utils/prefixmap.json
@@ -8,6 +8,7 @@
     "kgmicrobe.strain": "https://example.org/kgmicrobe/strain/",
     "GTDB": "https://gtdb.ecogenomic.org/tree?r=",
     "lpsn": "https://lpsn.dsmz.de/",
+    "INSDC": "https://www.ncbi.nlm.nih.gov/nuccore/",
     "NCBIGene": "http://identifiers.org/ncbigene/",
     "chemrof": "https://w3id.org/chemrof/",
     "orcid": "https://orcid.org/",

--- a/tests/test_lpsn_api_transform.py
+++ b/tests/test_lpsn_api_transform.py
@@ -67,6 +67,13 @@ def api_records():
             "is_legitimate": True,
             "nomenclatural_status": "correct name",
             "lpsn_taxonomic_status": "correct name",
+            # Two type-strain 16S records with INSDC accessions. Exercises
+            # both dict-key alternatives so the schema tolerance is verified.
+            "molecules": [
+                {"insdc_accession": "M87049", "gene": "16S rRNA"},
+                {"accession_number": "AB030918", "gene": "16S rRNA"},
+                {"insdc_accession": "M87049"},  # dup; must be dedup'd
+            ],
         },
         "1005": {
             "id": 1005,
@@ -78,6 +85,7 @@ def api_records():
             "is_legitimate": True,
             "nomenclatural_status": "correct name (comb. nov.)",
             "lpsn_taxonomic_status": "",
+            "molecules": [],  # no molecules — must not emit any INSDC edge
         },
     }
 
@@ -231,3 +239,38 @@ def test_missing_gss_raises_file_not_found(tmp_path):
     )
     with pytest.raises(FileNotFoundError, match="LPSN GSS transform output"):
         xform.run()
+
+
+def test_molecules_emit_insdc_close_match_edges(api_transform):
+    """Each unique INSDC accession → biolink:close_match edge from lpsn: to INSDC:."""
+    api_transform.run()
+    edges = _read_tsv(api_transform.output_edge_file)
+    targets = {
+        e["object"]
+        for e in edges
+        if e["subject"] == f"{LPSN_PREFIX}1002"
+        and e["object"].startswith("INSDC:")
+        and e["predicate"] == "biolink:close_match"
+    }
+    assert targets == {"INSDC:M87049", "INSDC:AB030918"}
+    # Dedup guard: the duplicate M87049 in the fixture must appear
+    # exactly once, not twice.
+    m87049 = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1002" and e["object"] == "INSDC:M87049"]
+    assert len(m87049) == 1
+
+
+def test_molecules_emit_nucleic_acid_stub_nodes(api_transform):
+    """INSDC stub targets land as biolink:NucleicAcidEntity so edges aren't dangling."""
+    api_transform.run()
+    nodes = _read_tsv(api_transform.output_node_file)
+    seq = {n["id"] for n in nodes if n["category"] == "biolink:NucleicAcidEntity"}
+    assert "INSDC:M87049" in seq
+    assert "INSDC:AB030918" in seq
+
+
+def test_empty_molecules_emit_no_insdc_edges(api_transform):
+    """Record 1005 with molecules=[] emits no INSDC edges (or stub nodes)."""
+    api_transform.run()
+    edges = _read_tsv(api_transform.output_edge_file)
+    hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1005" and e["object"].startswith("INSDC:")]
+    assert hits == []


### PR DESCRIPTION
## Summary

Extend the \`lpsn_api\` transform to fetch the \`molecules[]\` field from each LPSN JSON record and emit one \`biolink:close_match\` edge per INSDC (GenBank / EMBL / DDBJ) accession found there, plus a matching \`biolink:NucleicAcidEntity\` stub node.

This is the **TYGS-adjacent bridge** to NCBI's sequence records: an LPSN taxon that failed the direct name-match against NCBITaxon can still reach it via \`lpsn → INSDC → (NCBI sequence organism) → NCBITaxon\` in a downstream query. Every INSDC record on NCBI carries the source organism's NCBITaxon ID as metadata.

## Rationale

The user asked whether TYGS could provide additional LPSN → NCBI mapping. TYGS itself doesn't publish a bulk LPSN → NCBI index — its API is per-job, not a catalog. But LPSN's own JSON API includes the same 16S rRNA sequence identifiers TYGS uses for its genome-based classification — the \`molecules\` field. This was intentionally out of scope on the initial \`lpsn_api\` PR (#591) per the "everything except molecules" scope call at the time, but is now the shortest path to the TYGS-adjacent bridge.

## Schema tolerance

LPSN's API docs describe \`molecules[]\` as "Array of sequence data (16S rRNA only as of 2023)" but don't publish a formal per-object schema. The transform tries three well-known key names in order (\`insdc_accession\`, \`accession_number\`, \`accession\`) and takes the first non-empty match on each molecule. Duplicates within one record are deduplicated.

## Prefix registration

- \`INSDC\` prefix added to \`kg_microbe/transform_utils/prefixmap.json\` → NCBI nuccore URL.
- \`INSDC\`, \`doi\`, \`PMID\` added to \`kg-model-review\`'s \`STANDARD_PREFIXES\` so the review skill accepts \`lpsn_api\`'s targets.

## Test plan
- [x] \`poetry run tox\` — **377 passed**, all 6 envs green.
- [x] 3 new fixture-based tests: multi-molecule emits multi-INSDC deduped edges, INSDC stubs land as \`biolink:NucleicAcidEntity\`, empty molecules[] emits no edges.
- [ ] End-to-end verification against real LPSN API — deferred (still auth-gated).

## Related

Builds on #591. Refs #484. Closes the "additional LPSN ↔ NCBI mapping via TYGS" thread on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)