### PR TITLE
BacDive: emit biolink:in_taxon edges to LPSN taxonomic-name records

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -87,6 +87,8 @@ from kg_microbe.transform_utils.constants import (
     HAS_PHENOTYPE,
     HAS_PHENOTYPE_PREDICATE,
     ID_COLUMN,
+    IN_TAXON_PREDICATE,
+    IN_TAXON_RELATION,
     INFERRED_SUBCLASS_RELATION,
     INTERACTS_WITH_RELATION,
     IS_GROWN_IN,
@@ -258,6 +260,16 @@ class BacDiveTransform(Transform):
         self.assay_raw_data: Optional[dict] = None  # Raw JSON from assay_kits_simple.json
         self.assay_nodes_generated: Optional[List] = None  # Generated assay node rows
         self.assay_edges_generated: Optional[List] = None  # Generated assay→entity edge rows
+
+        # LPSN name → record_no index, loaded from data/raw/lpsn_gss.csv when
+        # present. Used to emit bacdive:<id> → biolink:close_match →
+        # lpsn:<record_no> for every strain whose LPSN block names an
+        # exactly-known LPSN species. Silent skip on missing CSV so a fresh
+        # checkout that hasn't downloaded LPSN still runs the BacDive
+        # transform cleanly.
+        self.lpsn_name_index = self._load_lpsn_name_index()
+        # Track cross-ref outcomes for the end-of-run summary.
+        self._lpsn_stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
 
         # Load NCBITaxon labels from ontologies transform output (fast TSV lookup).
         # NOTE: This depends on TSV files produced by the ontologies transform being present.
@@ -447,6 +459,83 @@ class BacDiveTransform(Transform):
         for key, value in METABOLITE_MAP.items():
             if value == name:
                 return key
+        return None
+
+    def _load_lpsn_name_index(self) -> Dict[str, list]:
+        """
+        Load ``data/raw/lpsn_gss.csv`` into ``{full_name: [record_no, ...]}``.
+
+        The GSS CSV isn't shipped in the repo (LPSN download requires a
+        free account) so absence is expected and non-fatal — we log
+        and return an empty dict, and the LPSN cross-ref emission
+        becomes a no-op. Fast enough (~34K rows) that no dedicated
+        cache is needed.
+        """
+        lpsn_csv = Path(self.input_base_dir) / "lpsn_gss.csv"
+        if not lpsn_csv.is_file():
+            logger.info(
+                "LPSN GSS CSV not found at %s — BacDive → LPSN cross-refs skipped. "
+                "Download the GSS CSV from https://lpsn.dsmz.de/downloads and place "
+                "it at data/raw/lpsn_gss.csv to enable.",
+                lpsn_csv,
+            )
+            return {}
+        name_index: Dict[str, list] = {}
+        with open(lpsn_csv, newline="") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                record_no = (row.get("record_no") or "").strip()
+                if not record_no:
+                    continue
+                genus = (row.get("genus_name") or "").strip()
+                sp = (row.get("sp_epithet") or "").strip()
+                subsp = (row.get("subsp_epithet") or "").strip()
+                # Assemble the same scientific-name form BacDive's LPSN
+                # block reports (`species` field): "Genus species [subspecies]".
+                full_name = " ".join(p for p in (genus, sp, subsp) if p)
+                if not full_name:
+                    continue
+                name_index.setdefault(full_name, []).append(record_no)
+        logger.info(
+            "LPSN name index loaded: %d distinct names for BacDive cross-refs",
+            len(name_index),
+        )
+        return name_index
+
+    def _lookup_lpsn(self, lpsn_block: dict) -> Optional[str]:
+        """
+        Return the LPSN ``record_no`` for ``lpsn_block``, or None.
+
+        BacDive's LPSN block reports the species-rank name in the
+        ``species`` field (e.g. ``"Moraxella canis"``); subspecies rows
+        add the epithet at the end. We match on ``species`` first
+        because it's the cleanest form; if that fails we fall back to
+        the first three tokens of ``full scientific name`` (stripping
+        the HTML italics tags LPSN wraps around genus/species).
+        """
+        if not lpsn_block or not self.lpsn_name_index:
+            return None
+        # Prefer the plain species field.
+        candidate = (lpsn_block.get("species") or "").strip()
+        if not candidate:
+            # Fallback: strip the HTML tags from full scientific name and
+            # keep the first two words (genus + species). Authorities and
+            # dates (e.g. "Jannes et al. 1993") sit past that, so slicing
+            # is safe.
+            raw = (lpsn_block.get("full scientific name") or "").strip()
+            cleaned = re.sub(r"<[^>]+>", "", raw).strip()
+            candidate = " ".join(cleaned.split()[:2]) if cleaned else ""
+        if not candidate:
+            return None
+
+        hits = self.lpsn_name_index.get(candidate, [])
+        if len(hits) == 1:
+            self._lpsn_stats["matched"] += 1
+            return hits[0]
+        if not hits:
+            self._lpsn_stats["unmatched"] += 1
+        else:
+            self._lpsn_stats["ambiguous"] += 1
         return None
 
     def _init_ontology_adapters(self):
@@ -1641,9 +1730,7 @@ class BacDiveTransform(Transform):
                     # cover obsolete / out-of-version CHEBI IDs (e.g. CHEBI:17004
                     # D-Tagatose) that would otherwise become biolink:NamedThing
                     # stubs at merge time.
-                    assay_target_nodes = generate_assay_entity_nodes(
-                        self.assay_raw_data, self.node_header
-                    )
+                    assay_target_nodes = generate_assay_entity_nodes(self.assay_raw_data, self.node_header)
                     if assay_target_nodes:
                         print(f"Writing {len(assay_target_nodes)} assay-target stub nodes...")
                         node_writer.writerows(assay_target_nodes)
@@ -2349,6 +2436,37 @@ class BacDiveTransform(Transform):
                         writer_2.writerow(phys_and_meta_data)
 
                     lpsn = name_tax_classification.get(LPSN)
+                    # BacDive → LPSN cross-ref via name-match against the
+                    # LPSN GSS index loaded in __init__. No-op when the CSV
+                    # isn't on disk, or when the LPSN block is absent /
+                    # ambiguous. Emitted per strain so the merge step
+                    # naturally reconciles bacdive:<id> with the LPSN
+                    # transform's lpsn:<record_no> nodes when both sources
+                    # ingest the same taxonomy.
+                    lpsn_record_no = self._lookup_lpsn(lpsn) if lpsn else None
+                    if lpsn_record_no:
+                        # ``biolink:in_taxon`` (RO:0002162) is the correct
+                        # predicate for a specific strain being classified
+                        # within an LPSN taxonomic-name record — the strain
+                        # is an instance of that taxon, not identical to it
+                        # (which would be exact_match) and not a subclass
+                        # (which would be subclass_of).
+                        knowledge_level, agent_type = self._add_edge_metadata(
+                            IN_TAXON_PREDICATE, IN_TAXON_RELATION, f"lpsn:{lpsn_record_no}"
+                        )
+                        edge_writer.writerow(
+                            [
+                                BACDIVE_PREFIX + key,
+                                IN_TAXON_PREDICATE,
+                                f"lpsn:{lpsn_record_no}",
+                                IN_TAXON_RELATION,
+                                self.knowledge_source,
+                                knowledge_level,
+                                agent_type,
+                                "",  # value
+                                "",  # unit
+                            ]
+                        )
                     synonyms = lpsn.get(SYNONYMS, {}) if lpsn and SYNONYMS in lpsn else None
                     if isinstance(synonyms, list):
                         synonym_parsed = " | ".join(synonym.get(SYNONYM, {}) for synonym in synonyms)
@@ -3155,6 +3273,13 @@ class BacDiveTransform(Transform):
         )
         drop_duplicates(self.output_edge_file)
 
