### PR TITLE
docs(CLAUDE.md): drop stale translation_table.yaml key-file reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,8 @@ Additional available transforms (commented out in DATA_SOURCES):
 ### Key Files
 
 - `kg_microbe/run.py`: CLI entry point with Click commands
-- `kg_microbe/transform_utils/constants.py`: Standard column names (ID_COLUMN, CATEGORY_COLUMN, etc.)
+- `kg_microbe/transform_utils/constants.py`: Standard column names (ID_COLUMN, CATEGORY_COLUMN, etc.) and entity-type translation tables (`TRANSLATION_TABLE_FOR_IDS` / `TRANSLATION_TABLE_FOR_LABELS`, applied via `str.maketrans`)
 - `kg_microbe/transform_utils/custom_curies.yaml`: Custom CURIE prefix mappings
-- `kg_microbe/transform_utils/translation_table.yaml`: Entity type translations
 - `pyproject.toml`: Poetry configuration, ruff/black settings
 
 ### Data Flow


### PR DESCRIPTION
One-line doc fix: CLAUDE.md listed `kg_microbe/transform_utils/translation_table.yaml` as a key file, but it's been replaced by in-code `str.maketrans` constants (`TRANSLATION_TABLE_FOR_IDS`/`TRANSLATION_TABLE_FOR_LABELS` in constants.py) — nothing loads the YAML. Folded the entity-translation note into the constants.py entry. Surfaced during branch-cleanup analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)