### PR TITLE
kg-model-review: integrate monarch-initiative/kgxval biolink validator

### DIFF
--- a/.claude/skills/kg-model-review/SKILL.md
+++ b/.claude/skills/kg-model-review/SKILL.md
@@ -249,8 +249,10 @@ dependency, so it runs in an isolated [`uv`](https://docs.astral.sh/uv/)
 environment. `--kgxval` shells out to
 `uv run --no-project --python 3.13 --with 'kgxval @ git+https://github.com/monarch-initiative/kgxval'`
 (`--no-project` so uv ignores kg-microbe's poetry `pyproject.toml`).
-If `uv` is missing or offline, the section is skipped with a note (the main
-review still completes). Set `KGXVAL_SOURCE` to a local checkout
+If `uv` is missing the section is skipped; if the run fails (offline, bad
+tarball, tool error) it degrades to a short "failed/skipped" note — either way
+the main review still completes and never raises. Set `KGXVAL_SOURCE` to a
+local checkout
 (e.g. `kgxval @ file:///abs/path/to/kgxval`) for pinned/offline runs.
 
 **How it's wired.** `kgxval_validate.py` (in this skill dir) is the driver.

--- a/.claude/skills/kg-model-review/SKILL.md
+++ b/.claude/skills/kg-model-review/SKILL.md
@@ -22,9 +22,13 @@ When this skill is invoked, run `kg_model_review.py` with the specified scope an
 
 1. **Identify scope** from user args (default: all transforms + merged)
 2. **Run the review script**: `poetry run python .claude/skills/kg-model-review/kg_model_review.py [args]`
+   - For a **merged-KG review**, add `--kgxval` to also run the external
+     [KGXVal](https://github.com/monarch-initiative/kgxval) Biolink domain/range
+     validator (see the KGXVal integration section below). Include it whenever
+     reviewing a merge / preparing a release; it complements the built-in checks.
 3. **Report findings** grouped by:
    - Transform name
-   - Check category (KGX / Biolink / METPO / Prefix)
+   - Check category (KGX / Biolink / METPO / Prefix / KGXVal)
    - Severity (ERROR / WARNING / INFO)
 4. **Highlight** any systematic issues that suggest a transform-level fix is needed
 
@@ -189,6 +193,11 @@ This section is what you hand to the upstream curation repos
 /kg-model-review --merged --mappings --format md
 ```
 
+### Merged KG plus external KGXVal biolink validation
+```
+/kg-model-review --merged --kgxval --format md
+```
+
 ### Verbose output with example violations
 ```
 /kg-model-review --transform bacdive --verbose
@@ -213,6 +222,56 @@ This section is what you hand to the upstream curation repos
   JSON-LD CURIE context). Off by default because it surfaces deviations we
   accept by design (e.g. KG-Microbe prefixes not in biolink's JSON-LD context,
   edges without `id` column). Use before a release to see the full gap list.
+- `--kgxval` — additionally run the external
+  [monarch-initiative/kgxval](https://github.com/monarch-initiative/kgxval)
+  Biolink validator on the merged KG (requires `--merged`). Appends a "KGXVal
+  biolink validation" section to the report. See below.
+
+## KGXVal integration (external Biolink domain/range validator)
+
+[KGXVal](https://github.com/monarch-initiative/kgxval) is Monarch's KGX→Biolink
+validator. It uses BMT to check, for every unique **(subject-category,
+object-category, predicate)** signature in the graph, that:
+
+- **BAD BIOLINK** — the predicate (and every edge category) is a real Biolink
+  element;
+- **BAD SUBJECT** — the subject's categories fall within the predicate's Biolink
+  **domain** (`get_descendants(domain)`);
+- **BAD OBJECT** — the object's categories fall within the predicate's Biolink
+  **range**.
+
+This is an authoritative, BMT-computed complement to this skill's own
+hand-curated `DomainRange` check — it derives the legal subject/object classes
+straight from the published Biolink model rather than a maintained allowlist.
+
+**Prerequisites.** KGXVal targets **Python ≥3.13** and is **not** a kg-microbe
+dependency, so it runs in an isolated [`uv`](https://docs.astral.sh/uv/)
+environment. `--kgxval` shells out to
+`uv run --no-project --python 3.13 --with 'kgxval @ git+https://github.com/monarch-initiative/kgxval'`
+(`--no-project` so uv ignores kg-microbe's poetry `pyproject.toml`).
+If `uv` is missing or offline, the section is skipped with a note (the main
+review still completes). Set `KGXVAL_SOURCE` to a local checkout
+(e.g. `kgxval @ file:///abs/path/to/kgxval`) for pinned/offline runs.
+
+**How it's wired.** `kgxval_validate.py` (in this skill dir) is the driver.
+KGXVal's `Ingest` reads TSV natively, but its `TSVDictGen` does **not** split
+KG-Microbe's pipe-delimited `category` column, and the `ingest_summary` CLI
+ships with the biolink sub/obj check disabled. So the driver:
+1. extracts `merged-kg_{nodes,edges}.tsv` from `data/merged/merged-kg.tar.gz`;
+2. builds the node→category map itself — splitting on `|` and keeping only the
+   `biolink:` components (so `METPO:1001000|biolink:Procedure` and METPO-only
+   nodes don't create phantom errors);
+3. calls KGXVal's own `findSubObjErrorsForIngest`;
+4. writes an error CSV that this skill summarizes.
+
+**Reading the output.** `BAD BIOLINK` is split into **METPO-native predicates**
+(`METPO:2000xxx` — KG-Microbe emits these intentionally and maps them to biolink
+in `metatraits.py`; expected, not a defect) vs **other unknown predicates**
+(actionable). `BAD SUBJECT` / `BAD OBJECT` list the predicate and the offending
+actual categories; `_(no biolink category)_` means the endpoint node carries no
+`biolink:` category at all. Expect a large METPO-native `BAD BIOLINK` count on
+KG-Microbe by design — focus on the non-METPO predicates and the domain/range
+table.
 
 ## Output Format
 

--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -14,9 +14,13 @@ import csv
 import gzip
 import io
 import json
+import os
 import re
+import shutil
+import subprocess
 import sys
 import tarfile
+import tempfile
 import yaml
 from collections import defaultdict
 from datetime import date, datetime
@@ -1529,6 +1533,128 @@ def run_kgx_strict(path: Path, kind: str, max_rows: int) -> list:
     return findings
 
 
+# Default source spec for the external kgxval tool. Overridable via the
+# KGXVAL_SOURCE env var to a local checkout (path or `name @ file://…`) for
+# offline / pinned runs.
+KGXVAL_DEFAULT_SOURCE = "kgxval @ git+https://github.com/monarch-initiative/kgxval"
+
+
+def _extract_tar_member(tar_path: Path, member_name: str, dest: Path) -> bool:
+    """Extract a single member (root or nested under one top dir) to dest. True on success."""
+    with tarfile.open(tar_path, "r:gz") as tf:
+        member = None
+        try:
+            member = tf.getmember(member_name)
+        except KeyError:
+            for m in tf.getmembers():
+                if m.name.endswith("/" + member_name) or m.name == member_name:
+                    member = m
+                    break
+        if member is None:
+            return False
+        src = tf.extractfile(member)
+        if src is None:
+            return False
+        with src, open(dest, "wb") as fdst:
+            shutil.copyfileobj(src, fdst)
+    return True
+
+
+def _summarize_kgxval_csv(out_csv: Path) -> str:
+    """Render kgxval's error CSV as a contextualized markdown section.
+
+    Splits BAD BIOLINK into METPO-native predicates (KG-Microbe emits these
+    intentionally and maps them to biolink downstream — expected) vs genuinely
+    unknown predicates (actionable). Surfaces the top BAD SUBJECT / BAD OBJECT
+    domain/range violations, which are the real modeling signal.
+    """
+    by_type: dict = defaultdict(int)
+    bad_biolink_metpo: set = set()
+    bad_biolink_other: set = set()
+    domain_range: dict = defaultdict(int)  # (predicate, error, actual_cats) -> count
+    with open(out_csv, newline="") as fh:
+        for row in csv.DictReader(fh):
+            err = row.get("ERROR", "")
+            pred = row.get("PREDICATE", "")
+            by_type[err] += 1
+            if err == "BAD BIOLINK":
+                (bad_biolink_metpo if pred.startswith("METPO:") else bad_biolink_other).add(pred)
+            elif err in ("BAD SUBJECT", "BAD OBJECT"):
+                domain_range[(pred, err, row.get("ACTUAL_CATEGORIES", ""))] += 1
+
+    lines = ["## KGXVal biolink validation",
+             "",
+             "_External check: [monarch-initiative/kgxval](https://github.com/monarch-initiative/kgxval) "
+             "validates every unique (subject-category, object-category, predicate) signature against "
+             "BMT's Biolink domain/range descendants._",
+             "",
+             "| Error type | distinct signatures |",
+             "|---|---:|"]
+    for etype in ("BAD BIOLINK", "BAD SUBJECT", "BAD OBJECT"):
+        lines.append(f"| {etype} | {by_type.get(etype, 0)} |")
+    lines.append("")
+    lines.append(f"**BAD BIOLINK predicates:** {len(bad_biolink_metpo)} METPO-native "
+                 "(expected — KG-Microbe maps these to biolink downstream), "
+                 f"{len(bad_biolink_other)} other.")
+    if bad_biolink_other:
+        lines.append("")
+        lines.append("Non-METPO unknown predicates (actionable):")
+        for p in sorted(bad_biolink_other)[:25]:
+            lines.append(f"- `{p}`")
+    if domain_range:
+        lines.append("")
+        lines.append("Top domain/range violations (predicate → offending actual categories):")
+        lines.append("")
+        lines.append("| predicate | error | actual categories | count |")
+        lines.append("|---|---|---|---:|")
+        for (pred, err, actual), cnt in sorted(domain_range.items(), key=lambda kv: -kv[1])[:20]:
+            actual_disp = actual if actual else "_(no biolink category)_"
+            lines.append(f"| `{pred}` | {err} | {actual_disp} | {cnt} |")
+    return "\n".join(lines)
+
+
+def run_kgxval_biolink_validation(merged_dir: Path) -> "str | None":
+    """Run kgxval's biolink validation on the merged KG in an isolated uv env.
+
+    kgxval requires Python >=3.13 and is not a kg-microbe dependency, so it runs
+    via ``uv run --with``. Returns a markdown section for the report, or a short
+    skipped/failed note (never raises) so the main review always completes.
+    """
+    tar_path = merged_dir / "merged-kg.tar.gz"
+    if not tar_path.exists():
+        print(f"  [kgxval] {tar_path} not found; skipping", file=sys.stderr)
+        return "## KGXVal biolink validation\n\n_Skipped: merged-kg.tar.gz not found._"
+    if shutil.which("uv") is None:
+        print("  [kgxval] `uv` not on PATH; skipping (see https://docs.astral.sh/uv/)", file=sys.stderr)
+        return "## KGXVal biolink validation\n\n_Skipped: `uv` not installed (needed to run the Python≥3.13 tool)._"
+
+    driver = Path(__file__).parent / "kgxval_validate.py"
+    source = os.environ.get("KGXVAL_SOURCE", KGXVAL_DEFAULT_SOURCE)
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        nodes_p, edges_p, out_csv = tdp / "nodes.tsv", tdp / "edges.tsv", tdp / "kgxval_errors.csv"
+        for member, dest in (("merged-kg_nodes.tsv", nodes_p), ("merged-kg_edges.tsv", edges_p)):
+            if not _extract_tar_member(tar_path, member, dest):
+                print(f"  [kgxval] {member} not in tarball; skipping", file=sys.stderr)
+                return f"## KGXVal biolink validation\n\n_Skipped: {member} not found in tarball._"
+        # --no-project: ignore kg-microbe's poetry pyproject.toml (no [project]
+        # table) so uv builds a clean ephemeral env for the py>=3.13 tool.
+        cmd = ["uv", "run", "--no-project", "--python", "3.13", "--with", source,
+               "python", str(driver), str(nodes_p), str(edges_p), str(out_csv)]
+        print("  [kgxval] running (first run compiles the env; may take a few min)...", file=sys.stderr)
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=7200)
+        except subprocess.TimeoutExpired:
+            return "## KGXVal biolink validation\n\n_Skipped: timed out after 2h._"
+        if proc.stdout:
+            print("  [kgxval] " + proc.stdout.strip().replace("\n", "\n  [kgxval] "), file=sys.stderr)
+        if proc.returncode != 0:
+            print(proc.stderr[-2000:], file=sys.stderr)
+            return (f"## KGXVal biolink validation\n\n_Failed (exit {proc.returncode}). "
+                    "Last stderr:_\n\n```\n" + proc.stderr[-1500:] + "\n```")
+        return _summarize_kgxval_csv(out_csv)
+
+
 def main():
     parser = argparse.ArgumentParser(description="KG-Microbe knowledge modeling review")
     parser.add_argument("--transform", help="Review specific transform (default: all)")
@@ -1548,7 +1674,16 @@ def main():
                         help="Run ONLY the mappings review (skip transform/merged review).")
     parser.add_argument("--no-save", action="store_true",
                         help="Skip writing a timestamped artifact under <skill>/reviews/")
+    parser.add_argument("--kgxval", action="store_true",
+                        help="Additionally run monarch-initiative/kgxval biolink domain/range "
+                             "validation on the merged KG (requires --merged, `uv`, and network "
+                             "for the Python>=3.13 tool). Appends a KGXVal section to the report.")
     args = parser.parse_args()
+
+    if args.kgxval and not args.merged:
+        print("  Error: --kgxval requires --merged (it validates the merged KG tarball).",
+              file=sys.stderr)
+        sys.exit(2)
 
     max_rows = args.max_rows  # 0 means unlimited (iter_tsv handles 0 as no limit)
 
@@ -1635,7 +1770,20 @@ def main():
         if args.format in ("md", "text"):
             rendered += "\n\n" + mappings_result["curation_report"]
 
+    # Append the external KGXVal biolink validation section when requested.
+    # The section is markdown; it appends to md/text reports. For json output
+    # it is saved as a sibling .md artifact and its path is noted on stderr.
+    kgxval_md = None
+    if args.kgxval:
+        print("  Reviewing merged KG with kgxval (external Biolink validator)...", file=sys.stderr)
+        kgxval_md = run_kgxval_biolink_validation(MERGED_DIR)
+        if kgxval_md and args.format in ("md", "text"):
+            rendered += "\n\n" + kgxval_md
+
     print(rendered)
+    if kgxval_md and args.format == "json" and not args.no_save:
+        kgxval_path = _save_review_artifact(kgxval_md, "merged-kgxval", ext="md")
+        print(f"  Saved kgxval section to {kgxval_path}", file=sys.stderr)
 
     if not args.no_save:
         if args.mappings_only:

--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -1630,29 +1630,38 @@ def run_kgxval_biolink_validation(merged_dir: Path) -> "str | None":
 
     driver = Path(__file__).parent / "kgxval_validate.py"
     source = os.environ.get("KGXVAL_SOURCE", KGXVAL_DEFAULT_SOURCE)
-    with tempfile.TemporaryDirectory() as td:
-        tdp = Path(td)
-        nodes_p, edges_p, out_csv = tdp / "nodes.tsv", tdp / "edges.tsv", tdp / "kgxval_errors.csv"
-        for member, dest in (("merged-kg_nodes.tsv", nodes_p), ("merged-kg_edges.tsv", edges_p)):
-            if not _extract_tar_member(tar_path, member, dest):
-                print(f"  [kgxval] {member} not in tarball; skipping", file=sys.stderr)
-                return f"## KGXVal biolink validation\n\n_Skipped: {member} not found in tarball._"
-        # --no-project: ignore kg-microbe's poetry pyproject.toml (no [project]
-        # table) so uv builds a clean ephemeral env for the py>=3.13 tool.
-        cmd = ["uv", "run", "--no-project", "--python", "3.13", "--with", source,
-               "python", str(driver), str(nodes_p), str(edges_p), str(out_csv)]
-        print("  [kgxval] running (first run compiles the env; may take a few min)...", file=sys.stderr)
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=7200)
-        except subprocess.TimeoutExpired:
-            return "## KGXVal biolink validation\n\n_Skipped: timed out after 2h._"
-        if proc.stdout:
-            print("  [kgxval] " + proc.stdout.strip().replace("\n", "\n  [kgxval] "), file=sys.stderr)
-        if proc.returncode != 0:
-            print(proc.stderr[-2000:], file=sys.stderr)
-            return (f"## KGXVal biolink validation\n\n_Failed (exit {proc.returncode}). "
-                    "Last stderr:_\n\n```\n" + proc.stderr[-1500:] + "\n```")
-        return _summarize_kgxval_csv(out_csv)
+    # Everything below is wrapped so the pass truly never raises (a corrupt
+    # tarball, a malformed CSV, or uv vanishing after the which() check must
+    # degrade to a note, not abort the whole review).
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            nodes_p, edges_p, out_csv = tdp / "nodes.tsv", tdp / "edges.tsv", tdp / "kgxval_errors.csv"
+            for member, dest in (("merged-kg_nodes.tsv", nodes_p), ("merged-kg_edges.tsv", edges_p)):
+                if not _extract_tar_member(tar_path, member, dest):
+                    print(f"  [kgxval] {member} not in tarball; skipping", file=sys.stderr)
+                    return f"## KGXVal biolink validation\n\n_Skipped: {member} not found in tarball._"
+            # --no-project: ignore kg-microbe's poetry pyproject.toml (no [project]
+            # table) so uv builds a clean ephemeral env for the py>=3.13 tool.
+            cmd = ["uv", "run", "--no-project", "--python", "3.13", "--with", source,
+                   "python", str(driver), str(nodes_p), str(edges_p), str(out_csv)]
+            print("  [kgxval] running (first run compiles the env; may take a few min)...", file=sys.stderr)
+            try:
+                proc = subprocess.run(cmd, capture_output=True, text=True, timeout=7200)
+            except subprocess.TimeoutExpired:
+                return "## KGXVal biolink validation\n\n_Skipped: timed out after 2h._"
+            if proc.stdout:
+                print("  [kgxval] " + proc.stdout.strip().replace("\n", "\n  [kgxval] "), file=sys.stderr)
+            if proc.returncode != 0:
+                print(proc.stderr[-2000:], file=sys.stderr)
+                # Strip backticks so the embedded stderr can't break the md fence.
+                tail = proc.stderr[-1500:].replace("`", "'")
+                return (f"## KGXVal biolink validation\n\n_Failed (exit {proc.returncode}). "
+                        "Last stderr:_\n\n```\n" + tail + "\n```")
+            return _summarize_kgxval_csv(out_csv)
+    except Exception as e:  # noqa: BLE001 — never let the external tool abort the review
+        print(f"  [kgxval] unexpected error: {e!r}", file=sys.stderr)
+        return f"## KGXVal biolink validation\n\n_Skipped: unexpected error ({type(e).__name__})._"
 
 
 def main():

--- a/.claude/skills/kg-model-review/kgxval_validate.py
+++ b/.claude/skills/kg-model-review/kgxval_validate.py
@@ -42,7 +42,14 @@ from kgxval.dir.Ingest import Ingest
 
 # KG-Microbe merged edges can exceed the default field-size limit on long
 # provenance columns; lift the cap so csv.DictReader never truncates a row.
-csv.field_size_limit(sys.maxsize)
+# sys.maxsize can overflow C long on some platforms — halve until accepted.
+_limit = sys.maxsize
+while True:
+    try:
+        csv.field_size_limit(_limit)
+        break
+    except OverflowError:
+        _limit //= 2
 
 
 def build_node_category_map(nodes_path: Path) -> dict[str, tuple[str, ...]]:
@@ -51,9 +58,12 @@ def build_node_category_map(nodes_path: Path) -> dict[str, tuple[str, ...]]:
 
     KG-Microbe stores ``category`` as a pipe-delimited string that may mix
     biolink and non-biolink (METPO, …) CURIEs. We keep only the ``biolink:``
-    components so kgxval's domain/range checks run against real Biolink classes;
-    a node with no biolink category maps to an empty tuple (skipped by the
-    checks rather than flagged as a phantom error).
+    components so kgxval's domain/range checks run against real Biolink classes.
+    A node with no biolink category maps to an empty tuple; kgxval then reports
+    its incident edges as BAD SUBJECT / BAD OBJECT (an empty category set can't
+    intersect any predicate's domain/range). The summary surfaces these as
+    ``(no biolink category)`` so they are visible, not silently dropped — worth
+    knowing if a future METPO-only-category node is emitted (none exist today).
     """
     node_to_cat: dict[str, tuple[str, ...]] = {}
     with open(nodes_path, newline="") as fh:

--- a/.claude/skills/kg-model-review/kgxval_validate.py
+++ b/.claude/skills/kg-model-review/kgxval_validate.py
@@ -1,0 +1,97 @@
+"""
+Run monarch-initiative/kgxval's biolink domain/range validation on a KG-Microbe KGX pair.
+
+kgxval (https://github.com/monarch-initiative/kgxval) validates KGX edges against
+the Biolink Model with BMT: for every unique (subject-category, object-category,
+predicate) signature it flags
+
+  * BAD BIOLINK  — predicate (or edge category) is not a Biolink element
+  * BAD SUBJECT  — subject node categories are outside the predicate's domain
+  * BAD OBJECT   — object node categories are outside the predicate's range
+
+using BMT's *actual* domain/range descendants — an authoritative complement to
+kg_model_review.py's hand-curated DomainRange check.
+
+kgxval requires Python >=3.13 and is not a kg-microbe dependency, so this driver
+is meant to run in kgxval's own environment, e.g. via uv:
+
+    uv run --python 3.13 \
+        --with 'kgxval @ git+https://github.com/monarch-initiative/kgxval' \
+        python kgxval_validate.py <nodes.tsv> <edges.tsv> <out.csv>
+
+Why this wrapper instead of the `ingest_summary` CLI: that CLI expects a
+JSONL ingest-directory tree and ships with the biolink sub/obj check disabled
+(`ExcelDFFlags(blink_subobj=False)`). kgxval's `Ingest` reads TSV natively, but
+its `TSVDictGen` does not split KG-Microbe's pipe-delimited `category` column,
+so multi-category nodes (e.g. ``METPO:1001000|biolink:Procedure``) and
+non-biolink categories (METPO/…) would produce spurious errors. We therefore
+build the node→category map ourselves — splitting on ``|`` and keeping only the
+``biolink:`` components — then hand it to kgxval's own validator.
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+from bmt.utils import parse_name
+from kgxval.biolink_validation.check_kgx_sub_obj_pred import (
+    findSubObjErrorsForIngest,
+    validationErrorsToFile,
+)
+from kgxval.dir.Ingest import Ingest
+
+# KG-Microbe merged edges can exceed the default field-size limit on long
+# provenance columns; lift the cap so csv.DictReader never truncates a row.
+csv.field_size_limit(sys.maxsize)
+
+
+def build_node_category_map(nodes_path: Path) -> dict[str, tuple[str, ...]]:
+    """
+    Map each node id to its tuple of BMT-parsed biolink categories.
+
+    KG-Microbe stores ``category`` as a pipe-delimited string that may mix
+    biolink and non-biolink (METPO, …) CURIEs. We keep only the ``biolink:``
+    components so kgxval's domain/range checks run against real Biolink classes;
+    a node with no biolink category maps to an empty tuple (skipped by the
+    checks rather than flagged as a phantom error).
+    """
+    node_to_cat: dict[str, tuple[str, ...]] = {}
+    with open(nodes_path, newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        for row in reader:
+            raw = row.get("category") or ""
+            cats = [c for c in raw.split("|") if c.startswith("biolink:")]
+            node_to_cat[row["id"]] = tuple(parse_name(c) for c in cats)
+    return node_to_cat
+
+
+def main() -> int:
+    """Validate a nodes/edges TSV pair and write a kgxval error CSV."""
+    if len(sys.argv) != 4:
+        print("usage: kgxval_validate.py <nodes.tsv> <edges.tsv> <out.csv>", file=sys.stderr)
+        return 2
+    nodes_path, edges_path, out_csv = (Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3])
+
+    ingest = Ingest("kg-microbe", nodes_path, edges_path, "normalized")
+    # Inject our correctly-split category map (bypasses TSVDictGen's no-split
+    # behaviour) and tolerate edges whose endpoint is absent from nodes.tsv
+    # (return an empty category tuple instead of raising).
+    node_to_cat = build_node_category_map(nodes_path)
+    ingest.node_to_category = node_to_cat
+    ingest.get_node_id_category = lambda node_id: node_to_cat.get(node_id, ())
+
+    errors = findSubObjErrorsForIngest(ingest)
+    validationErrorsToFile(errors, out_csv)
+
+    by_type: dict[str, int] = {}
+    for e in errors:
+        by_type[e.error] = by_type.get(e.error, 0) + 1
+    print(f"kgxval: {len(errors)} distinct (predicate,signature) errors across {len(node_to_cat):,} nodes")
+    for etype, cnt in sorted(by_type.items(), key=lambda kv: -kv[1]):
+        print(f"  {etype}: {cnt}")
+    print(f"wrote {out_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
Integrates the external [monarch-initiative/kgxval](https://github.com/monarch-initiative/kgxval) Biolink validator into the `kg-model-review` skill for merged-KG reviews.

kgxval uses BMT to check every unique (subject-category, object-category, predicate) signature against Biolink's **actual domain/range descendants** — an authoritative complement to the skill's hand-curated `DomainRange` check.

## Changes
- **`kgxval_validate.py`** — driver run in kgxval's own env. Builds the node→category map itself (splits KG-Microbe's pipe-delimited `category`, keeps `biolink:` components — kgxval's `TSVDictGen` doesn't split), then calls kgxval's `findSubObjErrorsForIngest`.
- **`kg_model_review.py`** — `--kgxval` flag (requires `--merged`). Extracts the merged tarball TSVs and runs the driver via `uv run --no-project --python 3.13 --with 'kgxval @ git+…'` (kgxval needs Python ≥3.13 and is not a kg-microbe dep). Appends a contextualized section: BAD BIOLINK split into METPO-native (expected) vs actionable; top domain/range violations. Skips gracefully when `uv` is absent/offline.
- **`SKILL.md`** — documents integration, prerequisites, output interpretation.

## Verification
Ran on the current merged KG (2.7M nodes / 13.6M edges): 284 error signatures — 183 BAD BIOLINK (67 METPO-native + 3 actionable: `owl:inverseOf`, `rdf:type`, `rdfs:subPropertyOf`), 59 BAD SUBJECT, 42 BAD OBJECT. `git+` source resolution verified via uv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