+        logger.info(
+            "[bacdive] LPSN cross-refs: %s matched, %s unmatched, %s ambiguous",
+            f"{self._lpsn_stats['matched']:,}",
+            f"{self._lpsn_stats['unmatched']:,}",
+            f"{self._lpsn_stats['ambiguous']:,}",
+        )
+
 
 # Tail of every kgmicrobe.strain CURIE the BacDive transform emits. Built
 # inline so this module-level helper doesn't need to import the (already
@@ -3203,7 +3328,7 @@ class _StrainProvenanceWriter:
             # Look at subject (col 0) then object (col 2) for a strain CURIE.
             for endpoint in (row[0], row[2] if len(row) > 2 else None):
                 if isinstance(endpoint, str) and endpoint.startswith(_STRAIN_BACDIVE_PREFIX):
-                    bacdive_id = endpoint[len(_STRAIN_BACDIVE_PREFIX):]
+                    bacdive_id = endpoint[len(_STRAIN_BACDIVE_PREFIX) :]
                     row[self._ks_idx] = f"['{self._ks}', 'bacdive:{bacdive_id}']"
                     break
         self._inner.writerow(row)

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -532,6 +532,12 @@ MOLECULAR_ACTIVITY_CATEGORY = "biolink:MolecularActivity"  # For GO molecular fu
 BIOLOGICAL_PROCESS_CATEGORY = "biolink:BiologicalProcess"  # For GO biological process terms
 CELLULAR_COMPONENT_CATEGORY = "biolink:CellularComponent"  # For GO cellular component terms
 RDFS_SUBCLASS_OF = "rdfs:subClassOf"
+# "in taxon" relation for organism → taxonomic-classification edges. Semantically
+# stronger than close_match (asserts membership), but weaker than subclass_of
+# (which would demand ontological subsumption). Used by BacDive → LPSN edges
+# where a strain is classified within an LPSN taxonomic-name record.
+IN_TAXON_PREDICATE = "biolink:in_taxon"
+IN_TAXON_RELATION = "RO:0002162"
 # Relation for inferred taxonomic relationships
 INFERRED_SUBCLASS_RELATION = "kgmicrobe:inferred_subClassOf"
 SUBCLASS_PREDICATE = "biolink:subclass_of"

--- a/tests/test_bacdive_lpsn_crossref.py
+++ b/tests/test_bacdive_lpsn_crossref.py
@@ -1,0 +1,217 @@
+"""
+Tests for BacDive → LPSN cross-ref helpers.
+
+We exercise the ``_load_lpsn_name_index`` and ``_lookup_lpsn`` helpers in
+isolation because the full ``BacDiveTransform.__init__`` pulls in the
+NCBITaxon SQLite adapter (~13 GB) plus every METPO / GO / ChEBI adapter,
+which makes a live end-to-end unit test impractical. Skipping the heavy
+constructor via ``__new__`` and populating only the fields the helpers
+touch is the standard pattern for isolating a single method in a
+class that owns a heavy constructor.
+"""
+
+import csv
+from pathlib import Path
+
+from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
+
+
+def _bare_transform(lpsn_csv: Path | None) -> BacDiveTransform:
+    """
+    Return a ``BacDiveTransform`` instance with only the fields the LPSN helpers need.
+
+    ``__init__`` isn't called (that would pull the NCBI/GO/ChEBI adapters
+    and the METPO mapping loaders). Instead we allocate via ``__new__``
+    and hand-set the two attributes ``_load_lpsn_name_index`` and
+    ``_lookup_lpsn`` use.
+    """
+    x = BacDiveTransform.__new__(BacDiveTransform)
+    x.input_base_dir = lpsn_csv.parent if lpsn_csv else Path("/nonexistent")
+    x._lpsn_stats = {"matched": 0, "unmatched": 0, "ambiguous": 0}
+    x.lpsn_name_index = x._load_lpsn_name_index()
+    return x
+
+
+def _write_gss(path: Path, rows):
+    """Write a minimal LPSN GSS CSV that ``_load_lpsn_name_index`` can parse."""
+    with open(path, "w", newline="") as fh:
+        w = csv.DictWriter(
+            fh,
+            fieldnames=[
+                "genus_name",
+                "sp_epithet",
+                "subsp_epithet",
+                "reference",
+                "status",
+                "authors",
+                "address",
+                "risk_grp",
+                "nomenclatural_type",
+                "record_no",
+                "record_lnk",
+            ],
+        )
+        w.writeheader()
+        for row in rows:
+            w.writerow(row)
+
+
+def test_missing_csv_returns_empty_index(tmp_path):
+    """No lpsn_gss.csv on disk → empty index, no exceptions."""
+    x = _bare_transform(tmp_path / "no_such.csv")
+    assert x.lpsn_name_index == {}
+    # Lookup on an empty index must silently return None.
+    assert x._lookup_lpsn({"species": "Escherichia coli"}) is None
+    assert x._lpsn_stats == {"matched": 0, "unmatched": 0, "ambiguous": 0}
+
+
+def test_species_lookup_via_species_field(tmp_path):
+    """The ``species`` field on the LPSN block maps to a single record_no."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            {
+                "genus_name": "Escherichia",
+                "sp_epithet": "coli",
+                "record_no": "1002",
+                "address": "https://lpsn.dsmz.de/species/escherichia-coli",
+                "status": "correct name",
+                "authors": "",
+                "reference": "",
+                "subsp_epithet": "",
+                "risk_grp": "",
+                "nomenclatural_type": "",
+                "record_lnk": "",
+            }
+        ],
+    )
+    x = _bare_transform(csv_path)
+    result = x._lookup_lpsn({"species": "Escherichia coli"})
+    assert result == "1002"
+    assert x._lpsn_stats["matched"] == 1
+    assert x._lpsn_stats["unmatched"] == 0
+
+
+def test_full_scientific_name_fallback_strips_html(tmp_path):
+    """When ``species`` is absent, parse the first two tokens of ``full scientific name``."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            {
+                "genus_name": "Moraxella",
+                "sp_epithet": "canis",
+                "record_no": "555",
+                "address": "https://lpsn.dsmz.de/species/moraxella-canis",
+                "status": "correct name",
+                "authors": "",
+                "reference": "",
+                "subsp_epithet": "",
+                "risk_grp": "",
+                "nomenclatural_type": "",
+                "record_lnk": "",
+            }
+        ],
+    )
+    x = _bare_transform(csv_path)
+    # BacDive's raw full-scientific-name string wraps genus/species in <I> tags
+    # and appends the authority + year.
+    lpsn_block = {
+        "full scientific name": "<I>Moraxella</I> <I>canis</I> Jannes et al. 1993",
+    }
+    assert x._lookup_lpsn(lpsn_block) == "555"
+
+
+def test_unknown_species_counts_as_unmatched(tmp_path):
+    """A species name not in the LPSN index → None, unmatched counter incremented."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            {
+                "genus_name": "Escherichia",
+                "sp_epithet": "coli",
+                "record_no": "1002",
+                "address": "",
+                "status": "",
+                "authors": "",
+                "reference": "",
+                "subsp_epithet": "",
+                "risk_grp": "",
+                "nomenclatural_type": "",
+                "record_lnk": "",
+            }
+        ],
+    )
+    x = _bare_transform(csv_path)
+    assert x._lookup_lpsn({"species": "Notgenus notspecies"}) is None
+    assert x._lpsn_stats["unmatched"] == 1
+    assert x._lpsn_stats["matched"] == 0
+
+
+def test_ambiguous_species_emits_no_edge(tmp_path):
+    """Same species name mapping to two LPSN record_no's → None, ambiguous counter incremented."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            {
+                "genus_name": "Escherichia",
+                "sp_epithet": "coli",
+                "record_no": "1002",
+                "address": "",
+                "status": "correct name",
+                "authors": "",
+                "reference": "",
+                "subsp_epithet": "",
+                "risk_grp": "",
+                "nomenclatural_type": "",
+                "record_lnk": "",
+            },
+            {
+                "genus_name": "Escherichia",
+                "sp_epithet": "coli",
+                "record_no": "9999",
+                "address": "",
+                "status": "later heterotypic synonym",
+                "authors": "",
+                "reference": "",
+                "subsp_epithet": "",
+                "risk_grp": "",
+                "nomenclatural_type": "",
+                "record_lnk": "",
+            },
+        ],
+    )
+    x = _bare_transform(csv_path)
+    assert x._lookup_lpsn({"species": "Escherichia coli"}) is None
+    assert x._lpsn_stats["ambiguous"] == 1
+
+
+def test_blank_lpsn_block_returns_none(tmp_path):
+    """An empty LPSN block → None, no stat increment."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            {
+                "genus_name": "Escherichia",
+                "sp_epithet": "coli",
+                "record_no": "1002",
+                "address": "",
+                "status": "correct name",
+                "authors": "",
+                "reference": "",
+                "subsp_epithet": "",
+                "risk_grp": "",
+                "nomenclatural_type": "",
+                "record_lnk": "",
+            }
+        ],
+    )
+    x = _bare_transform(csv_path)
+    assert x._lookup_lpsn({}) is None
+    assert x._lookup_lpsn(None) is None
+    # None + empty are treated as no-op; unmatched not incremented.
+    assert x._lpsn_stats["unmatched"] == 0


### PR DESCRIPTION
## Summary

Parse the LPSN taxonomic-classification block that BacDive publishes per strain, look up the species scientific name in a local LPSN GSS name → record_no index loaded at transform startup, and emit one edge per matched strain:

\`\`\`
bacdive:<id>  --biolink:in_taxon (RO:0002162)-->  lpsn:<record_no>
\`\`\`

Closes the BacDive-side of the LPSN cross-ref work from #484.

## Predicate choice

An earlier draft used \`biolink:close_match\`. That's semantically weak here because BacDive strains and LPSN records live at **different taxonomic levels**:

| Node | What it is |
|---|---|
| \`bacdive:12345\` | A specific **strain / isolate** (a physical culture) |
| \`lpsn:1002\` | A **taxonomic-name record** at species rank |

The right relation is \`biolink:in_taxon\` (relation \`RO:0002162\`), which biolink defines as "connects an entity to its taxonomic classification" — exactly the strain-belongs-to-species-taxon relationship.

- \`exact_match\` / \`same_as\`: wrong. A strain isn't identical to a species.
- \`close_match\`: technically valid but semantically loose.
- \`subclass_of\`: wrong. A strain is an instance of a species, not a subclass. (Existing bacdive → NCBITaxon links use subclass_of; that legacy pattern isn't disturbed here.)
- \`in_taxon\`: correct. Instance-of-taxon relationship.

New constants \`IN_TAXON_PREDICATE\` + \`IN_TAXON_RELATION\` added to \`kg_microbe/transform_utils/constants.py\` for reuse.

## Name matching

BacDive's LPSN block reports the species name in the \`species\` field (e.g. \`"Moraxella canis"\`) — no LPSN record_no is published directly, so we do exact-name matching against the LPSN GSS CSV loaded at \`data/raw/lpsn_gss.csv\`.

Order of attempts:
1. \`lpsn_block["species"]\` — cleanest, canonical form.
2. Fallback: strip the HTML italics tags from \`full scientific name\`, keep the first two whitespace-separated tokens (genus + species). Authorities and dates (\`"Jannes et al. 1993"\`) sit past that.

Only **single-hit** matches emit an edge. Zero- and multi-hit rows are tracked in \`_lpsn_stats\` and logged at end of run.

## Data source

LPSN GSS CSV at \`data/raw/lpsn_gss.csv\` (same location as the LPSN transform's input). Silent skip on missing CSV so a fresh checkout that hasn't downloaded LPSN still runs the BacDive transform cleanly.

## Test plan
- [x] \`poetry run tox\` — **383 passed**, all 6 envs green.
- [x] 6 new fixture-based tests in \`tests/test_bacdive_lpsn_crossref.py\`: missing CSV, species-field lookup, HTML-stripped fallback, unknown species, ambiguous name, blank block.
- [ ] End-to-end verification against real BacDive JSON + real LPSN CSV — deferred; the BacDive transform's full pipeline requires the 13 GB NCBITaxon adapter + BacDive API dump + several other heavy inputs.

## Related

Builds on the LPSN work stream (#586–#593). Refs #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)