### PR TITLE
Fix MediaDive cache corruption; add tag-filtered downloads; make every ontology single-source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,14 @@ poetry install
 # Download all data sources (configured in download.yaml)
 poetry run kg download
 
+# Download only selected source groups (tags are listed in download.yaml's header)
+poetry run kg download -t ontologies -t gtdb
+
+# Re-download a single file: delete it and re-run. `kg download` only fetches
+# files that are absent — it never checks whether the remote copy is newer.
+# `-i` ignores the cache for EVERY entry, so scope it with -t:
+poetry run kg download -i -t mediadive
+
 # Transform downloaded data into KG format (TSV: nodes.tsv, edges.tsv)
 poetry run kg transform
 

--- a/docs/DATA_HOSTING.md
+++ b/docs/DATA_HOSTING.md
@@ -9,20 +9,28 @@ the only options are to host a copy or to copy one by hand from a reference
 This file is the manifest for hosting those copies on the public LBNL Google
 Drive, plus the interim copy-by-hand procedure.
 
-## Files to host
+## Hosted files
 
-Six files, ~81 MB total. Checksums are from the copies currently in `data/raw`,
-which came from `data/raw_202607_andOLD_mixed/`. Each md5 is also recorded inline
-in `download.yaml` next to its placeholder.
+Six files, ~81 MB total, in the shared Drive folder
+<https://drive.google.com/drive/folders/1vCKoGREJk45BzImfnPVtGhXAb_DyndLq>
+(General access: *Anyone with the link*, Viewer — `gdown` runs
+unauthenticated, so an org-restricted folder returns a sign-in page and
+fails with HTTP 401). Uploaded and verified end to end 2026-07-25.
 
-| file | size | md5 | placeholder token in download.yaml |
+Each md5 below is also recorded inline in `download.yaml` beside its URL, so the
+pinned artifact is identifiable from the config alone. They were confirmed by
+moving all six out of `data/raw`, running
+`kg download -t metatraits_gtdb -t bactotraits`, and re-checksumming what
+arrived.
+
+| file | size | md5 | Drive file ID |
 |---|---|---|---|
-| `gtdb_species_summary.jsonl.gz` | 46 MB | `aca98ae9c978f238ae7844beaccec63b` | `REPLACE_ME_gtdb_species_summary` |
-| `gtdb_genus_summary.jsonl.gz` | 16 MB | `159828de09d22a7c85e2116e8a97944a` | `REPLACE_ME_gtdb_genus_summary` |
-| `gtdb_family_summary.jsonl.gz` | 4.4 MB | `1443132d2aa0f3d8743b23096ce23a13` | `REPLACE_ME_gtdb_family_summary` |
-| `NCBI2GTDB.tsv.gz` | 2.8 MB | `eca29d35869dd9035730caa12de12598` | `REPLACE_ME_ncbi2gtdb` |
-| `GTDB2NCBI.tsv.gz` | 2.8 MB | `a313f89ac32b7137c7225c789f724f63` | `REPLACE_ME_gtdb2ncbi` |
-| `BactoTraits_databaseV2_Jun2022.csv` | 8.6 MB | `e6bca5b947c1aa692d45ac24aa9025f3` | `REPLACE_ME_bactotraits_v2_jun2022` |
+| `gtdb_species_summary.jsonl.gz` | 46 MB | `aca98ae9c978f238ae7844beaccec63b` | `1xfZiMly-lJgcPL5ihR6QK1zxlv_JwC6J` |
+| `gtdb_genus_summary.jsonl.gz` | 16 MB | `159828de09d22a7c85e2116e8a97944a` | `1Kotk8g5Ky_Cc9MNiywO_Tjz6JLEG0y7Y` |
+| `gtdb_family_summary.jsonl.gz` | 4.4 MB | `1443132d2aa0f3d8743b23096ce23a13` | `1HpkfGAtZI1uRwyPzbTJFtI6avWlkEAlE` |
+| `NCBI2GTDB.tsv.gz` | 2.8 MB | `eca29d35869dd9035730caa12de12598` | `1npQ1z2Yc0NRPHpBkKjsKIBy2_evDAyCV` |
+| `GTDB2NCBI.tsv.gz` | 2.8 MB | `a313f89ac32b7137c7225c789f724f63` | `1ip7ualwruocq9MvcaoNAcH0YtLtAEASP` |
+| `BactoTraits_databaseV2_Jun2022.csv` | 8.6 MB | `e6bca5b947c1aa692d45ac24aa9025f3` | `1u7snG4VxbH6sh6M03dS1GumoYgLgbZrr` |
 
 All five MetaTraits files are hosted together so the KG builds against one fixed
 MetaTraits release, matching the three `ncbi_*_summary.jsonl.gz` inputs that are
@@ -95,10 +103,13 @@ update the md5 in `download.yaml` and in the table above as a deliberate act.
   older ontology release: the transforms skip regeneration when the derived file
   already exists.
 
-## Upload procedure
+## Upload procedure (for refreshing a file, or adding a new one)
 
-1. Upload each file to the public LBNL Drive folder **as binary**. Do not let
-   Drive or the browser recompress or rename anything.
+1. Upload the file to the Drive folder **as binary**. Do not let Drive or the
+   browser recompress or rename anything. Before the first upload, turn off
+   Drive → Settings → **"Convert uploaded files to Google Docs editor format"**,
+   or a `.csv` becomes a Google Sheet and `uc?id=` returns an export instead of
+   the file.
 2. Set sharing to **anyone with the link can view** — `kghub-downloader`'s
    `gdrive:` handler is unauthenticated.
 3. **Verify the round trip before trusting it.** Download your own upload and
@@ -122,14 +133,23 @@ update the md5 in `download.yaml` and in the table above as a deliberate act.
    and the NCBI→GTDB fallback quietly stopped working. Verifying the checksum
    still matters, because a decompressed upload has a different md5 than the
    table above and is no longer the pinned artifact.
-4. Take the file ID from the sharing link's `/d/<id>/` segment and paste it over
-   the placeholder in `download.yaml`:
+4. Take the file ID from the sharing link's `/d/<id>/` segment and put it in
+   `download.yaml`, updating the recorded md5 in the same edit:
 
    ```yaml
    -
-     url: gdrive:1AbCdEfGhIjKlMnOpQrStUvWxYz          # was gdrive:REPLACE_ME_...
+     url: gdrive:1AbCdEfGhIjKlMnOpQrStUvWxYz   # md5 <new checksum>
      local_name: gtdb_species_summary.jsonl.gz
      tag: metatraits_gtdb
+   ```
+
+   To list every ID in the folder at once, without clicking through six share
+   dialogs:
+
+   ```bash
+   poetry run python -c "import gdown; \
+     [print(f.id, f.path) for f in gdown.download_folder(
+        url='<folder url>', skip_download=True, quiet=True)]"
    ```
 
 5. Confirm the entry works in isolation:

--- a/docs/DATA_HOSTING.md
+++ b/docs/DATA_HOSTING.md
@@ -11,7 +11,7 @@ Drive, plus the interim copy-by-hand procedure.
 
 ## Files to host
 
-Six files, ~81 MB total. Checksums are from the copies currently in `data/raw`,
+Four files, ~75 MB total. Checksums are from the copies currently in `data/raw`,
 which came from `data/raw_202607_andOLD_mixed/`.
 
 | file | size | md5 | placeholder token in download.yaml |
@@ -19,21 +19,48 @@ which came from `data/raw_202607_andOLD_mixed/`.
 | `gtdb_species_summary.jsonl.gz` | 46 MB | `aca98ae9c978f238ae7844beaccec63b` | `REPLACE_ME_gtdb_species_summary` |
 | `gtdb_genus_summary.jsonl.gz` | 16 MB | `159828de09d22a7c85e2116e8a97944a` | `REPLACE_ME_gtdb_genus_summary` |
 | `gtdb_family_summary.jsonl.gz` | 4.4 MB | `1443132d2aa0f3d8743b23096ce23a13` | `REPLACE_ME_gtdb_family_summary` |
-| `NCBI2GTDB.tsv.gz` | 2.8 MB | `eca29d35869dd9035730caa12de12598` | `REPLACE_ME_ncbi2gtdb` |
-| `GTDB2NCBI.tsv.gz` | 2.8 MB | `a313f89ac32b7137c7225c789f724f63` | `REPLACE_ME_gtdb2ncbi` |
 | `BactoTraits_databaseV2_Jun2022.csv` | 8.6 MB | `e6bca5b947c1aa692d45ac24aa9025f3` | `REPLACE_ME_bactotraits_v2_jun2022` |
+
+### No longer needs hosting
+
+`NCBI2GTDB.tsv.gz` and `GTDB2NCBI.tsv.gz` are live again. They moved off the
+dead `metatraits.embl.de/static/downloads/` path to the Bork group's own web
+space, linked from <https://metatraits.embl.de/documentation>:
+
+```
+https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
+https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
+```
+
+Verified 2026-07-25: both are **byte-identical** to the vendored copies
+(md5 `eca29d35…` and `a313f89a…`). They are now ordinary `download.yaml` entries
+under the `metatraits_gtdb` tag.
 
 ### Why each one needs hosting
 
-- **`gtdb_*_summary.jsonl.gz`, `NCBI2GTDB.tsv.gz`, `GTDB2NCBI.tsv.gz`** —
-  MetaTraits (EMBL) products. `metatraits.embl.de/static/downloads/` now returns
-  HTTP 404 for all of them; access moved behind permission from the MetaTraits
-  contact named in `download.yaml`. Keyed by GTDB R220 taxon name, so they are
-  independent of which NCBITaxon release we build against.
-  Consumers: `metatraits_gtdb` reads the species summary
-  (`METATRAITS_GTDB_INPUT_FILES`); `metatraits` reads `NCBI2GTDB.tsv.gz`
-  (`_load_ncbi_gtdb_mappings`). Genus and family summaries are declared for
+- **`gtdb_*_summary.jsonl.gz`** — MetaTraits (EMBL) products, keyed by GTDB
+  r220 taxon name (so independent of which NCBITaxon release we build against).
+  The JSONL serialization has been **discontinued upstream**: the Bork directory
+  now publishes only `.tsv.gz`, in two variants per rank (`_all` and
+  `_no_predictions`). Our vendored JSONL corresponds to **`_all`** — verified by
+  comparing per-taxon trait sets at family rank: 73.9% of taxa match `_all`
+  exactly (the rest differ only because `_all` is a newer build adding traits
+  like `generalism score`, `generalist`, `habitat count`), versus 0.4% against
+  `_no_predictions`, which carries far fewer traits per taxon (6 vs 130 for
+  `0-14-0-10-38-17`). Note the taxa *counts* coincide (4,511 in both our JSONL
+  and `_no_predictions`) — that resemblance is misleading, so compare trait sets
+  rather than record counts if you revisit this.
+  Consumer: `metatraits_gtdb` reads the species summary
+  (`METATRAITS_GTDB_INPUT_FILES`); genus and family are declared for
   completeness but currently commented out in the transform.
+
+  **Switching to the TSV form would require a transform change** — the JSONL is
+  one object per taxon with a nested `summaries` list, while the TSV is one row
+  per taxon-trait pair with richer columns (`ontology_ids` carrying OMP terms,
+  `group_1`/`group_2` trait categories, min/median/mean/max, `taxon_lineage`).
+  It is also much larger: `gtdb_species_summary_all.tsv.gz` is 135 MB versus
+  46 MB for the JSONL. Until that work happens, hosting the vendored JSONL keeps
+  the transform running unchanged.
 - **`BactoTraits_databaseV2_Jun2022.csv`** — the host
   (`ordar.otelo.univ-lorraine.fr`) serves an incomplete TLS intermediate chain
   that no CA bundle can verify, so the download aborts the whole run. Static
@@ -104,9 +131,24 @@ hand:
 ```bash
 REF=data/raw_202607_andOLD_mixed
 cp -n $REF/gtdb_species_summary.jsonl.gz $REF/gtdb_genus_summary.jsonl.gz \
-      $REF/gtdb_family_summary.jsonl.gz $REF/NCBI2GTDB.tsv.gz \
-      $REF/GTDB2NCBI.tsv.gz $REF/BactoTraits_databaseV2_Jun2022.csv data/raw/
+      $REF/gtdb_family_summary.jsonl.gz \
+      $REF/BactoTraits_databaseV2_Jun2022.csv data/raw/
+
+# NCBI2GTDB / GTDB2NCBI no longer need copying — they download normally:
+poetry run kg download -t metatraits_gtdb
 ```
+
+### These are NOT GTDB downloads
+
+Worth stating plainly, because the names suggest otherwise: none of these files
+come from GTDB. The GTDB release directory
+(<https://data.gtdb.ecogenomic.org/releases/latest/>) publishes only
+`{bac120,ar53}_taxonomy.tsv[.gz]`, `{bac120,ar53}_metadata.tsv.gz`, trees, MSA
+masks and genomic files — no phenotypic trait summaries and no NCBI crosswalk.
+All of `gtdb_*_summary.*`, `NCBI2GTDB.tsv.gz` and `GTDB2NCBI.tsv.gz` are
+MetaTraits (EMBL, Bork group) products that are merely *keyed by* GTDB taxonomy.
+The four GTDB files we do fetch from GTDB proper are tagged `gtdb`, not
+`metatraits_gtdb`.
 
 Two related caches worth restoring the same way, both of which cost hours to
 rebuild and neither of which is a `download.yaml` entry:

--- a/docs/DATA_HOSTING.md
+++ b/docs/DATA_HOSTING.md
@@ -1,0 +1,132 @@
+# Hosting vendored data files
+
+Some KG-Microbe inputs cannot be fetched by `poetry run kg download`: their
+upstream URL is dead, TLS-broken, or permission-gated. They are **not
+regenerable** — we hold none of the upstream observations they summarize — so
+the only options are to host a copy or to copy one by hand from a reference
+`data/raw_*` directory.
+
+This file is the manifest for hosting those copies on the public LBNL Google
+Drive, plus the interim copy-by-hand procedure.
+
+## Files to host
+
+Six files, ~81 MB total. Checksums are from the copies currently in `data/raw`,
+which came from `data/raw_202607_andOLD_mixed/`.
+
+| file | size | md5 | placeholder token in download.yaml |
+|---|---|---|---|
+| `gtdb_species_summary.jsonl.gz` | 46 MB | `aca98ae9c978f238ae7844beaccec63b` | `REPLACE_ME_gtdb_species_summary` |
+| `gtdb_genus_summary.jsonl.gz` | 16 MB | `159828de09d22a7c85e2116e8a97944a` | `REPLACE_ME_gtdb_genus_summary` |
+| `gtdb_family_summary.jsonl.gz` | 4.4 MB | `1443132d2aa0f3d8743b23096ce23a13` | `REPLACE_ME_gtdb_family_summary` |
+| `NCBI2GTDB.tsv.gz` | 2.8 MB | `eca29d35869dd9035730caa12de12598` | `REPLACE_ME_ncbi2gtdb` |
+| `GTDB2NCBI.tsv.gz` | 2.8 MB | `a313f89ac32b7137c7225c789f724f63` | `REPLACE_ME_gtdb2ncbi` |
+| `BactoTraits_databaseV2_Jun2022.csv` | 8.6 MB | `e6bca5b947c1aa692d45ac24aa9025f3` | `REPLACE_ME_bactotraits_v2_jun2022` |
+
+### Why each one needs hosting
+
+- **`gtdb_*_summary.jsonl.gz`, `NCBI2GTDB.tsv.gz`, `GTDB2NCBI.tsv.gz`** —
+  MetaTraits (EMBL) products. `metatraits.embl.de/static/downloads/` now returns
+  HTTP 404 for all of them; access moved behind permission from the MetaTraits
+  contact named in `download.yaml`. Keyed by GTDB R220 taxon name, so they are
+  independent of which NCBITaxon release we build against.
+  Consumers: `metatraits_gtdb` reads the species summary
+  (`METATRAITS_GTDB_INPUT_FILES`); `metatraits` reads `NCBI2GTDB.tsv.gz`
+  (`_load_ncbi_gtdb_mappings`). Genus and family summaries are declared for
+  completeness but currently commented out in the transform.
+- **`BactoTraits_databaseV2_Jun2022.csv`** — the host
+  (`ordar.otelo.univ-lorraine.fr`) serves an incomplete TLS intermediate chain
+  that no CA bundle can verify, so the download aborts the whole run. Static
+  Jun-2022 dataset; it will not change.
+
+### Deliberately NOT hosted
+
+- **`lpsn_gss.csv`** — the LPSN GSS export is account-gated, and LPSN's
+  copyright terms (see `kg_microbe/transform_utils/lpsn/README.md`) require
+  attribution and restrict redistribution. Publishing it to a public Drive link
+  *is* redistribution. Keep the manual procedure documented in `download.yaml`:
+  register free at <https://lpsn.dsmz.de/register>, download the GSS CSV, place
+  it at `data/raw/lpsn_gss.csv`.
+- **Anything derived from a downloaded ontology release** — `ncbitaxon.db`,
+  `ncbitaxon_removed_subset.json`, `chebi.{db,owl,json}`, `go.{db,json}`,
+  `ec.db`, `bto.db`, `ncit.db`, `*-relation-graph.tsv.gz`, and the ROBOT-derived
+  `pato/ro/taxrank/uberon/upa/foodon.json`. These must be rebuilt from the OWL
+  you actually downloaded. Hosting or copying them silently pins the KG to an
+  older ontology release: the transforms skip regeneration when the derived file
+  already exists.
+
+## Upload procedure
+
+1. Upload each file to the public LBNL Drive folder **as binary**. Do not let
+   Drive or the browser recompress or rename anything.
+2. Set sharing to **anyone with the link can view** — `kghub-downloader`'s
+   `gdrive:` handler is unauthenticated.
+3. **Verify the round trip before trusting it.** Download your own upload and
+   check the md5 against the table above:
+
+   ```bash
+   curl -sL "https://drive.google.com/uc?export=download&id=<id>" -o /tmp/check
+   md5 -q /tmp/check
+   ```
+
+   This step is not optional. Drive has silently served `.gz` uploads
+   decompressed — that is exactly how `ncbi_*_summary.jsonl.gz` ended up as
+   plain JSON under a `.gz` name in `data/raw`. (The MetaTraits reader tolerates
+   it via a `BadGzipFile` fallback, but `metatraits_gtdb` and the `.tsv.gz`
+   crosswalks are read with plain `gzip.open` and would fail.)
+4. Take the file ID from the sharing link's `/d/<id>/` segment and paste it over
+   the placeholder in `download.yaml`:
+
+   ```yaml
+   -
+     url: gdrive:1AbCdEfGhIjKlMnOpQrStUvWxYz          # was gdrive:REPLACE_ME_...
+     local_name: gtdb_species_summary.jsonl.gz
+     tag: metatraits_gtdb
+   ```
+
+5. Confirm the entry works in isolation:
+
+   ```bash
+   mv data/raw/gtdb_species_summary.jsonl.gz /tmp/backup.gz   # keep a copy first
+   poetry run kg download -t metatraits_gtdb
+   md5 -q data/raw/gtdb_species_summary.jsonl.gz              # must match the table
+   ```
+
+   Move the file aside rather than relying on `-i`: `-i` deletes the local copy
+   *before* fetching, so a failed download leaves you with nothing.
+
+## Interim: copy from a reference directory
+
+Until the files are hosted, `kg download` skips them with a message naming each
+one (see `PENDING_HOSTING_MARKER` in `kg_microbe/download.py`). Restore them by
+hand:
+
+```bash
+REF=data/raw_202607_andOLD_mixed
+cp -n $REF/gtdb_species_summary.jsonl.gz $REF/gtdb_genus_summary.jsonl.gz \
+      $REF/gtdb_family_summary.jsonl.gz $REF/NCBI2GTDB.tsv.gz \
+      $REF/GTDB2NCBI.tsv.gz $REF/BactoTraits_databaseV2_Jun2022.csv data/raw/
+```
+
+Two related caches worth restoring the same way, both of which cost hours to
+rebuild and neither of which is a `download.yaml` entry:
+
+```bash
+cp -Rn $REF/mediadive data/raw/     # 4 bulk JSONs; skips a ~1h MediaDive crawl
+cp -Rn $REF/lpsn data/raw/          # 34,301 per-record LPSN API responses
+cp -n  $REF/lpsn_gss.csv data/raw/
+```
+
+Note both caches live *inside* `data/raw`, so rotating or replacing that
+directory loses them — which is what caused a full 34,300-record LPSN re-fetch.
+Once the six files above are hosted, only the LPSN artifacts still need this
+treatment.
+
+Two inputs cannot be restored from any reference directory:
+
+- `kegg/ko_minimal.json` (~30 MB) — run `python scripts/download_kegg_minimal.py`
+  (~50 min). The `kegg` transform errors without it. A 894 MB `ko_details.json`
+  fallback exists in `data/raw_last5/kegg/`.
+- `bakta/<dataset>/` — `BAKTA` is active in `DATA_SOURCES` but no copy exists in
+  `data/raw` or in the reference directory; `data/raw_last5/bakta/` holds a
+  170 MB `cmm_bakta_test1` only.

--- a/docs/DATA_HOSTING.md
+++ b/docs/DATA_HOSTING.md
@@ -11,30 +11,43 @@ Drive, plus the interim copy-by-hand procedure.
 
 ## Files to host
 
-Four files, ~75 MB total. Checksums are from the copies currently in `data/raw`,
-which came from `data/raw_202607_andOLD_mixed/`.
+Six files, ~81 MB total. Checksums are from the copies currently in `data/raw`,
+which came from `data/raw_202607_andOLD_mixed/`. Each md5 is also recorded inline
+in `download.yaml` next to its placeholder.
 
 | file | size | md5 | placeholder token in download.yaml |
 |---|---|---|---|
 | `gtdb_species_summary.jsonl.gz` | 46 MB | `aca98ae9c978f238ae7844beaccec63b` | `REPLACE_ME_gtdb_species_summary` |
 | `gtdb_genus_summary.jsonl.gz` | 16 MB | `159828de09d22a7c85e2116e8a97944a` | `REPLACE_ME_gtdb_genus_summary` |
 | `gtdb_family_summary.jsonl.gz` | 4.4 MB | `1443132d2aa0f3d8743b23096ce23a13` | `REPLACE_ME_gtdb_family_summary` |
+| `NCBI2GTDB.tsv.gz` | 2.8 MB | `eca29d35869dd9035730caa12de12598` | `REPLACE_ME_ncbi2gtdb` |
+| `GTDB2NCBI.tsv.gz` | 2.8 MB | `a313f89ac32b7137c7225c789f724f63` | `REPLACE_ME_gtdb2ncbi` |
 | `BactoTraits_databaseV2_Jun2022.csv` | 8.6 MB | `e6bca5b947c1aa692d45ac24aa9025f3` | `REPLACE_ME_bactotraits_v2_jun2022` |
 
-### No longer needs hosting
+All five MetaTraits files are hosted together so the KG builds against one fixed
+MetaTraits release, matching the three `ncbi_*_summary.jsonl.gz` inputs that are
+already Drive-hosted under the `metatraits` tag.
 
-`NCBI2GTDB.tsv.gz` and `GTDB2NCBI.tsv.gz` are live again. They moved off the
-dead `metatraits.embl.de/static/downloads/` path to the Bork group's own web
-space, linked from <https://metatraits.embl.de/documentation>:
+### Why pin the crosswalks rather than fetch them live
+
+`NCBI2GTDB.tsv.gz` and `GTDB2NCBI.tsv.gz` *are* still published upstream — they
+moved off the dead `metatraits.embl.de/static/downloads/` path to the Bork
+group's web space, linked from <https://metatraits.embl.de/documentation>:
 
 ```
 https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
 https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
 ```
 
-Verified 2026-07-25: both are **byte-identical** to the vendored copies
-(md5 `eca29d35…` and `a313f89a…`). They are now ordinary `download.yaml` entries
-under the `metatraits_gtdb` tag.
+Verified 2026-07-25: both are **byte-identical** to the copies in `data/raw`.
+
+We deliberately do not point `download.yaml` at them. That is an unversioned
+personal directory whose files are regenerated in place — the current build is
+dated 2025-08-14 and the name carries no release identifier — so two KG builds
+months apart would silently use different crosswalks with no way to tell from
+the config. The Drive copy fixes the release. **Those URLs are the refresh
+source**: when you want a newer crosswalk, download from there, re-upload, and
+update the md5 in `download.yaml` and in the table above as a deliberate act.
 
 ### Why each one needs hosting
 
@@ -97,10 +110,18 @@ under the `metatraits_gtdb` tag.
    ```
 
    This step is not optional. Drive has silently served `.gz` uploads
-   decompressed — that is exactly how `ncbi_*_summary.jsonl.gz` ended up as
-   plain JSON under a `.gz` name in `data/raw`. (The MetaTraits reader tolerates
-   it via a `BadGzipFile` fallback, but `metatraits_gtdb` and the `.tsv.gz`
-   crosswalks are read with plain `gzip.open` and would fail.)
+   decompressed — that is exactly how the already-hosted
+   `ncbi_*_summary.jsonl.gz` ended up as plain JSON under a `.gz` name in
+   `data/raw`, and the five files below go up the same way.
+
+   Every MetaTraits read path now tolerates a decompressed `.gz` via
+   `_open_maybe_gzipped` (`transform_utils/metatraits/metatraits.py`), so this
+   no longer breaks a build. It used to matter most for the crosswalk:
+   `_load_ncbi_gtdb_mappings` wraps its read in `except Exception`, so a
+   `BadGzipFile` there never crashed — it silently produced **zero** mappings
+   and the NCBI→GTDB fallback quietly stopped working. Verifying the checksum
+   still matters, because a decompressed upload has a different md5 than the
+   table above and is no longer the pinned artifact.
 4. Take the file ID from the sharing link's `/d/<id>/` segment and paste it over
    the placeholder in `download.yaml`:
 
@@ -131,11 +152,8 @@ hand:
 ```bash
 REF=data/raw_202607_andOLD_mixed
 cp -n $REF/gtdb_species_summary.jsonl.gz $REF/gtdb_genus_summary.jsonl.gz \
-      $REF/gtdb_family_summary.jsonl.gz \
-      $REF/BactoTraits_databaseV2_Jun2022.csv data/raw/
-
-# NCBI2GTDB / GTDB2NCBI no longer need copying — they download normally:
-poetry run kg download -t metatraits_gtdb
+      $REF/gtdb_family_summary.jsonl.gz $REF/NCBI2GTDB.tsv.gz \
+      $REF/GTDB2NCBI.tsv.gz $REF/BactoTraits_databaseV2_Jun2022.csv data/raw/
 ```
 
 ### These are NOT GTDB downloads

--- a/download.yaml
+++ b/download.yaml
@@ -29,10 +29,28 @@
 #    kegg        KEGG KO list (see the KEGG section for the manual cache step)
 #    gtdb        GTDB taxonomy + metadata
 #    metatraits  MetaTraits per-taxon trait summaries (NCBITaxon ranks)
+#    metatraits_gtdb  MetaTraits summaries + crosswalks keyed by GTDB taxonomy
+#    bactotraits BactoTraits V2 (static Jun-2022 dataset)
 #    schema      Reference specs (Biolink Model, KGX format) — not pipeline inputs
 #
 #  A new entry MUST have a tag: tests/test_download_tags.py fails otherwise, so
 #  an untagged source can never be silently unreachable via -t.
+#
+#  PENDING HOSTING
+#  Some sources have a dead upstream URL and no hosted replacement yet. They are
+#  declared normally but with a placeholder URL containing "REPLACE_ME_":
+#
+#    -
+#      url: gdrive:REPLACE_ME_gtdb_species_summary
+#      local_name: gtdb_species_summary.jsonl.gz
+#      tag: metatraits_gtdb
+#
+#  kg download skips these and prints what it skipped, so a placeholder never
+#  aborts a run. To activate one, replace the whole url value with the real
+#  Google Drive file ID (`gdrive:<id>`, from the sharing link's /d/<id>/ segment;
+#  the file must be readable by anyone with the link). Until then, copy the file
+#  from a reference data/raw_* directory. See tests/test_download_tags.py, which
+#  enforces that placeholders stay skippable and tagged.
 #
 #  For downloading from S3 buckets, see here for information about what URL to use:
 #  https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro
@@ -248,9 +266,12 @@
 # bactotraits transform runs normally. To refresh, fetch the CSV manually
 # (verification relaxed) to that path, then re-enable this entry.
 #
-#-
-#  url: https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
-#  local_name: BactoTraits_databaseV2_Jun2022.csv
+# Original (broken TLS) source, kept for provenance:
+#   https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+-
+  url: gdrive:REPLACE_ME_bactotraits_v2_jun2022
+  local_name: BactoTraits_databaseV2_Jun2022.csv
+  tag: bactotraits
 
 #
 # CTD
@@ -465,15 +486,22 @@
 # antheaguo@berkeley.edu). The last public copies (2026-03-24) are vendored
 # into data/raw/ from data/raw_last8/. To refresh, obtain access and re-enable.
 #
-#-
-#  url: https://metatraits.embl.de/static/downloads/gtdb_species_summary.jsonl.gz
-#  local_name: gtdb_species_summary.jsonl.gz
-#-
-#  url: https://metatraits.embl.de/static/downloads/gtdb_genus_summary.jsonl.gz
-#  local_name: gtdb_genus_summary.jsonl.gz
-#-
-#  url: https://metatraits.embl.de/static/downloads/gtdb_family_summary.jsonl.gz
-#  local_name: gtdb_family_summary.jsonl.gz
+# Original (now HTTP 404) sources, kept for provenance:
+#   https://metatraits.embl.de/static/downloads/gtdb_{species,genus,family}_summary.jsonl.gz
+# Only the species summary is read by the transform; genus/family are declared
+# here for completeness (see METATRAITS_GTDB_INPUT_FILES).
+-
+  url: gdrive:REPLACE_ME_gtdb_species_summary
+  local_name: gtdb_species_summary.jsonl.gz
+  tag: metatraits_gtdb
+-
+  url: gdrive:REPLACE_ME_gtdb_genus_summary
+  local_name: gtdb_genus_summary.jsonl.gz
+  tag: metatraits_gtdb
+-
+  url: gdrive:REPLACE_ME_gtdb_family_summary
+  local_name: gtdb_family_summary.jsonl.gz
+  tag: metatraits_gtdb
 
 #
 # GTDB-NCBITaxon Mappings (for overlap analysis)
@@ -481,12 +509,17 @@
 # NOTE: Commented out — same dead metatraits.embl.de endpoint (HTTP 404).
 # Last public copies (2026-03-24) vendored into data/raw/ from data/raw_last8/.
 #
-#-
-#  url: https://metatraits.embl.de/static/downloads/GTDB2NCBI.tsv.gz
-#  local_name: GTDB2NCBI.tsv.gz
-#-
-#  url: https://metatraits.embl.de/static/downloads/NCBI2GTDB.tsv.gz
-#  local_name: NCBI2GTDB.tsv.gz
+# Original (now HTTP 404) sources, kept for provenance:
+#   https://metatraits.embl.de/static/downloads/{GTDB2NCBI,NCBI2GTDB}.tsv.gz
+# NCBI2GTDB.tsv.gz is read by the metatraits transform (_load_ncbi_gtdb_mappings).
+-
+  url: gdrive:REPLACE_ME_gtdb2ncbi
+  local_name: GTDB2NCBI.tsv.gz
+  tag: metatraits_gtdb
+-
+  url: gdrive:REPLACE_ME_ncbi2gtdb
+  local_name: NCBI2GTDB.tsv.gz
+  tag: metatraits_gtdb
 
 #
 # Biolink Model

--- a/download.yaml
+++ b/download.yaml
@@ -509,15 +509,21 @@
 # NOTE: Commented out — same dead metatraits.embl.de endpoint (HTTP 404).
 # Last public copies (2026-03-24) vendored into data/raw/ from data/raw_last8/.
 #
-# Original (now HTTP 404) sources, kept for provenance:
-#   https://metatraits.embl.de/static/downloads/{GTDB2NCBI,NCBI2GTDB}.tsv.gz
+# These moved off metatraits.embl.de/static/downloads/ (now HTTP 404) to the
+# Bork group's own web space, which the metaTraits documentation page points at:
+# https://metatraits.embl.de/documentation. Verified 2026-07-25: both URLs
+# return byte-identical files to the copies previously vendored into data/raw
+# (NCBI2GTDB md5 eca29d35869dd9035730caa12de12598,
+#  GTDB2NCBI md5 a313f89ac32b7137c7225c789f724f63).
+# Mapping is GTDB r220 <-> NCBI 2025-07-28, assigned where >=85% of genomes
+# share the same ID in both taxonomies.
 # NCBI2GTDB.tsv.gz is read by the metatraits transform (_load_ncbi_gtdb_mappings).
 -
-  url: gdrive:REPLACE_ME_gtdb2ncbi
+  url: https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
   local_name: GTDB2NCBI.tsv.gz
   tag: metatraits_gtdb
 -
-  url: gdrive:REPLACE_ME_ncbi2gtdb
+  url: https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
   local_name: NCBI2GTDB.tsv.gz
   tag: metatraits_gtdb
 

--- a/download.yaml
+++ b/download.yaml
@@ -11,6 +11,28 @@
 #    # brief comment about file, and optionally a local_name:
 #    url: http://curefordisease.org/some_data.txt
 #    local_name: some_data_more_chars_prevent_name_collision.pdf
+#    tag: some_group
+#
+#  Every active entry carries a 'tag', which groups it for selective
+#  downloads:  poetry run kg download -t ontologies -t gtdb
+#  Without -t, everything is downloaded. Current tags:
+#
+#    tools       ROBOT jar + wrapper (needed by the ontology transforms)
+#    ontologies  OBO ontology files (OWL/JSON) loaded by the ontologies transform
+#    stubs       Prebuilt SemSQL DBs / MeSH RDF for the selective stub-import
+#    mappings    Crosswalk tables (EC->GO, EPM curies, compound mappings)
+#    bacdive     BacDive strains + assay-kit metadata
+#    mediadive   MediaDive basic media list (also triggers the bulk API download)
+#    madin       Madin et al. condensed traits + environment conversion table
+#    rhea        Rhea reaction mappings (to GO and EC)
+#    cog         Clusters of Orthologous Groups definitions
+#    kegg        KEGG KO list (see the KEGG section for the manual cache step)
+#    gtdb        GTDB taxonomy + metadata
+#    metatraits  MetaTraits per-taxon trait summaries (NCBITaxon ranks)
+#    schema      Reference specs (Biolink Model, KGX format) — not pipeline inputs
+#
+#  A new entry MUST have a tag: tests/test_download_tags.py fails otherwise, so
+#  an untagged source can never be silently unreachable via -t.
 #
 #  For downloading from S3 buckets, see here for information about what URL to use:
 #  https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro
@@ -25,9 +47,11 @@
 -
   url: https://github.com/ontodev/robot/releases/download/v1.9.8/robot.jar
   local_name: robot.jar
+  tag: tools
 -
   url: https://raw.githubusercontent.com/ontodev/robot/master/bin/robot 
   local_name: robot
+  tag: tools
 
 # **** Ontology files ****
 #
@@ -36,12 +60,14 @@
 -
   url: http://purl.obolibrary.org/obo/envo.json
   local_name: envo.json
+  tag: ontologies
 
 # NCBITaxon
 #
 -
   url: http://purl.obolibrary.org/obo/ncbitaxon.owl.gz
   local_name: ncbitaxon.owl.gz
+  tag: ontologies
 
 #
 # ChEBI
@@ -49,6 +75,7 @@
 -
   url: http://purl.obolibrary.org/obo/chebi.owl.gz
   local_name: chebi.owl.gz
+  tag: ontologies
 
 #
 # GO — single source of truth (fix 2, #604): download only go.owl; the
@@ -59,6 +86,7 @@
 -
   url: http://purl.obolibrary.org/obo/go.owl
   local_name: go.owl
+  tag: ontologies
 
 #
 # EC to GO mappings (Gene Ontology Consortium)
@@ -66,6 +94,7 @@
 -
   url: https://current.geneontology.org/ontology/external2go/ec2go
   local_name: ec2go.txt
+  tag: mappings
 
 #
 # MONDO
@@ -73,12 +102,14 @@
 -
   url: https://purl.obolibrary.org/obo/mondo/mondo.json
   local_name: mondo.json
+  tag: ontologies
 #
 # HP
 #
 -
   url: https://purl.obolibrary.org/obo/hp/hp.json
   local_name: hp.json
+  tag: ontologies
 
 #
 # UBERON (Uber Anatomy Ontology)
@@ -86,6 +117,7 @@
 -
   url: https://purl.obolibrary.org/obo/uberon.owl
   local_name: uberon.owl
+  tag: ontologies
 
 #
 # FOODON
@@ -93,6 +125,7 @@
 -
   url: https://purl.obolibrary.org/obo/foodon.owl
   local_name: foodon.owl
+  tag: ontologies
 
 #
 # PATO (Phenotype And Trait Ontology)
@@ -100,6 +133,7 @@
 -
   url: http://purl.obolibrary.org/obo/pato.owl
   local_name: pato.owl
+  tag: ontologies
 
 # **** Data sources ****
 
@@ -108,12 +142,14 @@
 -
   url: gdrive:1b_UWdIvsIM81V5WdFedNoxN3R4UUf4F2
   local_name: bacdive_strains.json
+  tag: bacdive
 
 # BacDive Assay Metadata
 # Assay kit metadata for API and BiOLOG assay systems
 -
   url: https://raw.githubusercontent.com/CultureBotAI/assay-metadata/refs/heads/main/data/assay_kits_simple.json
   local_name: assay_kits_simple.json
+  tag: bacdive
 
 # MediaDive
 # Explore MediaDive data
@@ -125,11 +161,13 @@
 -
   url: https://mediadive.dsmz.de/rest/media
   local_name: mediadive.json
+  tag: mediadive
 
 # Madin et al Condensed-traits
 -
   url: https://github.com/bacteria-archaea-traits/bacteria-archaea-traits/blob/master/output/condensed_traits_NCBI.csv?raw=true
   local_name: madin_etal.csv
+  tag: madin
 
 # # # ****Conversion Tables****
 #
@@ -138,6 +176,7 @@
 -
   url: https://raw.githubusercontent.com/bacteria-archaea-traits/bacteria-archaea-traits/master/data/conversion_tables/environments.csv
   local_name: environments.csv
+  tag: madin
 
 # 
 # EPM JSON for curies package
@@ -145,6 +184,7 @@
 -
   url: https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/obo.epm.json
   local_name: epm.json
+  tag: mappings
 
 #
 # Uniprot Functional Microbes
@@ -169,15 +209,18 @@
 -
   url: https://github.com/geneontology/unipathway/raw/master/upa.owl
   local_name: upa.owl
+  tag: ontologies
 
 # RHEA mappings
 - 
   url: https://ftp.expasy.org/databases/rhea/tsv/rhea2go.tsv
   local_name: rhea2go.tsv
+  tag: rhea
 
 -
   url: https://ftp.expasy.org/databases/rhea/tsv/rhea2ec.tsv
   local_name: rhea2ec.tsv
+  tag: rhea
 
 # 
 # EC
@@ -185,6 +228,7 @@
 - 
   url: https://w3id.org/biopragmatics/resources/eccode/eccode.json
   local_name: ec.json
+  tag: ontologies
 
 # 
 # EC OWL
@@ -192,6 +236,7 @@
 -
   url: https://w3id.org/biopragmatics/resources/eccode/eccode.owl.gz
   local_name: ec.owl.gz
+  tag: ontologies
 
 #
 # BactoTraits
@@ -246,9 +291,11 @@
 -
   url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/metpo.owl
   local_name: metpo.owl
+  tag: ontologies
 -
   url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/metpo.json
   local_name: metpo.json
+  tag: ontologies
 
 #
 # RO (Relations Ontology)
@@ -257,6 +304,7 @@
 -
   url: http://purl.obolibrary.org/obo/ro.owl
   local_name: ro.owl
+  tag: ontologies
 
 #
 # PO (Plant Ontology)
@@ -270,6 +318,7 @@
 -
   url: http://purl.obolibrary.org/obo/po.owl
   local_name: po.owl
+  tag: ontologies
 
 #
 
@@ -282,6 +331,7 @@
 -
   url: http://purl.obolibrary.org/obo/taxrank.owl
   local_name: taxrank.owl
+  tag: ontologies
 
 #
 # MICRO (Microbial Conditions Ontology / OntologyOfMicrobialConditions)
@@ -292,6 +342,7 @@
 -
   url: https://raw.githubusercontent.com/carrineblank/MicrO/master/MicrOandImportModules/MicrO.owl
   local_name: micro.owl
+  tag: ontologies
 
 #
 # MicroMediaParam Chemical Mappings - High Confidence
@@ -318,6 +369,7 @@
 -
   url: https://github.com/CultureBotAI/MicroMediaParam/raw/main/pipeline_output/merge_mappings/compound_mappings_strict_final.tsv
   local_name: compound_mappings_strict.tsv
+  tag: mappings
 
 #
 # MicroMediaParam Chemical Mappings - Hydrate (Takes Precedence)
@@ -330,6 +382,7 @@
 -
   url: https://github.com/CultureBotAI/MicroMediaParam/raw/main/pipeline_output/merge_mappings/compound_mappings_strict_final_hydrate.tsv
   local_name: compound_mappings_strict_hydrate.tsv
+  tag: mappings
 
 #
 # COG (Clusters of Orthologous Groups)
@@ -337,9 +390,11 @@
 -
   url: https://ftp.ncbi.nlm.nih.gov/pub/COG/COG2024/data/cog-24.def.tab
   local_name: cog/cog-24.def.tab
+  tag: cog
 -
   url: https://ftp.ncbi.nlm.nih.gov/pub/COG/COG2024/data/cog-24.fun.tab
   local_name: cog/cog-24.fun.tab
+  tag: cog
 
 #
 # KEGG (Kyoto Encyclopedia of Genes and Genomes)
@@ -358,6 +413,7 @@
 -
   url: https://rest.kegg.jp/list/ko
   local_name: kegg/ko_list.txt
+  tag: kegg
 
 #
 # GTDB (Genome Taxonomy Database)
@@ -365,15 +421,19 @@
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/bac120_taxonomy.tsv
   local_name: gtdb/bac120_taxonomy.tsv
+  tag: gtdb
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/ar53_taxonomy.tsv
   local_name: gtdb/ar53_taxonomy.tsv
+  tag: gtdb
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/bac120_metadata.tsv.gz
   local_name: gtdb/bac120_metadata.tsv.gz
+  tag: gtdb
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/ar53_metadata.tsv.gz
   local_name: gtdb/ar53_metadata.tsv.gz
+  tag: gtdb
 
 #
 # MetaTraits
@@ -385,12 +445,15 @@
 -
   url: gdrive:1vL9wujvty4Xh2ZG2HHquX0RE7968Dkbm
   local_name: ncbi_species_summary.jsonl.gz
+  tag: metatraits
 -
   url: gdrive:1WL6VhD2I6MGuI3iHKbCQYTncG1UB-u6e
   local_name: ncbi_genus_summary.jsonl.gz
+  tag: metatraits
 -
   url: gdrive:1pgOugA5jQG96GbCktkTJN9FGn6rypTOI
   local_name: ncbi_family_summary.jsonl.gz
+  tag: metatraits
 
 #
 # MetaTraits GTDB
@@ -434,6 +497,7 @@
 -
   url: https://raw.githubusercontent.com/biolink/biolink-model/v4.3.6/biolink-model.yaml
   local_name: biolink-model.yaml
+  tag: schema
 
 #
 # KGX Format Specification
@@ -442,6 +506,7 @@
 -
   url: https://raw.githubusercontent.com/biolink/kgx/master/docs/kgx_format.md
   local_name: kgx-format.md
+  tag: schema
 
 
 #
@@ -484,12 +549,15 @@
 -
   url: https://semanticsql.berkeleybop.io/ncit.db.gz
   local_name: ncit.db.gz
+  tag: stubs
 -
   url: https://semanticsql.berkeleybop.io/bto.db.gz
   local_name: bto.db.gz
+  tag: stubs
 -
   url: https://semanticsql.berkeleybop.io/po.db.gz
   local_name: po.db.gz
+  tag: stubs
 
 #
 # MeSH (Medical Subject Headings) — full N-Triples RDF from NLM
@@ -505,6 +573,7 @@
 -
   url: https://nlmpubs.nlm.nih.gov/projects/mesh/rdf/2026/mesh2026.nt.gz
   local_name: mesh2026.nt.gz
+  tag: stubs
 
 #
 # LPSN — List of Prokaryotic names with Standing in Nomenclature

--- a/download.yaml
+++ b/download.yaml
@@ -269,7 +269,7 @@
 # Original (broken TLS) source, kept for provenance:
 #   https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
 -
-  url: gdrive:REPLACE_ME_bactotraits_v2_jun2022  # md5 e6bca5b947c1aa692d45ac24aa9025f3
+  url: gdrive:1u7snG4VxbH6sh6M03dS1GumoYgLgbZrr  # md5 e6bca5b947c1aa692d45ac24aa9025f3
   local_name: BactoTraits_databaseV2_Jun2022.csv
   tag: bactotraits
 
@@ -495,15 +495,15 @@
 # the TSV would need a transform change, so the pinned JSONL build stays the
 # input. See docs/DATA_HOSTING.md.
 -
-  url: gdrive:REPLACE_ME_gtdb_species_summary   # md5 aca98ae9c978f238ae7844beaccec63b
+  url: gdrive:1xfZiMly-lJgcPL5ihR6QK1zxlv_JwC6J   # md5 aca98ae9c978f238ae7844beaccec63b
   local_name: gtdb_species_summary.jsonl.gz
   tag: metatraits_gtdb
 -
-  url: gdrive:REPLACE_ME_gtdb_genus_summary     # md5 159828de09d22a7c85e2116e8a97944a
+  url: gdrive:1Kotk8g5Ky_Cc9MNiywO_Tjz6JLEG0y7Y     # md5 159828de09d22a7c85e2116e8a97944a
   local_name: gtdb_genus_summary.jsonl.gz
   tag: metatraits_gtdb
 -
-  url: gdrive:REPLACE_ME_gtdb_family_summary    # md5 1443132d2aa0f3d8743b23096ce23a13
+  url: gdrive:1HpkfGAtZI1uRwyPzbTJFtI6avWlkEAlE    # md5 1443132d2aa0f3d8743b23096ce23a13
   local_name: gtdb_family_summary.jsonl.gz
   tag: metatraits_gtdb
 
@@ -527,11 +527,11 @@
 # rebuild months apart would silently use different crosswalks. The Drive copy
 # fixes the release; refresh it deliberately, from the URLs above.
 -
-  url: gdrive:REPLACE_ME_gtdb2ncbi          # md5 a313f89ac32b7137c7225c789f724f63
+  url: gdrive:1ip7ualwruocq9MvcaoNAcH0YtLtAEASP          # md5 a313f89ac32b7137c7225c789f724f63
   local_name: GTDB2NCBI.tsv.gz
   tag: metatraits_gtdb
 -
-  url: gdrive:REPLACE_ME_ncbi2gtdb          # md5 eca29d35869dd9035730caa12de12598
+  url: gdrive:1npQ1z2Yc0NRPHpBkKjsKIBy2_evDAyCV          # md5 eca29d35869dd9035730caa12de12598
   local_name: NCBI2GTDB.tsv.gz
   tag: metatraits_gtdb
 

--- a/download.yaml
+++ b/download.yaml
@@ -67,7 +67,7 @@
   local_name: robot.jar
   tag: tools
 -
-  url: https://raw.githubusercontent.com/ontodev/robot/master/bin/robot 
+  url: https://raw.githubusercontent.com/ontodev/robot/master/bin/robot
   local_name: robot
   tag: tools
 

--- a/download.yaml
+++ b/download.yaml
@@ -258,13 +258,12 @@
 
 #
 # BactoTraits
-# NOTE: Commented out — the host (ordar.otelo.univ-lorraine.fr) serves a broken
-# TLS certificate chain (incomplete intermediate) that no CA bundle can verify,
-# so this download aborts the whole run. BactoTraits V2 is a static Jun-2022
-# dataset; the last public copy is vendored into
-# data/raw/BactoTraits_databaseV2_Jun2022.csv from data/raw_last8/, so the
-# bactotraits transform runs normally. To refresh, fetch the CSV manually
-# (verification relaxed) to that path, then re-enable this entry.
+# Served from our Drive copy, not from the origin: the host
+# (ordar.otelo.univ-lorraine.fr) presents a broken TLS chain (incomplete
+# intermediate) that no CA bundle can verify, which aborts the whole run.
+# BactoTraits V2 is a static Jun-2022 dataset, so a pinned copy loses nothing.
+# To refresh, fetch the CSV manually (verification relaxed), re-upload, and
+# update the md5 recorded beside the URL. See docs/DATA_HOSTING.md.
 #
 # Original (broken TLS) source, kept for provenance:
 #   https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
@@ -481,10 +480,17 @@
 # Microbial trait data from MetaTraits organized by GTDB taxonomy (R220)
 # Enables genome-level trait associations via GTDB taxonomy
 # NOTE: Requires overlap analysis to assess value vs NCBITaxon metatraits
-# NOTE: Commented out — the metatraits.embl.de/static/downloads/ endpoint now
-# returns HTTP 404 for all of these (access moved behind permission from
-# antheaguo@berkeley.edu). The last public copies (2026-03-24) are vendored
-# into data/raw/ from data/raw_last8/. To refresh, obtain access and re-enable.
+# Served from our Drive copy: metatraits.embl.de/static/downloads/ now returns
+# HTTP 404 for all of these, and the JSONL serialization is discontinued
+# upstream entirely (only .tsv.gz variants are published now). Pinned as one set
+# with the other MetaTraits inputs so a rebuild uses a single fixed release.
+#
+# Genus and family are declared but not read today — the transform reads only the
+# species summary (METATRAITS_GTDB_INPUT_FILES, genus/family commented out
+# there). They are kept because they belong to the pinned set and switching the
+# transform to read them is a one-line change; contrast po.db.gz, which was
+# removed because PO's hierarchy comes from po.owl and no code path could ever
+# read the DB. See docs/DATA_HOSTING.md.
 #
 # Original (now HTTP 404) sources, kept for provenance:
 #   https://metatraits.embl.de/static/downloads/gtdb_{species,genus,family}_summary.jsonl.gz
@@ -508,10 +514,10 @@
   tag: metatraits_gtdb
 
 #
-# GTDB-NCBITaxon Mappings (for overlap analysis)
-# Maps between GTDB R220 and NCBITaxon taxonomies
-# NOTE: Commented out — same dead metatraits.embl.de endpoint (HTTP 404).
-# Last public copies (2026-03-24) vendored into data/raw/ from data/raw_last8/.
+# GTDB-NCBITaxon Mappings
+# Maps between GTDB R220 and NCBITaxon taxonomies. NCBI2GTDB.tsv.gz is read by
+# the metatraits transform; GTDB2NCBI.tsv.gz is the reverse direction, declared
+# so the pinned set is complete and symmetric.
 #
 # GTDB r220 <-> NCBI 2025-07-28 crosswalks, assigned where >=85% of genomes
 # share the same ID in both taxonomies. NCBI2GTDB.tsv.gz is read by the

--- a/download.yaml
+++ b/download.yaml
@@ -332,9 +332,9 @@
 # The ~6 PO CURIEs referenced by BacDive isolation_source mappings sit in
 # a coherent subtree under PO:0025131 (plant anatomical entity). The stub
 # transform runs ROBOT MIREOT against this OWL to emit those stubs plus
-# their ancestor chain (~21 nodes, ~23 subClassOf edges). See also the
-# `po.db.gz` entry under the stub-import section below — kept for any
-# future caller wanting the full SemSQL DB.
+# their ancestor chain (~21 nodes, ~23 subClassOf edges). This OWL is the
+# single source for PO — there is intentionally no po.db entry in the
+# stub-import section below.
 #
 -
   url: http://purl.obolibrary.org/obo/po.owl
@@ -588,10 +588,13 @@
 # download.py, not kg_microbe/download.py), so no extra header config is
 # needed here.
 #
-# MICRO's SemSQL distribution (micro.db.gz) is a 29-byte truncated placeholder
-# rather than a real SemSQL DB; PO's SemSQL .db is fine but the OWL path is the
-# one the stub transform exercises for hierarchy. The MICRO and PO OWLs are
-# declared above in the ontologies section.
+# Only BTO and NCIT are fetched as SemSQL DBs, because only they are read that
+# way (source_type semsql_mireot / label-only OAK lookups), and neither has an
+# OWL declared here, so there is no second copy to drift from. MICRO's SemSQL
+# distribution (micro.db.gz) is a 29-byte truncated placeholder rather than a
+# real DB, and PO's — while a valid DB — was never read by anything. Both take
+# the ROBOT MIREOT path against their OWLs, declared above in the ontologies
+# section.
 #
 -
   url: https://semanticsql.berkeleybop.io/ncit.db.gz
@@ -601,10 +604,11 @@
   url: https://semanticsql.berkeleybop.io/bto.db.gz
   local_name: bto.db.gz
   tag: stubs
--
-  url: https://semanticsql.berkeleybop.io/po.db.gz
-  local_name: po.db.gz
-  tag: stubs
+# PO deliberately has no SemSQL .db entry. Its stub import is owl_mireot against
+# po.owl (see STUB_ONTOLOGY_SOURCES["PO"]), so nothing ever read po.db — the
+# downloaded po.db.gz was never even decompressed. Removing it also removes a
+# second, independently-versioned copy of PO that could drift from po.owl with no
+# gate to catch it (#604). Re-add only alongside a switch to semsql_mireot.
 
 #
 # MeSH (Medical Subject Headings) — full N-Triples RDF from NLM

--- a/download.yaml
+++ b/download.yaml
@@ -269,7 +269,7 @@
 # Original (broken TLS) source, kept for provenance:
 #   https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
 -
-  url: gdrive:REPLACE_ME_bactotraits_v2_jun2022
+  url: gdrive:REPLACE_ME_bactotraits_v2_jun2022  # md5 e6bca5b947c1aa692d45ac24aa9025f3
   local_name: BactoTraits_databaseV2_Jun2022.csv
   tag: bactotraits
 
@@ -490,16 +490,20 @@
 #   https://metatraits.embl.de/static/downloads/gtdb_{species,genus,family}_summary.jsonl.gz
 # Only the species summary is read by the transform; genus/family are declared
 # here for completeness (see METATRAITS_GTDB_INPUT_FILES).
+# The JSONL serialization is discontinued upstream; only *_all.tsv.gz and
+# *_no_predictions.tsv.gz are published now (ours corresponds to _all). Reading
+# the TSV would need a transform change, so the pinned JSONL build stays the
+# input. See docs/DATA_HOSTING.md.
 -
-  url: gdrive:REPLACE_ME_gtdb_species_summary
+  url: gdrive:REPLACE_ME_gtdb_species_summary   # md5 aca98ae9c978f238ae7844beaccec63b
   local_name: gtdb_species_summary.jsonl.gz
   tag: metatraits_gtdb
 -
-  url: gdrive:REPLACE_ME_gtdb_genus_summary
+  url: gdrive:REPLACE_ME_gtdb_genus_summary     # md5 159828de09d22a7c85e2116e8a97944a
   local_name: gtdb_genus_summary.jsonl.gz
   tag: metatraits_gtdb
 -
-  url: gdrive:REPLACE_ME_gtdb_family_summary
+  url: gdrive:REPLACE_ME_gtdb_family_summary    # md5 1443132d2aa0f3d8743b23096ce23a13
   local_name: gtdb_family_summary.jsonl.gz
   tag: metatraits_gtdb
 
@@ -509,21 +513,25 @@
 # NOTE: Commented out — same dead metatraits.embl.de endpoint (HTTP 404).
 # Last public copies (2026-03-24) vendored into data/raw/ from data/raw_last8/.
 #
-# These moved off metatraits.embl.de/static/downloads/ (now HTTP 404) to the
-# Bork group's own web space, which the metaTraits documentation page points at:
-# https://metatraits.embl.de/documentation. Verified 2026-07-25: both URLs
-# return byte-identical files to the copies previously vendored into data/raw
-# (NCBI2GTDB md5 eca29d35869dd9035730caa12de12598,
-#  GTDB2NCBI md5 a313f89ac32b7137c7225c789f724f63).
-# Mapping is GTDB r220 <-> NCBI 2025-07-28, assigned where >=85% of genomes
-# share the same ID in both taxonomies.
-# NCBI2GTDB.tsv.gz is read by the metatraits transform (_load_ncbi_gtdb_mappings).
+# GTDB r220 <-> NCBI 2025-07-28 crosswalks, assigned where >=85% of genomes
+# share the same ID in both taxonomies. NCBI2GTDB.tsv.gz is read by the
+# metatraits transform (_load_ncbi_gtdb_mappings).
+#
+# These are still published upstream, at the Bork group's web space (linked from
+# https://metatraits.embl.de/documentation):
+#   https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
+#   https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
+# Verified 2026-07-25: byte-identical to the pinned copies below. We deliberately
+# do NOT point at those URLs — it is an unversioned personal directory whose
+# contents are regenerated in place (our build is dated 2025-08-14), so a KG
+# rebuild months apart would silently use different crosswalks. The Drive copy
+# fixes the release; refresh it deliberately, from the URLs above.
 -
-  url: https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
+  url: gdrive:REPLACE_ME_gtdb2ncbi          # md5 a313f89ac32b7137c7225c789f724f63
   local_name: GTDB2NCBI.tsv.gz
   tag: metatraits_gtdb
 -
-  url: https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
+  url: gdrive:REPLACE_ME_ncbi2gtdb          # md5 eca29d35869dd9035730caa12de12598
   local_name: NCBI2GTDB.tsv.gz
   tag: metatraits_gtdb
 

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -24,6 +24,18 @@ MEDIADIVE_TAG = "mediadive"
 PENDING_HOSTING_MARKER = "REPLACE_ME_"
 
 
+class UnknownDownloadTagError(ValueError):
+
+    """
+    Raised when a requested -t tag matches no entry in the download config.
+
+    A dedicated type so the CLI can report bad tags as usage errors without
+    also swallowing unrelated ValueErrors raised deeper in the download (JSON
+    decode failures and pydantic ValidationError are both ValueError
+    subclasses, and were being presented as "Invalid value" for -t).
+    """
+
+
 def download(
     yaml_file: str,
     output_dir: str,
@@ -133,14 +145,14 @@ def _validate_tags(yaml_file: str, tags: Sequence[str]) -> None:
 
     :param yaml_file: Path to the download config being filtered.
     :param tags: Tags requested on the command line.
-    :raises ValueError: If any tag matches no entry.
+    :raises UnknownDownloadTagError: If any tag matches no entry.
     """
     with open(yaml_file) as f:
         entries = yaml.safe_load(f) or []
     known = {entry.get("tag") for entry in entries if entry.get("tag")}
     unknown = sorted(set(tags) - known)
     if unknown:
-        raise ValueError(
+        raise UnknownDownloadTagError(
             f"Unknown download tag(s): {', '.join(unknown)}. Available tags in {yaml_file}: {', '.join(sorted(known))}"
         )
 

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -42,7 +42,8 @@ def _post_download_mediadive_bulk(output_dir: str, ignore_cache: bool = False) -
     API calls during transform.
 
     :param output_dir: Output directory where data is downloaded
-    :param ignore_cache: If True, re-download even if bulk files exist
+    :param ignore_cache: If True, re-download even if bulk files exist, and
+        discard cached HTTP responses so the API is actually re-queried
     """
     mediadive_basic_file = Path(output_dir) / "mediadive.json"
     mediadive_bulk_dir = Path(output_dir) / "mediadive"
@@ -72,7 +73,7 @@ def _post_download_mediadive_bulk(output_dir: str, ignore_cache: bool = False) -
     print("\n" + "=" * 80)
     print("Starting MediaDive bulk download...")
     print("=" * 80)
-    download_mediadive_bulk(str(mediadive_basic_file), str(mediadive_bulk_dir))
+    download_mediadive_bulk(str(mediadive_basic_file), str(mediadive_bulk_dir), ignore_cache=ignore_cache)
     print("=" * 80)
     print("MediaDive bulk download complete!")
     print("=" * 80 + "\n")

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -1,8 +1,10 @@
 """Download resources from YAML file."""
 
+import tempfile
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 
+import yaml
 from kghub_downloader.download_utils import download_from_yaml
 
 from kg_microbe.utils.mediadive_bulk_download import download_mediadive_bulk
@@ -13,6 +15,13 @@ from kg_microbe.utils.mediadive_bulk_download import download_mediadive_bulk
 # off an hour of MediaDive API calls just because mediadive.json is on disk
 # from an earlier run.
 MEDIADIVE_TAG = "mediadive"
+
+# Marker for a source whose original URL is dead and whose replacement copy is
+# not hosted yet (see the "pending hosting" note in download.yaml). Such entries
+# are declared normally — so they carry a tag, appear in the config, and start
+# working the moment a real URL is pasted in — but are skipped at download time.
+# Without the skip, the placeholder URL would raise and abort the whole run.
+PENDING_HOSTING_MARKER = "REPLACE_ME_"
 
 
 def download(
@@ -41,13 +50,21 @@ def download(
     if tags:
         _validate_tags(yaml_file, tags)
 
-    download_from_yaml(
-        yaml_file=yaml_file,
-        output_dir=output_dir,
-        snippet_only=snippet_only,
-        ignore_cache=ignore_cache,
-        tags=tags,
-    )
+    effective_yaml, pending = _without_pending_hosting(yaml_file, tags)
+    if pending:
+        _report_pending(pending)
+
+    try:
+        download_from_yaml(
+            yaml_file=effective_yaml,
+            output_dir=output_dir,
+            snippet_only=snippet_only,
+            ignore_cache=ignore_cache,
+            tags=tags,
+        )
+    finally:
+        if effective_yaml != yaml_file:
+            Path(effective_yaml).unlink(missing_ok=True)
 
     # Post-download: Trigger MediaDive bulk download if mediadive.json was downloaded
     if snippet_only:  # Skip bulk download in snippet mode
@@ -55,6 +72,56 @@ def download(
     if tags and MEDIADIVE_TAG not in tags:
         return
     _post_download_mediadive_bulk(output_dir, ignore_cache)
+
+
+def _without_pending_hosting(yaml_file: str, tags: Optional[Sequence[str]]) -> Tuple[str, List[dict]]:
+    """
+    Split off entries still carrying a hosting placeholder.
+
+    kghub-downloader reads the config file itself and aborts the whole run on the
+    first download error, so a placeholder URL cannot simply be left in place.
+    When any is present we hand the downloader a filtered copy of the config
+    instead.
+
+    :param yaml_file: Path to the download config.
+    :param tags: Tags the run is restricted to, or None for all.
+    :return: (config path to use, list of skipped entries). The path is the
+        original when nothing is pending; otherwise a temp file the caller must
+        delete.
+    """
+    with open(yaml_file) as f:
+        entries = yaml.safe_load(f) or []
+
+    def is_pending(entry: dict) -> bool:
+        """Report whether this entry's URL is still a hosting placeholder."""
+        return PENDING_HOSTING_MARKER in entry.get("url", "")
+
+    # Only entries this run would actually have attempted are worth reporting.
+    selected = [e for e in entries if not tags or e.get("tag") in tags]
+    pending = [e for e in selected if is_pending(e)]
+    if not pending:
+        return yaml_file, []
+
+    ready = [e for e in entries if not is_pending(e)]
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tmp:
+        yaml.safe_dump(ready, tmp, sort_keys=False)
+        return tmp.name, pending
+
+
+def _report_pending(pending: Sequence[dict]) -> None:
+    """
+    Tell the user which sources were skipped and why.
+
+    A silent skip would look like a successful download of a file that never
+    arrived — the same failure mode as an unknown tag.
+
+    :param pending: Entries skipped because their URL is a placeholder.
+    """
+    print(f"\nSkipping {len(pending)} source(s) whose replacement copy is not hosted yet:")
+    for entry in pending:
+        print(f"  - {entry.get('local_name')} (tag: {entry.get('tag')})")
+    print("  Copy these from a reference data/raw_* directory, or paste the real")
+    print("  URL over the REPLACE_ME_ placeholder in download.yaml once hosted.\n")
 
 
 def _validate_tags(yaml_file: str, tags: Sequence[str]) -> None:
@@ -68,8 +135,6 @@ def _validate_tags(yaml_file: str, tags: Sequence[str]) -> None:
     :param tags: Tags requested on the command line.
     :raises ValueError: If any tag matches no entry.
     """
-    import yaml  # local import: only needed when filtering
-
     with open(yaml_file) as f:
         entries = yaml.safe_load(f) or []
     known = {entry.get("tag") for entry in entries if entry.get("tag")}

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -1,13 +1,27 @@
 """Download resources from YAML file."""
 
 from pathlib import Path
+from typing import Optional, Sequence
 
 from kghub_downloader.download_utils import download_from_yaml
 
 from kg_microbe.utils.mediadive_bulk_download import download_mediadive_bulk
 
+# Tag (in download.yaml) of the entry that pulls the MediaDive media list. A
+# tag-filtered run only does the follow-on bulk API download when MediaDive is
+# among the requested tags — otherwise `kg download -t ontologies` would kick
+# off an hour of MediaDive API calls just because mediadive.json is on disk
+# from an earlier run.
+MEDIADIVE_TAG = "mediadive"
 
-def download(yaml_file: str, output_dir: str, snippet_only: bool, ignore_cache: bool = False) -> None:
+
+def download(
+    yaml_file: str,
+    output_dir: str,
+    snippet_only: bool,
+    ignore_cache: bool = False,
+    tags: Optional[Sequence[str]] = None,
+) -> None:
     """
     Download data files from list of URLs.
 
@@ -19,18 +33,51 @@ def download(yaml_file: str, output_dir: str, snippet_only: bool, ignore_cache: 
     :param output_dir: A string pointing to the location to download data to.
     :param snippet_only: Downloads only the first 5 kB of the source,for testing and file checks.
     :param ignore_cache: Ignore cache and download files even if they exist [false]
+    :param tags: Only download entries carrying one of these tags. None or empty
+        means download everything.
     :return: None.
     """
+    tags = list(tags) if tags else None
+    if tags:
+        _validate_tags(yaml_file, tags)
+
     download_from_yaml(
         yaml_file=yaml_file,
         output_dir=output_dir,
         snippet_only=snippet_only,
         ignore_cache=ignore_cache,
+        tags=tags,
     )
 
     # Post-download: Trigger MediaDive bulk download if mediadive.json was downloaded
-    if not snippet_only:  # Skip bulk download in snippet mode
-        _post_download_mediadive_bulk(output_dir, ignore_cache)
+    if snippet_only:  # Skip bulk download in snippet mode
+        return
+    if tags and MEDIADIVE_TAG not in tags:
+        return
+    _post_download_mediadive_bulk(output_dir, ignore_cache)
+
+
+def _validate_tags(yaml_file: str, tags: Sequence[str]) -> None:
+    """
+    Fail fast on a tag that matches nothing in the YAML.
+
+    kghub-downloader silently downloads zero files for an unknown tag, which
+    looks exactly like a successful no-op run.
+
+    :param yaml_file: Path to the download config being filtered.
+    :param tags: Tags requested on the command line.
+    :raises ValueError: If any tag matches no entry.
+    """
+    import yaml  # local import: only needed when filtering
+
+    with open(yaml_file) as f:
+        entries = yaml.safe_load(f) or []
+    known = {entry.get("tag") for entry in entries if entry.get("tag")}
+    unknown = sorted(set(tags) - known)
+    if unknown:
+        raise ValueError(
+            f"Unknown download tag(s): {', '.join(unknown)}. Available tags in {yaml_file}: {', '.join(sorted(known))}"
+        )
 
 
 def _post_download_mediadive_bulk(output_dir: str, ignore_cache: bool = False) -> None:

--- a/kg_microbe/run.py
+++ b/kg_microbe/run.py
@@ -42,6 +42,13 @@ def main():
     default=False,
     help="ignore cache and download files even if they exist [false]",
 )
+@click.option(
+    "tags",
+    "-t",
+    "--tag",
+    multiple=True,
+    help="only download sources with this tag (repeatable); omit for all. See the tag list in download.yaml's header.",
+)
 def download(*args, **kwargs) -> None:
     """
     Download from list of URLs (default: download.yaml) into data directory (default: data/raw).
@@ -50,9 +57,15 @@ def download(*args, **kwargs) -> None:
     :param output_dir: A string pointing to the directory to download data to.
     :param snippet_only: Download 5 kB of each uncompressed source, for testing and file checks.
     :param ignore_cache: If specified, will ignore existing files and download again.
+    :param tags: Restrict the run to sources carrying these tags (all sources if empty).
+    :raises click.BadParameter: If a requested tag matches no entry in the YAML.
     :return: None
     """
-    kg_download(*args, **kwargs)
+    try:
+        kg_download(*args, **kwargs)
+    except ValueError as e:
+        # An unknown -t value is user error, not a crash — report it as such.
+        raise click.BadParameter(str(e)) from e
 
     return None
 

--- a/kg_microbe/run.py
+++ b/kg_microbe/run.py
@@ -10,6 +10,7 @@ import click
 warnings.filterwarnings("ignore", message=".*pkg_resources is deprecated.*", category=UserWarning)
 
 from kg_microbe import download as kg_download  # noqa: E402
+from kg_microbe.download import UnknownDownloadTagError  # noqa: E402
 from kg_microbe.merge_utils.merge_kg import load_and_merge  # noqa: E402
 from kg_microbe.query import parse_query_yaml, result_dict_to_tsv, run_query  # noqa: E402
 from kg_microbe.transform import DATA_SOURCES  # noqa: E402
@@ -63,8 +64,11 @@ def download(*args, **kwargs) -> None:
     """
     try:
         kg_download(*args, **kwargs)
-    except ValueError as e:
+    except UnknownDownloadTagError as e:
         # An unknown -t value is user error, not a crash — report it as such.
+        # Deliberately narrow: a blanket `except ValueError` also caught
+        # JSONDecodeError and pydantic ValidationError from deeper in the
+        # download and mislabelled them as bad tags, hiding the traceback.
         raise click.BadParameter(str(e)) from e
 
     return None

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -189,12 +189,18 @@ def _open_maybe_gzipped(path: Path):
     :return: An open text-mode handle.
     """
     if path.name.endswith(".gz"):
+        handle = None
         try:
-            f = gzip.open(path, "rt", encoding="utf-8")
-            f.read(1)  # Trigger gzip header read
-            f.seek(0)
-            return f
+            handle = gzip.open(path, "rt", encoding="utf-8")
+            handle.read(1)  # Trigger gzip header read
+            handle.seek(0)
+            return handle
         except gzip.BadGzipFile:
+            # The probe already opened the file; without this close the handle
+            # leaks on every decompressed-.gz read (#621), which is the normal
+            # case for the Drive-hosted inputs.
+            if handle is not None:
+                handle.close()
             return open(path, "r", encoding="utf-8")
     return open(path, "r", encoding="utf-8")
 

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -139,8 +139,19 @@ def _ensure_ncbitaxon_db_ready() -> None:
     if oak_cache.exists():
         cache_ok, cache_reason = _validate_ncbitaxon_db(oak_cache)
         if cache_ok:
-            if local_db.exists() or local_db.is_symlink():
+            # Never trade a real local DB for the symlink. _validate_ncbitaxon_db
+            # wraps an OAK query in a bare `except Exception`, so a transient
+            # adapter error would otherwise delete a 13 GB build that took hours
+            # and replace it with the very artifact this design avoids.
+            if local_db.is_symlink():
                 local_db.unlink()
+            elif local_db.exists():
+                print(
+                    f"  Keeping the existing {local_db} rather than replacing it with "
+                    f"the OAK cache; it failed validation ({reason}) — delete it "
+                    "manually if it is genuinely corrupt."
+                )
+                return
             local_db.symlink_to(oak_cache)
             print(f"  Repaired symlink: {local_db} -> {oak_cache}")
             return
@@ -153,11 +164,12 @@ def _ensure_ncbitaxon_db_ready() -> None:
         f"  local: {local_db} ({reason})\n"
         f"  cache: {oak_cache} ({'missing' if not oak_cache.exists() else 'invalid'})\n"
         "Remediation:\n"
-        "  1. Remove corrupt cache: rm ~/.data/oaklib/ncbitaxon.db\n"
-        "  2. Re-download sequentially (not in parallel):\n"
-        "     poetry run python -c 'from oaklib import get_adapter; "
-        'get_adapter("sqlite:obo:ncbitaxon")\'\n'
-        "  3. Re-run the transform."
+        "  1. Remove the local DB (a symlink here is safe to delete):\n"
+        "     rm data/raw/ncbitaxon.db\n"
+        "  2. Re-run the transform; it rebuilds from ncbitaxon.owl via `semsql make`.\n"
+        "     Refreshing OAK's prebuilt cache instead does NOT realign the release,\n"
+        "     and deleting ~/.data/oaklib/ncbitaxon.db while data/raw/ncbitaxon.db\n"
+        "     symlinks to it leaves a dangling link."
     )
 
 
@@ -734,9 +746,26 @@ class MetaTraitsTransform(Transform):
                             "mapping_type": mapping_type,
                             "confidence": "high",
                         }
-            print(f"  Loaded {len(gtdb_mappings)} NCBI to GTDB taxon mappings")
+            if not gtdb_mappings:
+                # _open_maybe_gzipped tolerates a non-gzip payload, which is right
+                # for the Drive-hosted inputs that arrive decompressed — but it also
+                # means an HTML quota interstitial or a 0-byte file reads as an empty
+                # table and would otherwise print the success line above. Master's
+                # bare gzip.open at least raised BadGzipFile here.
+                print(
+                    f"  Warning: {mappings_file} yielded no NCBI to GTDB mappings. "
+                    "The file is present but has no usable rows — check it is the "
+                    "real crosswalk and not an error page or a truncated download."
+                )
+            else:
+                print(f"  Loaded {len(gtdb_mappings)} NCBI to GTDB taxon mappings")
         except Exception as e:
-            print(f"  Warning: Could not load NCBI to GTDB mappings: {e}")
+            # A partially-read file keeps whatever rows were parsed; say so, because
+            # a half-loaded crosswalk is indistinguishable from a smaller one.
+            print(
+                f"  Warning: Could not fully load NCBI to GTDB mappings: {e} "
+                f"({len(gtdb_mappings)} mappings loaded before the error)"
+            )
 
         return gtdb_mappings
 

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -60,9 +60,9 @@ METATRAITS_INPUT_FILES = [
 ]
 
 
-# Minimum plausible size for a healthy NCBITaxon OAK DB. Full file is ~12 GB;
-# any smaller and it's a partial extract/download, regardless of SQLite header.
-_NCBITAXON_DB_MIN_SIZE = 1_000_000_000  # 1 GB
+# Single source of truth lives in ontology_utils, alongside the builder that
+# enforces it (_ensure_ncbitaxon_db).
+from kg_microbe.utils.ontology_utils import _NCBITAXON_DB_MIN_SIZE  # noqa: E402
 
 
 def _ncbitaxon_db_paths() -> Tuple[Path, Path]:
@@ -108,6 +108,8 @@ def _ensure_ncbitaxon_db_ready() -> None:
 
     Raises RuntimeError with remediation steps if no valid DB can be found.
     """
+    from kg_microbe.utils.ontology_utils import _ensure_ncbitaxon_db
+
     local_db, oak_cache = _ncbitaxon_db_paths()
 
     # Happy path: symlink resolves to a valid DB.
@@ -118,7 +120,20 @@ def _ensure_ncbitaxon_db_ready() -> None:
 
     print(f"  NCBITaxon DB at {local_db} invalid ({reason}); attempting repair")
 
-    # Attempt repair from OAK cache.
+    # Preferred repair: build from the ncbitaxon.owl this run emits nodes from,
+    # so lookups and emitted nodes are the same release by construction (#604).
+    # A no-op when semsql or the OWL is unavailable, which leaves the OAK-cache
+    # fallback below as the last resort.
+    if _ensure_ncbitaxon_db(str(local_db)):
+        built_ok, built_reason = _validate_ncbitaxon_db(local_db)
+        if built_ok:
+            print(f"  Built NCBITaxon DB from OWL: {local_db}")
+            return
+        print(f"  Freshly built DB failed validation ({built_reason})")
+
+    # Fallback: adopt OAK's prebuilt cache. Its release is whatever the upstream
+    # CDN last published and may lag ncbitaxon.owl; assert_ncbitaxon_version_alignment
+    # surfaces that gap.
     if oak_cache.exists():
         cache_ok, cache_reason = _validate_ncbitaxon_db(oak_cache)
         if cache_ok:

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -161,12 +161,18 @@ def _get_ncbitaxon_adapter():
     return get_adapter(f"sqlite:{local_db}")
 
 
-def _open_jsonl(path: Path):
+def _open_maybe_gzipped(path: Path):
     """
-    Open JSONL file; use gzip for .gz files, plain text otherwise.
+    Open a ``.gz`` file that may not actually be gzip-compressed.
 
-    If a .gz file is not actually gzip-compressed (e.g. misnamed plain JSON),
-    falls back to plain text.
+    Google Drive silently serves some uploads decompressed, so a file named
+    ``*.gz`` can arrive as plain text — this is how the Drive-hosted
+    ``ncbi_*_summary.jsonl.gz`` inputs ended up as plain JSON in ``data/raw``.
+    Every read of a Drive-hosted input must go through here rather than calling
+    ``gzip.open`` directly.
+
+    :param path: File to open.
+    :return: An open text-mode handle.
     """
     if path.name.endswith(".gz"):
         try:
@@ -177,6 +183,16 @@ def _open_jsonl(path: Path):
         except gzip.BadGzipFile:
             return open(path, "r", encoding="utf-8")
     return open(path, "r", encoding="utf-8")
+
+
+def _open_jsonl(path: Path):
+    """
+    Open JSONL file; use gzip for .gz files, plain text otherwise.
+
+    If a .gz file is not actually gzip-compressed (e.g. misnamed plain JSON),
+    falls back to plain text.
+    """
+    return _open_maybe_gzipped(path)
 
 
 def _process_file_worker(args: Tuple[Path, Path, Dict[str, Any], bool]) -> Dict[str, Any]:
@@ -672,7 +688,10 @@ class MetaTraitsTransform(Transform):
             return gtdb_mappings
 
         try:
-            with gzip.open(mappings_file, "rt", encoding="utf-8") as f:
+            # Not gzip.open: this file is Drive-hosted and can arrive
+            # decompressed. The except below would swallow BadGzipFile and
+            # leave the mappings silently empty.
+            with _open_maybe_gzipped(mappings_file) as f:
                 reader = csv.DictReader(f, delimiter="\t")
                 for row in reader:
                     ncbi_species = row.get("species (NCBI)", "").strip()

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -50,6 +50,10 @@ from kg_microbe.utils.metpo_predicates import (  # noqa: E402
 )
 from kg_microbe.utils.microbial_trait_mappings import load_microbial_trait_mappings  # noqa: E402
 from kg_microbe.utils.oak_utils import search_by_label  # noqa: E402
+
+# _NCBITAXON_DB_MIN_SIZE is single-sourced in ontology_utils, beside the
+# builder that enforces it (_ensure_ncbitaxon_db).
+from kg_microbe.utils.ontology_utils import _NCBITAXON_DB_MIN_SIZE  # noqa: E402
 from kg_microbe.utils.pandas_utils import drop_duplicates  # noqa: E402
 
 # Input file names (transform accepts either ncbi_* or metatraits_* convention)
@@ -58,11 +62,6 @@ METATRAITS_INPUT_FILES = [
     "ncbi_species_summary.jsonl.gz",
     "metatraits_species_summary.jsonl.gz",
 ]
-
-
-# Single source of truth lives in ontology_utils, alongside the builder that
-# enforces it (_ensure_ncbitaxon_db).
-from kg_microbe.utils.ontology_utils import _NCBITAXON_DB_MIN_SIZE  # noqa: E402
 
 
 def _ncbitaxon_db_paths() -> Tuple[Path, Path]:

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -126,9 +126,12 @@ def _ensure_ncbitaxon_db_ready() -> None:
     if _ensure_ncbitaxon_db(str(local_db)):
         built_ok, built_reason = _validate_ncbitaxon_db(local_db)
         if built_ok:
-            print(f"  Built NCBITaxon DB from OWL: {local_db}")
+            print(f"  NCBITaxon DB ready from OWL: {local_db}")
             return
-        print(f"  Freshly built DB failed validation ({built_reason})")
+        # Deliberately does not claim a build happened: _ensure_ncbitaxon_db also
+        # returns True on its reuse path, so this branch is usually reporting a
+        # DB that was already present and still fails validation.
+        print(f"  NCBITaxon DB at {local_db} still invalid after ensure ({built_reason})")
 
     # Fallback: adopt OAK's prebuilt cache. Its release is whatever the upstream
     # CDN last published and may lag ncbitaxon.owl; assert_ncbitaxon_version_alignment

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -94,9 +94,11 @@ ONTOLOGIES_MAP = {
     # are now per-CURIE imports via the OntologiesStubsTransform
     # (kg_microbe/transform_utils/ontologies_stubs/), which emits one
     # labelled stub node per referenced CURIE instead of pulling in
-    # ~2,170 + ~17,600 unrelated nodes. PO uses the bbop-sqlite SemSQL DB
-    # (data/raw/po.db); MICRO uses the obograph JSON (data/raw/micro.json)
-    # because MICRO's bbop-sqlite distribution is broken.
+    # ~2,170 + ~17,600 unrelated nodes. Both go through ROBOT MIREOT against
+    # the OWL (owl_mireot): PO from data/raw/po.owl, MICRO from
+    # data/raw/micro.owl. Neither uses a SemSQL .db — MICRO's bbop-sqlite
+    # distribution is a truncated placeholder, and PO's was downloaded but
+    # never read, so it was dropped from download.yaml (#604).
 }
 
 

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -447,15 +447,12 @@ class OntologiesTransform(Transform):
             # small molecules default to CHEBI_CATEGORY (biolink:ChemicalEntity)
             print("  Fixing ChEBI categories (detecting roles/macromolecules; default → CHEBI_CATEGORY)...")
 
-            # Create ChEBI adapter once to avoid file descriptor leaks
-            from oaklib import get_adapter
+            # Create ChEBI adapter once to avoid file descriptor leaks. Goes
+            # through get_chebi_adapter so chebi.db is built from (and checked
+            # against) the chebi.owl these nodes are emitted from.
+            from kg_microbe.utils.ontology_utils import get_chebi_adapter
 
-            from kg_microbe.transform_utils.constants import CHEBI_SOURCE
-
-            try:
-                chebi_adapter = get_adapter(f"sqlite:{CHEBI_SOURCE}")
-            except Exception:
-                chebi_adapter = get_adapter("sqlite:data/raw/chebi.db")
+            chebi_adapter = get_chebi_adapter()
 
             def fix_chebi_category(row):
                 """Fix ChEBI category (SmallMolecule/ChemicalRole) and replace deprecated categories."""

--- a/kg_microbe/utils/mediadive_bulk_download.py
+++ b/kg_microbe/utils/mediadive_bulk_download.py
@@ -14,12 +14,20 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import requests
-import requests_cache
+from requests_cache import CachedSession
+from requests_cache.backends.sqlite import SQLiteCache
 from tqdm import tqdm
 
 # Default to 5 workers — still a large speedup over sequential but polite to
 # MediaDive, which is a small academic REST API at DSMZ.
 DEFAULT_MAX_WORKERS = 5
+
+# Name of the HTTP response cache, stored alongside the bulk output files.
+CACHE_FILENAME = "mediadive_bulk_cache.sqlite"
+
+# Milliseconds a thread waits for the SQLite write lock before giving up. Each
+# thread holds its own connection, so brief contention on writes is expected.
+CACHE_BUSY_TIMEOUT_MS = 30_000
 
 # Descriptive User-Agent so the API operator can identify traffic source.
 USER_AGENT = "kg-microbe (Knowledge-Graph-Hub; https://github.com/Knowledge-Graph-Hub/kg-microbe)"
@@ -45,16 +53,112 @@ COMPOUND_ID_KEY = "compound_id"
 SOLUTION_ID_KEY = "solution_id"
 
 
-def setup_cache(cache_name: str = "mediadive_bulk_cache"):
-    """Set up HTTP caching to avoid re-downloading data."""
-    requests_cache.install_cache(cache_name, backend="sqlite")
-    print(f"HTTP cache enabled: {cache_name}.sqlite")
+# Per-thread HTTP sessions.
+#
+# requests_cache's SQLiteDict keeps a *single* sqlite3.Connection shared by every
+# caller (backends/sqlite.py: `self._connection`, opened with
+# check_same_thread=False) and deliberately takes no lock on reads:
+#
+#     # Read operations can be run in parallel (no lock or COMMIT)
+#     else:
+#         yield self._connection
+#
+# Driving one CachedSession from a ThreadPoolExecutor therefore runs concurrent
+# execute() calls on one connection, which tramples its internal pager state and
+# makes SQLite raise "database disk image is malformed" against a perfectly
+# intact file. Giving each thread its own CachedSession gives each thread its own
+# connection; multiple connections to one SQLite file is supported usage, and the
+# cached responses are still shared because they live in the same database.
+#
+# The previous implementation used requests_cache.install_cache(), which
+# monkeypatches requests.Session globally — every session in the process became a
+# CachedSession as a side effect. Caching is now explicit and scoped to this
+# module.
+_thread_local = threading.local()
+
+# Set by setup_cache(); None means "no HTTP caching" (plain sessions).
+_cache_path: Optional[Path] = None
+
+
+def setup_cache(cache_dir: Optional[Path] = None, migrate_legacy: bool = False) -> Optional[Path]:
+    """
+    Enable HTTP caching for subsequent sessions created by this module.
+
+    Args:
+    ----
+        cache_dir: Directory to hold the cache database. If None, caching is
+            disabled and plain (uncached) sessions are used.
+        migrate_legacy: If True, adopt a cache database left in the current
+            working directory by older versions of this module (which stored it
+            there). Off by default: this *moves* a file outside cache_dir, so
+            only the real download entry point should ask for it.
+
+    Returns:
+    -------
+        Path to the cache database, or None if caching was disabled.
+
+    """
+    global _cache_path
+
+    # Drop any sessions built against a previously configured cache.
+    _reset_sessions()
+
+    if cache_dir is None:
+        _cache_path = None
+        return None
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    _cache_path = cache_dir / CACHE_FILENAME
+    if migrate_legacy:
+        _migrate_legacy_cache(_cache_path)
+
+    # Create the tables up front so worker threads don't race on the initial
+    # CREATE TABLE when they open their own connections.
+    _make_backend()
+    print(f"HTTP cache enabled: {_cache_path}")
+    return _cache_path
+
+
+def _migrate_legacy_cache(cache_path: Path) -> None:
+    """
+    Move a cache database left in the working directory to its new home.
+
+    Older versions called requests_cache.install_cache(), which put the database
+    in the CWD (normally the repo root). Adopting it avoids re-downloading
+    thousands of already-cached MediaDive responses.
+    """
+    legacy_path = Path.cwd() / CACHE_FILENAME
+    if cache_path.exists() or not legacy_path.exists() or legacy_path.resolve() == cache_path.resolve():
+        return
+    legacy_path.rename(cache_path)
+    print(f"Adopted existing HTTP cache: {legacy_path} -> {cache_path}")
+
+
+def _make_backend() -> SQLiteCache:
+    """Build a SQLiteCache backed by the configured cache path."""
+    # WAL keeps readers from blocking writers across the worker threads, and
+    # busy_timeout makes a thread wait for the write lock instead of failing.
+    return SQLiteCache(str(_cache_path), wal=True, busy_timeout=CACHE_BUSY_TIMEOUT_MS)
+
+
+def _reset_sessions() -> None:
+    """Discard cached per-thread sessions (used by setup_cache and tests)."""
+    global _thread_local
+    _thread_local = threading.local()
 
 
 def _make_session() -> requests.Session:
-    """Create a requests Session with the kg-microbe User-Agent."""
-    session = requests.Session()
-    session.headers.update({"User-Agent": USER_AGENT})
+    """
+    Return this thread's HTTP session, creating it on first use.
+
+    Must be called from the thread that will use the session — see the module
+    comment above on why sessions are never shared across threads.
+    """
+    session = getattr(_thread_local, "session", None)
+    if session is None:
+        session = CachedSession(backend=_make_backend()) if _cache_path else requests.Session()
+        session.headers.update({"User-Agent": USER_AGENT})
+        _thread_local.session = session
     return session
 
 
@@ -76,7 +180,7 @@ def get_json_from_api(
         retry_count: Number of retries on failure
         retry_delay: Delay in seconds between retries (overridden by Retry-After on 429)
         verbose: If True, log empty responses (useful for debugging)
-        session: Optional requests Session to reuse (uses module-level session if None)
+        session: Optional requests Session to reuse (uses this thread's session if None)
 
     Returns:
     -------
@@ -190,12 +294,12 @@ def download_detailed_media(
     """
     print(f"\nDownloading detailed recipes for {len(media_list)} media...")
     detailed_data: Dict[str, Dict] = {}
-    session = _make_session()
     rate_limiter = threading.Semaphore(max_workers)
 
     def fetch(medium: Dict) -> tuple[str, dict]:
-        """Fetch detail for a single medium using the shared session and rate limiter."""
-        return _fetch_medium_detail(medium, session, rate_limiter, retry_count, retry_delay)
+        """Fetch detail for a single medium using this thread's session and the rate limiter."""
+        # _make_session() runs inside the worker thread so each thread gets its own.
+        return _fetch_medium_detail(medium, _make_session(), rate_limiter, retry_count, retry_delay)
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for medium_id, data in tqdm(
@@ -235,12 +339,12 @@ def download_medium_strains(
     """
     print(f"\nDownloading strain associations for {len(media_list)} media...")
     strain_data: Dict[str, List] = {}
-    session = _make_session()
     rate_limiter = threading.Semaphore(max_workers)
 
     def fetch(medium: Dict) -> tuple[str, dict]:
-        """Fetch strain associations for a single medium using the shared session and rate limiter."""
-        return _fetch_medium_strains(medium, session, rate_limiter, retry_count, retry_delay)
+        """Fetch strain associations for a single medium using this thread's session."""
+        # _make_session() runs inside the worker thread so each thread gets its own.
+        return _fetch_medium_strains(medium, _make_session(), rate_limiter, retry_count, retry_delay)
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for medium_id, data in tqdm(
@@ -374,8 +478,8 @@ def download_mediadive_bulk(
     print(f"API warnings will be logged to: {log_file}")
     print(f"Using {max_workers} parallel workers")
 
-    # Set up HTTP caching
-    setup_cache()
+    # Set up HTTP caching (stored alongside the bulk output, not in the CWD)
+    setup_cache(output_path, migrate_legacy=True)
 
     # Step 1: Load basic media list
     print("\n[1/5] Loading basic media list...")

--- a/kg_microbe/utils/mediadive_bulk_download.py
+++ b/kg_microbe/utils/mediadive_bulk_download.py
@@ -130,8 +130,11 @@ def setup_cache(
         _delete_cache(_cache_path)
 
     # Create the tables up front so worker threads don't race on the initial
-    # CREATE TABLE when they open their own connections.
-    _make_backend()
+    # CREATE TABLE when they open their own connections. Closed immediately —
+    # SQLiteDict opens its connection eagerly in __init__, so an unreferenced
+    # backend would leave two connections open on a file a later clear() unlinks.
+    warmup = _make_backend()
+    warmup.close()
     print(f"HTTP cache enabled: {_cache_path}")
     return _cache_path
 
@@ -580,4 +583,9 @@ def download_mediadive_bulk(
     print(f"  - {len(compounds_data)} compounds")
     print(f"\nAPI warnings logged to: {output_path / 'mediadive_download.log'}")
     print("These files will be used by the MediaDive transform to avoid API calls.")
+
+    # Close every per-thread session. The worker threads from both pools are gone
+    # by now, but their sessions are still referenced by _live_sessions, so
+    # without this their SQLite connections stay open for the life of the process.
+    _reset_sessions()
     print("=" * 80)

--- a/kg_microbe/utils/mediadive_bulk_download.py
+++ b/kg_microbe/utils/mediadive_bulk_download.py
@@ -80,7 +80,11 @@ _thread_local = threading.local()
 _cache_path: Optional[Path] = None
 
 
-def setup_cache(cache_dir: Optional[Path] = None, migrate_legacy: bool = False) -> Optional[Path]:
+def setup_cache(
+    cache_dir: Optional[Path] = None,
+    migrate_legacy: bool = False,
+    clear: bool = False,
+) -> Optional[Path]:
     """
     Enable HTTP caching for subsequent sessions created by this module.
 
@@ -92,6 +96,10 @@ def setup_cache(cache_dir: Optional[Path] = None, migrate_legacy: bool = False) 
             working directory by older versions of this module (which stored it
             there). Off by default: this *moves* a file outside cache_dir, so
             only the real download entry point should ask for it.
+        clear: If True, discard any existing cached responses so every request
+            goes back to the API. This is what `kg download --ignore-cache`
+            needs; without it the bulk JSON files are rebuilt from cached HTTP
+            responses and never actually refresh.
 
     Returns:
     -------
@@ -109,14 +117,29 @@ def setup_cache(cache_dir: Optional[Path] = None, migrate_legacy: bool = False) 
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     _cache_path = cache_dir / CACHE_FILENAME
+    # Adopt the legacy cache before clearing, so a stale copy can't linger in
+    # the CWD and get picked up by a later run that isn't clearing.
     if migrate_legacy:
         _migrate_legacy_cache(_cache_path)
+    if clear:
+        _delete_cache(_cache_path)
 
     # Create the tables up front so worker threads don't race on the initial
     # CREATE TABLE when they open their own connections.
     _make_backend()
     print(f"HTTP cache enabled: {_cache_path}")
     return _cache_path
+
+
+def _delete_cache(cache_path: Path) -> None:
+    """Remove a cache database and its WAL sidecar files, if present."""
+    removed = False
+    for path in (cache_path, *(cache_path.with_name(cache_path.name + s) for s in ("-wal", "-shm"))):
+        if path.exists():
+            path.unlink()
+            removed = True
+    if removed:
+        print(f"Cleared HTTP cache: {cache_path}")
 
 
 def _migrate_legacy_cache(cache_path: Path) -> None:
@@ -447,6 +470,7 @@ def download_mediadive_bulk(
     max_workers: int = DEFAULT_MAX_WORKERS,
     retry_count: int = 3,
     retry_delay: float = 2.0,
+    ignore_cache: bool = False,
 ):
     """
     Download all MediaDive data in bulk.
@@ -460,6 +484,9 @@ def download_mediadive_bulk(
         max_workers: Number of parallel download threads (default: 5, polite for small APIs)
         retry_count: Number of retries on request failure
         retry_delay: Seconds between retries (overridden by Retry-After on 429)
+        ignore_cache: If True, discard cached HTTP responses and re-fetch from
+            the API. Rebuilding the bulk files from a warm cache would otherwise
+            reproduce the old data byte for byte.
 
     """
     output_path = Path(output_dir)
@@ -479,7 +506,7 @@ def download_mediadive_bulk(
     print(f"Using {max_workers} parallel workers")
 
     # Set up HTTP caching (stored alongside the bulk output, not in the CWD)
-    setup_cache(output_path, migrate_legacy=True)
+    setup_cache(output_path, migrate_legacy=True, clear=ignore_cache)
 
     # Step 1: Load basic media list
     print("\n[1/5] Loading basic media list...")

--- a/kg_microbe/utils/mediadive_bulk_download.py
+++ b/kg_microbe/utils/mediadive_bulk_download.py
@@ -76,6 +76,11 @@ SOLUTION_ID_KEY = "solution_id"
 # module.
 _thread_local = threading.local()
 
+# Every session handed out, so _reset_sessions can close them. A thread-local
+# alone is not enough: one thread cannot reach another's sessions to close them.
+_live_sessions: List[requests.Session] = []
+_sessions_lock = threading.Lock()
+
 # Set by setup_cache(); None means "no HTTP caching" (plain sessions).
 _cache_path: Optional[Path] = None
 
@@ -165,8 +170,22 @@ def _make_backend() -> SQLiteCache:
 
 
 def _reset_sessions() -> None:
-    """Discard cached per-thread sessions (used by setup_cache and tests)."""
+    """
+    Close and discard cached per-thread sessions (used by setup_cache and tests).
+
+    Rebinding rather than clearing an attribute is deliberate: it makes *every*
+    thread see a fresh local, which is what a cache reconfiguration needs. The
+    sessions themselves must be closed explicitly, or each one's SQLite
+    connection lingers until garbage collection (#617).
+    """
     global _thread_local
+    with _sessions_lock:
+        for session in _live_sessions:
+            try:
+                session.close()
+            except Exception as e:  # noqa: BLE001 — teardown must not mask the real work
+                logger.debug(f"Ignoring error while closing a cached session: {e}")
+        _live_sessions.clear()
     _thread_local = threading.local()
 
 
@@ -182,6 +201,8 @@ def _make_session() -> requests.Session:
         session = CachedSession(backend=_make_backend()) if _cache_path else requests.Session()
         session.headers.update({"User-Agent": USER_AGENT})
         _thread_local.session = session
+        with _sessions_lock:
+            _live_sessions.append(session)
     return session
 
 

--- a/kg_microbe/utils/mediadive_bulk_download.py
+++ b/kg_microbe/utils/mediadive_bulk_download.py
@@ -7,6 +7,7 @@ to avoid repeated API calls during transforms.
 
 import json
 import logging
+import shutil
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -161,14 +162,23 @@ def _migrate_legacy_cache(cache_path: Path) -> None:
     legacy_path = Path.cwd() / CACHE_FILENAME
     if cache_path.exists() or not legacy_path.exists() or legacy_path.resolve() == cache_path.resolve():
         return
-    legacy_path.rename(cache_path)
+    try:
+        shutil.move(str(legacy_path), str(cache_path))
+    except OSError as e:
+        # Adopting the old cache is an optimisation; failing it (e.g. EXDEV when
+        # data/ is on another filesystem) must not abort the whole download.
+        print(f"Could not adopt {legacy_path} ({e}); continuing with a fresh cache")
+        return
     # Move the WAL sidecars too. A cache this module created is WAL-enabled, so
     # leaving them behind would drop uncheckpointed responses and orphan the
     # files in the working directory (#622).
     for suffix in ("-wal", "-shm"):
         sidecar = legacy_path.with_name(legacy_path.name + suffix)
         if sidecar.exists():
-            sidecar.rename(cache_path.with_name(cache_path.name + suffix))
+            try:
+                shutil.move(str(sidecar), str(cache_path.with_name(cache_path.name + suffix)))
+            except OSError as e:
+                print(f"Could not move {sidecar.name} ({e}); it can be deleted safely")
     print(f"Adopted existing HTTP cache: {legacy_path} -> {cache_path}")
 
 
@@ -539,53 +549,58 @@ def download_mediadive_bulk(
     # Set up HTTP caching (stored alongside the bulk output, not in the CWD)
     setup_cache(output_path, migrate_legacy=True, clear=ignore_cache)
 
-    # Step 1: Load basic media list
-    print("\n[1/5] Loading basic media list...")
-    media_list = load_basic_media_list(basic_file)
+    # Wrapped so an interrupted or failing run still closes its sessions:
+    # otherwise every per-thread SQLite connection stays open, which is exactly
+    # the case where a stale handle on a cache file matters most.
+    try:
+        # Step 1: Load basic media list
+        print("\n[1/5] Loading basic media list...")
+        media_list = load_basic_media_list(basic_file)
 
-    # Step 2: Download detailed medium recipes
-    print("\n[2/5] Downloading detailed medium recipes...")
-    detailed_media = download_detailed_media(
-        media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
-    )
-    save_json_file(detailed_media, output_path / "media_detailed.json", "detailed media recipes")
+        # Step 2: Download detailed medium recipes
+        print("\n[2/5] Downloading detailed medium recipes...")
+        detailed_media = download_detailed_media(
+            media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
+        )
+        save_json_file(detailed_media, output_path / "media_detailed.json", "detailed media recipes")
 
-    # Step 3: Download medium-strain associations
-    print("\n[3/5] Downloading medium-strain associations...")
-    media_strains = download_medium_strains(
-        media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
-    )
-    save_json_file(media_strains, output_path / "media_strains.json", "medium-strain associations")
+        # Step 3: Download medium-strain associations
+        print("\n[3/5] Downloading medium-strain associations...")
+        media_strains = download_medium_strains(
+            media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
+        )
+        save_json_file(media_strains, output_path / "media_strains.json", "medium-strain associations")
 
-    # Step 4: Extract solutions from embedded structure
-    print("\n[4/5] Extracting solutions from embedded structure...")
-    solutions_data = extract_solutions_from_media(detailed_media)
-    print(f"Extracted {len(solutions_data)} unique solutions from embedded data")
-    save_json_file(solutions_data, output_path / "solutions.json", "solution data")
+        # Step 4: Extract solutions from embedded structure
+        print("\n[4/5] Extracting solutions from embedded structure...")
+        solutions_data = extract_solutions_from_media(detailed_media)
+        print(f"Extracted {len(solutions_data)} unique solutions from embedded data")
+        save_json_file(solutions_data, output_path / "solutions.json", "solution data")
 
-    # Step 5: Extract compounds from embedded structure
-    # Compound data is embedded in the recipe structure of detailed media
-    # The transform will use MicroMediaParam mappings and fall back to mediadive.ingredient: prefix
-    print("\n[5/5] Extracting compounds from embedded structure...")
-    compounds_data = extract_compounds_from_media(detailed_media)
-    print(f"Extracted {len(compounds_data)} compounds from embedded data")
-    save_json_file(compounds_data, output_path / "compounds.json", "compound data")
+        # Step 5: Extract compounds from embedded structure
+        # Compound data is embedded in the recipe structure of detailed media
+        # The transform will use MicroMediaParam mappings and fall back to mediadive.ingredient: prefix
+        print("\n[5/5] Extracting compounds from embedded structure...")
+        compounds_data = extract_compounds_from_media(detailed_media)
+        print(f"Extracted {len(compounds_data)} compounds from embedded data")
+        save_json_file(compounds_data, output_path / "compounds.json", "compound data")
 
-    # Summary
-    print("\n" + "=" * 80)
-    print("MediaDive bulk download summary:")
-    print("=" * 80)
-    print(f"Output directory: {output_path}")
-    print(f"  - {len(media_list)} media records (basic)")
-    print(f"  - {len(detailed_media)} media recipes (detailed)")
-    print(f"  - {len(media_strains)} media-strain associations")
-    print(f"  - {len(solutions_data)} solutions")
-    print(f"  - {len(compounds_data)} compounds")
-    print(f"\nAPI warnings logged to: {output_path / 'mediadive_download.log'}")
-    print("These files will be used by the MediaDive transform to avoid API calls.")
+        # Summary
+        print("\n" + "=" * 80)
+        print("MediaDive bulk download summary:")
+        print("=" * 80)
+        print(f"Output directory: {output_path}")
+        print(f"  - {len(media_list)} media records (basic)")
+        print(f"  - {len(detailed_media)} media recipes (detailed)")
+        print(f"  - {len(media_strains)} media-strain associations")
+        print(f"  - {len(solutions_data)} solutions")
+        print(f"  - {len(compounds_data)} compounds")
+        print(f"\nAPI warnings logged to: {output_path / 'mediadive_download.log'}")
+        print("These files will be used by the MediaDive transform to avoid API calls.")
 
-    # Close every per-thread session. The worker threads from both pools are gone
-    # by now, but their sessions are still referenced by _live_sessions, so
-    # without this their SQLite connections stay open for the life of the process.
-    _reset_sessions()
+    finally:
+        # Close every per-thread session; the worker threads are gone but
+        # _live_sessions still holds their connections open.
+        _reset_sessions()
+
     print("=" * 80)

--- a/kg_microbe/utils/mediadive_bulk_download.py
+++ b/kg_microbe/utils/mediadive_bulk_download.py
@@ -159,6 +159,13 @@ def _migrate_legacy_cache(cache_path: Path) -> None:
     if cache_path.exists() or not legacy_path.exists() or legacy_path.resolve() == cache_path.resolve():
         return
     legacy_path.rename(cache_path)
+    # Move the WAL sidecars too. A cache this module created is WAL-enabled, so
+    # leaving them behind would drop uncheckpointed responses and orphan the
+    # files in the working directory (#622).
+    for suffix in ("-wal", "-shm"):
+        sidecar = legacy_path.with_name(legacy_path.name + suffix)
+        if sidecar.exists():
+            sidecar.rename(cache_path.with_name(cache_path.name + suffix))
     print(f"Adopted existing HTTP cache: {legacy_path} -> {cache_path}")
 
 

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -534,6 +534,16 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
     if not _semsql_build_enabled():
         print(f"Skipping NCBITaxon SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
         return os.path.exists(db_path)
+    if owl_source and not owl_source.exists():
+        # semsql needs the plain OWL, but the download ships ncbitaxon.owl.gz and
+        # NCBITAXON_SOURCE names the uncompressed path — without this a fresh
+        # checkout skips the build and silently falls back to OAK's prebuilt DB,
+        # defeating the single-source guarantee (#620).
+        archive = owl_source.with_suffix(owl_source.suffix + ".gz")
+        if archive.exists():
+            print(f"Decompressing {archive} for the NCBITaxon SemSQL build...")
+            if not _decompress_atomically(archive, owl_source):
+                return os.path.exists(db_path)
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — NCBITaxon OWL source {owl_source} is missing")
         return os.path.exists(db_path)

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -1,5 +1,6 @@
 """Ontology utilities for category assignment and term processing."""
 
+import gzip
 import os
 import re
 import shutil
@@ -40,6 +41,10 @@ _GO_DB_MIN_SIZE = 10_000_000
 # ~13 GB; anything smaller is a partial extract/download or an interrupted
 # `semsql make`, regardless of whether the SQLite header looks valid.
 _NCBITAXON_DB_MIN_SIZE = 1_000_000_000  # 1 GB
+
+# Minimum plausible size for a healthy ChEBI SemSQL DB. A full build is ~1-2 GB;
+# the upstream distribution is ~800 MB compressed.
+_CHEBI_DB_MIN_SIZE = 100_000_000  # 100 MB
 # OBO release stamp, e.g. ``releases/2026-05-19/`` in a versionIRI.
 _RELEASE_RE = re.compile(r"releases/(\d{4}-\d{2}-\d{2})")
 
@@ -242,6 +247,188 @@ def assert_ncbitaxon_version_alignment(db_path: str, strict: Optional[bool] = No
         if strict:
             raise RuntimeError(msg)
         print(f"WARNING: {msg}")
+
+
+def _chebi_release_from_owl(path: Path, nbytes: int = 2_000_000) -> Optional[str]:
+    """
+    Return the ChEBI release recorded near the top of ``chebi.owl``.
+
+    ChEBI does not use OBO's ``YYYY-MM-DD`` stamp — it versions by an
+    incrementing integer (``versionIRI .../obo/chebi/253/chebi.owl``,
+    ``<owl:versionInfo>253</owl:versionInfo>``). :func:`_obo_release_from_head`
+    only recognises dates, so it silently returns None for ChEBI and any gate
+    built on it no-ops. Hence this separate reader.
+
+    :param path: Path to ``chebi.owl``.
+    :param nbytes: Bytes to read from the head (ChEBI OWL is ~1 GB uncompressed).
+    :return: Release as a string (e.g. ``"253"``), or None if unreadable/unstamped.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as fh:
+            head = fh.read(nbytes)
+    except OSError:
+        return None
+    m = re.search(r"versionIRI[^>]{0,160}?/chebi/(\d+)/", head)
+    if m:
+        return m.group(1)
+    m = re.search(r"<owl:versionInfo>\s*(\d+)\s*</owl:versionInfo>", head)
+    return m.group(1) if m else None
+
+
+def _chebi_db_release(db_path: str) -> Optional[str]:
+    """
+    Return the ChEBI release recorded in a SemSQL ``chebi.db``.
+
+    Mirrors :func:`_go_db_release` but accepts ChEBI's bare integer stamp
+    instead of a date. Restricted to the ontology subject so a version-shaped
+    value on a ``CHEBI:...`` term subject can't be mistaken for the release.
+
+    :param db_path: Path to ``chebi.db``.
+    :return: Release as a string, or None on read error / missing stamp.
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT value FROM statements WHERE predicate = 'owl:versionInfo' "
+                "AND value IS NOT NULL AND ("
+                "subject IN ('obo:chebi.owl', 'obo:chebi') OR subject LIKE '%/chebi.owl'"
+                ") LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    if not row or not row[0]:
+        return None
+    m = re.search(r"(\d+)", str(row[0]))
+    return m.group(1) if m else None
+
+
+def assert_chebi_version_alignment(db_path: str, strict: Optional[bool] = None) -> None:
+    """
+    Guard that the ChEBI lookup DB matches the transform's OWL release.
+
+    ``chebi.db`` decides each ChEBI node's Biolink category (SmallMolecule vs
+    ChemicalRole vs macromolecule) via ancestor lookups, while the nodes
+    themselves are emitted from ``chebi.owl``. A release gap means a term the
+    transform emits may be absent from the DB, so its category silently falls
+    back to the default — the same failure mode the GO gate exists to prevent.
+
+    Defaults to **warn** rather than raise: when ``semsql`` is unavailable the
+    pipeline legitimately falls back to a prebuilt ``chebi.db`` of a different
+    release, and aborting the run would be worse than mis-categorising a handful
+    of terms. Set ``KG_CHEBI_VERSION_CHECK=strict`` (or pass ``strict=True``) to
+    fail loud. No-op when either stamp can't be read.
+
+    :param db_path: Path to ``chebi.db``.
+    :param strict: Override the env var / default strictness.
+    :raises RuntimeError: On mismatch when strict.
+    """
+    from kg_microbe.transform_utils.constants import CHEBI_SOURCE
+
+    strict = _version_check_strict("KG_CHEBI_VERSION_CHECK", strict, default_strict=False)
+    if not CHEBI_SOURCE:
+        return
+    owl_release = _chebi_release_from_owl(Path(CHEBI_SOURCE))
+    db_release = _chebi_db_release(db_path)
+    if owl_release and db_release and owl_release != db_release:
+        msg = (
+            f"ChEBI source version mismatch: chebi.owl={owl_release} vs "
+            f"chebi.db={db_release}. Node categories are resolved against "
+            "chebi.db but nodes are emitted from chebi.owl; a release gap can "
+            "leave emitted terms uncategorised. To realign, rebuild the DB from "
+            "the OWL (rm data/raw/chebi.db; the next run rebuilds via `semsql make`)."
+        )
+        if strict:
+            raise RuntimeError(msg)
+        print(f"WARNING: {msg}")
+
+
+def _ensure_chebi_db(db_path: str) -> bool:
+    """
+    Build the ChEBI SemSQL DB from ``chebi.owl``; return True if usable.
+
+    Third application of the GO single-source rule (#604), after GO and
+    NCBITaxon. Previously ``chebi.db`` was whatever OAK had fetched or a copy
+    carried over from an older ``data/raw``, with no gate — and unlike the other
+    two it could not even be checked, because ChEBI's integer release stamp is
+    invisible to the date-based reader.
+
+    Decompresses ``chebi.owl.gz`` when only the archive is present, since
+    ``semsql make`` needs the plain OWL beside it. Rebuilds on release drift and
+    degrades to a warning (keeping any existing DB) when the OWL or ``semsql`` is
+    unavailable.
+
+    :param db_path: Target path for ``chebi.db``.
+    :return: True if a usable DB exists at db_path when this returns.
+    """
+    from kg_microbe.transform_utils.constants import CHEBI_SOURCE
+
+    owl_source = Path(CHEBI_SOURCE) if CHEBI_SOURCE else None
+    if os.path.exists(db_path) and os.path.getsize(db_path) >= _CHEBI_DB_MIN_SIZE:
+        owl_release = _chebi_release_from_owl(owl_source) if owl_source else None
+        db_release = _chebi_db_release(db_path)
+        if not (owl_release and db_release and owl_release != db_release):
+            return True
+        print(
+            f"Rebuilding {db_path}: release {db_release} drifted from "
+            f"chebi.owl {owl_release} (single-source realign)..."
+        )
+    if owl_source and not owl_source.exists():
+        # semsql needs the plain OWL; the download ships chebi.owl.gz.
+        archive = owl_source.with_suffix(owl_source.suffix + ".gz")
+        if archive.exists():
+            print(f"Decompressing {archive} for the ChEBI SemSQL build...")
+            try:
+                with gzip.open(archive, "rb") as src, open(owl_source, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+            except OSError as e:
+                print(f"Warning: failed to decompress {archive}: {e}")
+                return os.path.exists(db_path)
+    if not (owl_source and owl_source.exists()):
+        print(f"Warning: cannot build {db_path} — ChEBI OWL source {owl_source} is missing")
+        return os.path.exists(db_path)
+    if shutil.which("semsql") is None:
+        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
+        return os.path.exists(db_path)
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    print(
+        f"Building {db_path} from {owl_source} via `semsql make` (one-time; "
+        "ChEBI runs relation-graph and can take 30+ minutes / several GB RAM)..."
+    )
+    try:
+        subprocess.run(  # noqa: S603
+            ["semsql", "make", os.path.basename(db_path)],  # noqa: S607
+            cwd=str(owl_source.parent),
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError) as e:
+        print(f"Warning: failed to build {db_path}: {e}")
+        return False
+    return os.path.exists(db_path) and os.path.getsize(db_path) >= _CHEBI_DB_MIN_SIZE
+
+
+def get_chebi_adapter():
+    """
+    Return an OAK adapter for ChEBI, building/realigning ``chebi.db`` first.
+
+    Single entry point so the category-fixing code paths cannot diverge on how
+    the DB is obtained (they previously each did ``get_adapter("sqlite:<owl>")``
+    with an untested fallback to ``sqlite:data/raw/chebi.db``, which quietly
+    accepted whatever DB happened to be on disk).
+
+    :return: OAK adapter over ``chebi.db``.
+    """
+    from oaklib import get_adapter
+
+    from kg_microbe.transform_utils.constants import CHEBI_SOURCE
+
+    db_path = str(Path(CHEBI_SOURCE).parent / "chebi.db")
+    _ensure_chebi_db(db_path)
+    assert_chebi_version_alignment(db_path)
+    return get_adapter(f"sqlite:{db_path}")
 
 
 def _ensure_ncbitaxon_db(db_path: str) -> bool:
@@ -498,16 +685,7 @@ def get_chebi_category(chebi_term_id: str, chebi_adapter: Optional[OboGraphInter
 
     # Create adapter if not provided
     if chebi_adapter is None:
-        try:
-            from oaklib import get_adapter
-
-            from kg_microbe.transform_utils.constants import CHEBI_SOURCE
-
-            chebi_adapter = get_adapter(f"sqlite:{CHEBI_SOURCE}")
-        except Exception:
-            from oaklib import get_adapter
-
-            chebi_adapter = get_adapter("sqlite:data/raw/chebi.db")
+        chebi_adapter = get_chebi_adapter()
 
     try:
         ancestors = list(chebi_adapter.ancestors(chebi_term_id))

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+import zlib
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional
@@ -241,9 +242,11 @@ def assert_ncbitaxon_version_alignment(db_path: str, strict: Optional[bool] = No
             f"ncbitaxon.db={db_release}. The metatraits transform emits nodes from "
             "ncbitaxon.owl but looks taxa up in ncbitaxon.db; a release gap can "
             "resolve lookups against taxa the transform didn't emit. To realign, "
-            "refresh the OAK SemSQL DB to the pinned release "
-            "(rm ~/.data/oaklib/ncbitaxon.db; poetry run python -c "
-            "'from oaklib import get_adapter; get_adapter(\"sqlite:obo:ncbitaxon\")')."
+            "rebuild the DB from the OWL: rm data/raw/ncbitaxon.db and re-run, and "
+            "the next transform rebuilds it via `semsql make`. Refreshing OAK's "
+            "prebuilt cache instead does NOT close the gap — those builds lag the "
+            "OBO release train by months. Do not delete ~/.data/oaklib/ncbitaxon.db "
+            "while data/raw/ncbitaxon.db symlinks to it."
         )
         if strict:
             raise RuntimeError(msg)
@@ -258,12 +261,36 @@ def _semsql_build_enabled() -> bool:
     right default for a maintainer refreshing the KG, but it is triggered by
     ordinary ``kg transform`` commands, so anyone else needs a way to decline
     (see #613). ``KG_SEMSQL_BUILD=off`` (or ``false``/``0``/``no``) skips the
-    build; the caller then falls back to a prebuilt DB and the version gate warns
+    build and uses whatever DB is already on disk, with the version gate warning
     about any resulting drift.
+
+    Note the opt-out only helps when a usable DB already exists — it declines to
+    *build* one, it does not conjure one. With no DB present, ChEBI category
+    lookups still fail; supply a prebuilt ``chebi.db`` in that case.
 
     :return: False when the opt-out is set, True otherwise.
     """
     return os.environ.get("KG_SEMSQL_BUILD", "").strip().lower() not in {"off", "false", "0", "no"}
+
+
+def _clear_build_target(db_path: str) -> None:
+    """
+    Remove whatever occupies the SemSQL build target, including a broken symlink.
+
+    ``os.path.exists`` follows symlinks and is False for a dangling one, so a
+    stale link would survive and ``semsql make`` — which opens the target name for
+    writing — would follow it and deposit the multi-GB result at the link's
+    target instead. The closing size check follows the link too, so the build
+    would be reported successful while the DB sat somewhere else entirely.
+
+    That state is reachable from the pipeline's own advice: the OAK-cache fallback
+    creates ``data/raw/ncbitaxon.db -> ~/.data/oaklib/ncbitaxon.db``, and the
+    remediation text tells users to ``rm`` the cache, leaving the link dangling.
+
+    :param db_path: Build target to clear.
+    """
+    if os.path.lexists(db_path):
+        os.remove(db_path)
 
 
 def _decompress_atomically(archive: Path, destination: Path) -> bool:
@@ -283,7 +310,10 @@ def _decompress_atomically(archive: Path, destination: Path) -> bool:
         with gzip.open(archive, "rb") as src, open(tmp, "wb") as dst:
             shutil.copyfileobj(src, dst)
         os.replace(tmp, destination)
-    except OSError as e:
+    # A truncated archive raises EOFError and a corrupt one zlib.error, neither of
+    # which is an OSError — catching OSError alone let those escape, defeating the
+    # "degrades gracefully" contract and orphaning a multi-GB .partial.
+    except (OSError, EOFError, zlib.error) as e:
         print(f"Warning: failed to decompress {archive}: {e}")
         tmp.unlink(missing_ok=True)
         return False
@@ -419,6 +449,11 @@ def _ensure_chebi_db(db_path: str) -> bool:
     if not _semsql_build_enabled():
         print(f"Skipping ChEBI SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
         return os.path.exists(db_path)
+    # Checked before decompressing: without semsql there is nothing to build, and
+    # unpacking ~1 GB only to then bail out is pure waste (#10).
+    if shutil.which("semsql") is None:
+        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
+        return os.path.exists(db_path)
     if owl_source and not owl_source.exists():
         # semsql needs the plain OWL; the download ships chebi.owl.gz.
         archive = owl_source.with_suffix(owl_source.suffix + ".gz")
@@ -429,11 +464,7 @@ def _ensure_chebi_db(db_path: str) -> bool:
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — ChEBI OWL source {owl_source} is missing")
         return os.path.exists(db_path)
-    if shutil.which("semsql") is None:
-        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
-        return os.path.exists(db_path)
-    if os.path.exists(db_path):
-        os.remove(db_path)
+    _clear_build_target(db_path)
     print(
         f"Building {db_path} from {owl_source} via `semsql make`.\n"
         "  ChEBI runs relation-graph: expect 30+ minutes and several GB of RAM.\n"
@@ -448,7 +479,11 @@ def _ensure_chebi_db(db_path: str) -> bool:
     except (subprocess.CalledProcessError, OSError) as e:
         print(f"Warning: failed to build {db_path}: {e}")
         return False
-    return os.path.exists(db_path) and os.path.getsize(db_path) >= _CHEBI_DB_MIN_SIZE
+    return (
+        os.path.exists(db_path)
+        and not os.path.islink(db_path)  # a symlinked result means the build went elsewhere
+        and os.path.getsize(db_path) >= _CHEBI_DB_MIN_SIZE
+    )
 
 
 @lru_cache(maxsize=None)
@@ -534,6 +569,11 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
     if not _semsql_build_enabled():
         print(f"Skipping NCBITaxon SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
         return os.path.exists(db_path)
+    # Checked before decompressing: without semsql there is nothing to build, and
+    # unpacking ~2 GB only to then bail out is pure waste (#10).
+    if shutil.which("semsql") is None:
+        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
+        return os.path.exists(db_path)
     if owl_source and not owl_source.exists():
         # semsql needs the plain OWL, but the download ships ncbitaxon.owl.gz and
         # NCBITAXON_SOURCE names the uncompressed path — without this a fresh
@@ -547,13 +587,7 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — NCBITaxon OWL source {owl_source} is missing")
         return os.path.exists(db_path)
-    if shutil.which("semsql") is None:
-        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
-        return os.path.exists(db_path)
-    # A stale/partial file would otherwise be treated as an up-to-date target by
-    # semsql's make-based build.
-    if os.path.exists(db_path):
-        os.remove(db_path)
+    _clear_build_target(db_path)
     print(
         f"Building {db_path} from {owl_source} via `semsql make`.\n"
         "  NCBITaxon is the heaviest source in the pipeline: expect hours and a\n"
@@ -569,7 +603,11 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
     except (subprocess.CalledProcessError, OSError) as e:
         print(f"Warning: failed to build {db_path}: {e}")
         return False
-    return os.path.exists(db_path) and os.path.getsize(db_path) >= _NCBITAXON_DB_MIN_SIZE
+    return (
+        os.path.exists(db_path)
+        and not os.path.islink(db_path)  # a symlinked result means the build went elsewhere
+        and os.path.getsize(db_path) >= _NCBITAXON_DB_MIN_SIZE
+    )
 
 
 def _ensure_go_db(go_db_path: str) -> bool:
@@ -764,9 +802,16 @@ def get_chebi_category(chebi_term_id: str, chebi_adapter: Optional[OboGraphInter
     """
     from kg_microbe.transform_utils.constants import MACROMOLECULE_CATEGORY
 
-    # Create adapter if not provided
+    # Create adapter if not provided. A standalone call degrades to the default
+    # category when no DB can be produced, matching the behaviour before the
+    # adapter was centralised; the bulk transform path passes an adapter it built
+    # itself, so there the failure stays loud.
     if chebi_adapter is None:
-        chebi_adapter = get_chebi_adapter()
+        try:
+            chebi_adapter = get_chebi_adapter()
+        except RuntimeError as e:
+            print(f"WARNING: {e}\n  Falling back to the default ChEBI category.")
+            return SMALL_MOLECULE_CATEGORY
 
     try:
         ancestors = list(chebi_adapter.ancestors(chebi_term_id))

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -59,10 +59,8 @@ def _obo_release_from_head(path: Path, nbytes: int = 2_000_000) -> Optional[str]
     (``meta`` versionInfo) carry the release near the file head, so a bounded
     read avoids parsing hundreds of MB. Returns None if unreadable / unstamped.
     """
-    try:
-        with open(path, encoding="utf-8", errors="ignore") as fh:
-            head = fh.read(nbytes)
-    except OSError:
+    head = _read_head(path, nbytes)
+    if head is None:
         return None
     m = _RELEASE_RE.search(head)
     if m:
@@ -273,7 +271,51 @@ def _semsql_build_enabled() -> bool:
     return os.environ.get("KG_SEMSQL_BUILD", "").strip().lower() not in {"off", "false", "0", "no"}
 
 
-def _clear_build_target(db_path: str) -> None:
+def _usable_db(db_path: str, min_size: int) -> bool:
+    """
+    Report whether a SemSQL DB at ``db_path`` is present and plausibly complete.
+
+    Every "we could not build; use what's there" exit must go through this rather
+    than bare ``os.path.exists``: a 0-byte or truncated ``chebi.db`` passes an
+    existence check, yields an adapter with no ``entailed_edge`` table, and makes
+    every ChEBI term fall through to the default category — the same silent
+    miscategorisation ``_GO_DB_MIN_SIZE`` was introduced to prevent. A symlinked
+    result is rejected too: it means a build landed somewhere else.
+
+    :param db_path: Path to the DB.
+    :param min_size: Smallest plausible size for a complete build.
+    :return: True if the file is usable.
+    """
+    return os.path.exists(db_path) and not os.path.islink(db_path) and os.path.getsize(db_path) >= min_size
+
+
+def _read_head(path: Path, nbytes: int) -> Optional[str]:
+    """
+    Read the head of ``path``, transparently falling back to ``path`` + ``.gz``.
+
+    Release stamps live in the first few KB, and the downloads ship compressed
+    (``chebi.owl.gz``, ``ncbitaxon.owl.gz``) while the ``*_SOURCE`` constants name
+    the uncompressed path. Without this fallback the release reads return None on
+    a fresh checkout, which makes both the drift check and the version gate
+    silently no-op — leaving an old DB in place, the exact drift this module
+    exists to catch.
+
+    :param path: Uncompressed path to read.
+    :param nbytes: How many characters to read.
+    :return: The head as text, or None if neither form is readable.
+    """
+    for opener, target in ((open, path), (gzip.open, path.with_name(path.name + ".gz"))):
+        if not target.exists():
+            continue
+        try:
+            with opener(target, "rt", encoding="utf-8", errors="ignore") as fh:
+                return fh.read(nbytes)
+        except (OSError, EOFError, zlib.error):
+            return None
+    return None
+
+
+def _clear_build_target(db_path: str) -> Optional[str]:
     """
     Remove whatever occupies the SemSQL build target, including a broken symlink.
 
@@ -287,10 +329,45 @@ def _clear_build_target(db_path: str) -> None:
     creates ``data/raw/ncbitaxon.db -> ~/.data/oaklib/ncbitaxon.db``, and the
     remediation text tells users to ``rm`` the cache, leaving the link dangling.
 
+    A real file is moved aside rather than deleted, so a build that fails (OOM is
+    a live risk on the 13 GB NCBITaxon build) can put it back instead of leaving
+    the caller with nothing.
+
     :param db_path: Build target to clear.
+    :return: Path the previous DB was moved to, or None if there was nothing to keep.
     """
-    if os.path.lexists(db_path):
+    if not os.path.lexists(db_path):
+        return None
+    if os.path.islink(db_path):
         os.remove(db_path)
+        return None
+    kept = f"{db_path}.prev"
+    if os.path.lexists(kept):
+        os.remove(kept)
+    os.replace(db_path, kept)
+    return kept
+
+
+def _restore_build_target(db_path: str, kept: Optional[str]) -> None:
+    """
+    Put back the DB moved aside by :func:`_clear_build_target` after a failed build.
+
+    :param db_path: Original DB path.
+    :param kept: Path returned by :func:`_clear_build_target`, or None.
+    """
+    if kept and os.path.exists(kept):
+        os.replace(kept, db_path)
+        print(f"  Restored the previous {db_path} after the failed build")
+
+
+def _discard_kept_target(kept: Optional[str]) -> None:
+    """
+    Delete the moved-aside DB once a build has succeeded.
+
+    :param kept: Path returned by :func:`_clear_build_target`, or None.
+    """
+    if kept and os.path.exists(kept):
+        os.remove(kept)
 
 
 def _decompress_atomically(archive: Path, destination: Path) -> bool:
@@ -334,10 +411,8 @@ def _chebi_release_from_owl(path: Path, nbytes: int = 2_000_000) -> Optional[str
     :param nbytes: Bytes to read from the head (ChEBI OWL is ~1 GB uncompressed).
     :return: Release as a string (e.g. ``"253"``), or None if unreadable/unstamped.
     """
-    try:
-        with open(path, encoding="utf-8", errors="ignore") as fh:
-            head = fh.read(nbytes)
-    except OSError:
+    head = _read_head(path, nbytes)
+    if head is None:
         return None
     m = re.search(r"versionIRI[^>]{0,160}?/chebi/(\d+)/", head)
     if m:
@@ -436,8 +511,9 @@ def _ensure_chebi_db(db_path: str) -> bool:
     """
     from kg_microbe.transform_utils.constants import CHEBI_SOURCE
 
+    min_size = _CHEBI_DB_MIN_SIZE
     owl_source = Path(CHEBI_SOURCE) if CHEBI_SOURCE else None
-    if os.path.exists(db_path) and os.path.getsize(db_path) >= _CHEBI_DB_MIN_SIZE:
+    if _usable_db(db_path, min_size):
         owl_release = _chebi_release_from_owl(owl_source) if owl_source else None
         db_release = _chebi_db_release(db_path)
         if not (owl_release and db_release and owl_release != db_release):
@@ -448,23 +524,23 @@ def _ensure_chebi_db(db_path: str) -> bool:
         )
     if not _semsql_build_enabled():
         print(f"Skipping ChEBI SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
-        return os.path.exists(db_path)
+        return _usable_db(db_path, min_size)
     # Checked before decompressing: without semsql there is nothing to build, and
     # unpacking ~1 GB only to then bail out is pure waste (#10).
     if shutil.which("semsql") is None:
         print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
-        return os.path.exists(db_path)
+        return _usable_db(db_path, min_size)
     if owl_source and not owl_source.exists():
         # semsql needs the plain OWL; the download ships chebi.owl.gz.
         archive = owl_source.with_suffix(owl_source.suffix + ".gz")
         if archive.exists():
             print(f"Decompressing {archive} for the ChEBI SemSQL build...")
             if not _decompress_atomically(archive, owl_source):
-                return os.path.exists(db_path)
+                return _usable_db(db_path, min_size)
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — ChEBI OWL source {owl_source} is missing")
-        return os.path.exists(db_path)
-    _clear_build_target(db_path)
+        return _usable_db(db_path, min_size)
+    kept = _clear_build_target(db_path)
     print(
         f"Building {db_path} from {owl_source} via `semsql make`.\n"
         "  ChEBI runs relation-graph: expect 30+ minutes and several GB of RAM.\n"
@@ -478,12 +554,14 @@ def _ensure_chebi_db(db_path: str) -> bool:
         )
     except (subprocess.CalledProcessError, OSError) as e:
         print(f"Warning: failed to build {db_path}: {e}")
-        return False
-    return (
-        os.path.exists(db_path)
-        and not os.path.islink(db_path)  # a symlinked result means the build went elsewhere
-        and os.path.getsize(db_path) >= _CHEBI_DB_MIN_SIZE
-    )
+        _restore_build_target(db_path, kept)
+        return _usable_db(db_path, min_size)
+    built = _usable_db(db_path, min_size)
+    if built:
+        _discard_kept_target(kept)
+    else:
+        _restore_build_target(db_path, kept)
+    return built
 
 
 @lru_cache(maxsize=None)
@@ -502,13 +580,10 @@ def _chebi_adapter_for(db_path: str):
     from oaklib import get_adapter
 
     if not _ensure_chebi_db(db_path):
-        # Without this the gate silently no-ops on the missing file and OAK is
-        # handed a nonexistent path, losing the actionable warning above (#616).
-        raise RuntimeError(
-            f"No usable ChEBI SemSQL DB at {db_path}. Install `semsql` and place "
-            "chebi.owl (or chebi.owl.gz) in data/raw so it can be built, or supply "
-            "a prebuilt chebi.db. See the warning above for which step failed."
-        )
+        # Returned, not raised: lru_cache does not memoise exceptions, so raising
+        # here would re-run the whole ensure — including a 30-minute `semsql make`
+        # — on every subsequent call. get_chebi_adapter turns this into the error.
+        return None
     assert_chebi_version_alignment(db_path)
     return get_adapter(f"sqlite:{db_path}")
 
@@ -527,7 +602,15 @@ def get_chebi_adapter():
     """
     from kg_microbe.transform_utils.constants import CHEBI_SOURCE
 
-    return _chebi_adapter_for(str(Path(CHEBI_SOURCE).parent / "chebi.db"))
+    db_path = str(Path(CHEBI_SOURCE).parent / "chebi.db")
+    adapter = _chebi_adapter_for(db_path)
+    if adapter is None:
+        raise RuntimeError(
+            f"No usable ChEBI SemSQL DB at {db_path}. Install `semsql` and place "
+            "chebi.owl (or chebi.owl.gz) in data/raw so it can be built, or supply "
+            "a prebuilt chebi.db. See the warning above for which step failed."
+        )
+    return adapter
 
 
 get_chebi_adapter.cache_clear = _chebi_adapter_for.cache_clear
@@ -556,8 +639,9 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
     """
     from kg_microbe.transform_utils.constants import NCBITAXON_SOURCE
 
+    min_size = _NCBITAXON_DB_MIN_SIZE
     owl_source = Path(NCBITAXON_SOURCE) if NCBITAXON_SOURCE else None
-    if os.path.exists(db_path) and os.path.getsize(db_path) >= _NCBITAXON_DB_MIN_SIZE:
+    if _usable_db(db_path, min_size):
         owl_release = _obo_release_from_head(owl_source) if owl_source else None
         db_release = _ncbitaxon_db_release(db_path)
         if not (owl_release and db_release and owl_release != db_release):
@@ -568,12 +652,12 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
         )
     if not _semsql_build_enabled():
         print(f"Skipping NCBITaxon SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
-        return os.path.exists(db_path)
+        return _usable_db(db_path, min_size)
     # Checked before decompressing: without semsql there is nothing to build, and
     # unpacking ~2 GB only to then bail out is pure waste (#10).
     if shutil.which("semsql") is None:
         print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
-        return os.path.exists(db_path)
+        return _usable_db(db_path, min_size)
     if owl_source and not owl_source.exists():
         # semsql needs the plain OWL, but the download ships ncbitaxon.owl.gz and
         # NCBITAXON_SOURCE names the uncompressed path — without this a fresh
@@ -583,11 +667,11 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
         if archive.exists():
             print(f"Decompressing {archive} for the NCBITaxon SemSQL build...")
             if not _decompress_atomically(archive, owl_source):
-                return os.path.exists(db_path)
+                return _usable_db(db_path, min_size)
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — NCBITaxon OWL source {owl_source} is missing")
-        return os.path.exists(db_path)
-    _clear_build_target(db_path)
+        return _usable_db(db_path, min_size)
+    kept = _clear_build_target(db_path)
     print(
         f"Building {db_path} from {owl_source} via `semsql make`.\n"
         "  NCBITaxon is the heaviest source in the pipeline: expect hours and a\n"
@@ -602,12 +686,14 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
         )
     except (subprocess.CalledProcessError, OSError) as e:
         print(f"Warning: failed to build {db_path}: {e}")
-        return False
-    return (
-        os.path.exists(db_path)
-        and not os.path.islink(db_path)  # a symlinked result means the build went elsewhere
-        and os.path.getsize(db_path) >= _NCBITAXON_DB_MIN_SIZE
-    )
+        _restore_build_target(db_path, kept)
+        return _usable_db(db_path, min_size)
+    built = _usable_db(db_path, min_size)
+    if built:
+        _discard_kept_target(kept)
+    else:
+        _restore_build_target(db_path, kept)
+    return built
 
 
 def _ensure_go_db(go_db_path: str) -> bool:

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -35,6 +35,11 @@ _GO_NAMESPACE_LOAD_FAILED: bool = False
 # 0-byte stub (the failure that miscategorized every GO term as
 # biological_process this session).
 _GO_DB_MIN_SIZE = 10_000_000
+
+# Minimum plausible size for a healthy NCBITaxon SemSQL DB. A full build is
+# ~13 GB; anything smaller is a partial extract/download or an interrupted
+# `semsql make`, regardless of whether the SQLite header looks valid.
+_NCBITAXON_DB_MIN_SIZE = 1_000_000_000  # 1 GB
 # OBO release stamp, e.g. ``releases/2026-05-19/`` in a versionIRI.
 _RELEASE_RE = re.compile(r"releases/(\d{4}-\d{2}-\d{2})")
 
@@ -237,6 +242,66 @@ def assert_ncbitaxon_version_alignment(db_path: str, strict: Optional[bool] = No
         if strict:
             raise RuntimeError(msg)
         print(f"WARNING: {msg}")
+
+
+def _ensure_ncbitaxon_db(db_path: str) -> bool:
+    """
+    Build the NCBITaxon SemSQL DB from ``ncbitaxon.owl``; return True if usable.
+
+    Applies the GO single-source rule (#604) to NCBITaxon. The alternative — OAK's
+    ``sqlite:obo:ncbitaxon``, which fetches whatever prebuilt SemSQL the upstream
+    CDN last published — cannot be kept aligned: those builds lag the OBO release
+    train by months (checked 2026-07-26, the newest ``ncbitaxon.db.gz`` upstream
+    was built 2026-05-24 while ``ncbitaxon.owl`` was at 2026-07-12), so refreshing
+    the cache does not close a gap, it only re-downloads 2.3 GB. Building from the
+    OWL we actually ship makes the lookup DB and the emitted nodes the same
+    release by construction.
+
+    Rebuilds when the DB's release stamp has drifted from the OWL's, mirroring
+    :func:`_ensure_go_db`. Degrades gracefully (warn + report current state) when
+    the OWL source or ``semsql`` is unavailable, so a machine without the build
+    toolchain still falls back to whatever DB is already present.
+
+    :param db_path: Target path for ``ncbitaxon.db``.
+    :return: True if a usable DB exists at db_path when this returns.
+    """
+    from kg_microbe.transform_utils.constants import NCBITAXON_SOURCE
+
+    owl_source = Path(NCBITAXON_SOURCE) if NCBITAXON_SOURCE else None
+    if os.path.exists(db_path) and os.path.getsize(db_path) >= _NCBITAXON_DB_MIN_SIZE:
+        owl_release = _obo_release_from_head(owl_source) if owl_source else None
+        db_release = _ncbitaxon_db_release(db_path)
+        if not (owl_release and db_release and owl_release != db_release):
+            return True
+        print(
+            f"Rebuilding {db_path}: release {db_release} drifted from "
+            f"ncbitaxon.owl {owl_release} (single-source realign)..."
+        )
+    if not (owl_source and owl_source.exists()):
+        print(f"Warning: cannot build {db_path} — NCBITaxon OWL source {owl_source} is missing")
+        return os.path.exists(db_path)
+    if shutil.which("semsql") is None:
+        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
+        return os.path.exists(db_path)
+    # A stale/partial file would otherwise be treated as an up-to-date target by
+    # semsql's make-based build.
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    print(
+        f"Building {db_path} from {owl_source} via `semsql make` (one-time; "
+        "NCBITaxon is the heaviest source in the pipeline — expect hours and a "
+        "~13 GB result)..."
+    )
+    try:
+        subprocess.run(  # noqa: S603
+            ["semsql", "make", os.path.basename(db_path)],  # noqa: S607
+            cwd=str(owl_source.parent),
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError) as e:
+        print(f"Warning: failed to build {db_path}: {e}")
+        return False
+    return os.path.exists(db_path) and os.path.getsize(db_path) >= _NCBITAXON_DB_MIN_SIZE
 
 
 def _ensure_go_db(go_db_path: str) -> bool:

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -249,6 +250,46 @@ def assert_ncbitaxon_version_alignment(db_path: str, strict: Optional[bool] = No
         print(f"WARNING: {msg}")
 
 
+def _semsql_build_enabled() -> bool:
+    """
+    Report whether SemSQL DB builds are permitted in this run.
+
+    Building ``ncbitaxon.db`` (~13 GB, hours) or ``chebi.db`` (30+ minutes) is the
+    right default for a maintainer refreshing the KG, but it is triggered by
+    ordinary ``kg transform`` commands, so anyone else needs a way to decline
+    (see #613). ``KG_SEMSQL_BUILD=off`` (or ``false``/``0``/``no``) skips the
+    build; the caller then falls back to a prebuilt DB and the version gate warns
+    about any resulting drift.
+
+    :return: False when the opt-out is set, True otherwise.
+    """
+    return os.environ.get("KG_SEMSQL_BUILD", "").strip().lower() not in {"off", "false", "0", "no"}
+
+
+def _decompress_atomically(archive: Path, destination: Path) -> bool:
+    """
+    Decompress a ``.gz`` archive to ``destination`` via a temp file + rename.
+
+    Writing straight to the destination leaves a truncated file at the real
+    filename if interrupted (#615) — and a truncated OWL is not detectable
+    downstream, because the version stamp lives in the head and still parses.
+
+    :param archive: Source ``.gz`` file.
+    :param destination: Path to place the decompressed file at.
+    :return: True if destination now holds the complete contents.
+    """
+    tmp = destination.with_name(destination.name + ".partial")
+    try:
+        with gzip.open(archive, "rb") as src, open(tmp, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        os.replace(tmp, destination)
+    except OSError as e:
+        print(f"Warning: failed to decompress {archive}: {e}")
+        tmp.unlink(missing_ok=True)
+        return False
+    return True
+
+
 def _chebi_release_from_owl(path: Path, nbytes: int = 2_000_000) -> Optional[str]:
     """
     Return the ChEBI release recorded near the top of ``chebi.owl``.
@@ -375,16 +416,15 @@ def _ensure_chebi_db(db_path: str) -> bool:
             f"Rebuilding {db_path}: release {db_release} drifted from "
             f"chebi.owl {owl_release} (single-source realign)..."
         )
+    if not _semsql_build_enabled():
+        print(f"Skipping ChEBI SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
+        return os.path.exists(db_path)
     if owl_source and not owl_source.exists():
         # semsql needs the plain OWL; the download ships chebi.owl.gz.
         archive = owl_source.with_suffix(owl_source.suffix + ".gz")
         if archive.exists():
             print(f"Decompressing {archive} for the ChEBI SemSQL build...")
-            try:
-                with gzip.open(archive, "rb") as src, open(owl_source, "wb") as dst:
-                    shutil.copyfileobj(src, dst)
-            except OSError as e:
-                print(f"Warning: failed to decompress {archive}: {e}")
+            if not _decompress_atomically(archive, owl_source):
                 return os.path.exists(db_path)
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — ChEBI OWL source {owl_source} is missing")
@@ -395,8 +435,9 @@ def _ensure_chebi_db(db_path: str) -> bool:
     if os.path.exists(db_path):
         os.remove(db_path)
     print(
-        f"Building {db_path} from {owl_source} via `semsql make` (one-time; "
-        "ChEBI runs relation-graph and can take 30+ minutes / several GB RAM)..."
+        f"Building {db_path} from {owl_source} via `semsql make`.\n"
+        "  ChEBI runs relation-graph: expect 30+ minutes and several GB of RAM.\n"
+        "  Set KG_SEMSQL_BUILD=off to skip and use a prebuilt DB instead."
     )
     try:
         subprocess.run(  # noqa: S603
@@ -410,6 +451,33 @@ def _ensure_chebi_db(db_path: str) -> bool:
     return os.path.exists(db_path) and os.path.getsize(db_path) >= _CHEBI_DB_MIN_SIZE
 
 
+@lru_cache(maxsize=None)
+def _chebi_adapter_for(db_path: str):
+    """
+    Build/realign ``chebi.db``, gate its release, and open an adapter over it.
+
+    Cached per path so the ensure + gate work (a 2 MB head read of ``chebi.owl``
+    plus a SQLite open) happens once per process rather than per call (#618).
+    Call :func:`get_chebi_adapter.cache_clear` to reset.
+
+    :param db_path: Path to ``chebi.db``.
+    :return: OAK adapter over ``chebi.db``.
+    :raises RuntimeError: If no usable DB could be produced.
+    """
+    from oaklib import get_adapter
+
+    if not _ensure_chebi_db(db_path):
+        # Without this the gate silently no-ops on the missing file and OAK is
+        # handed a nonexistent path, losing the actionable warning above (#616).
+        raise RuntimeError(
+            f"No usable ChEBI SemSQL DB at {db_path}. Install `semsql` and place "
+            "chebi.owl (or chebi.owl.gz) in data/raw so it can be built, or supply "
+            "a prebuilt chebi.db. See the warning above for which step failed."
+        )
+    assert_chebi_version_alignment(db_path)
+    return get_adapter(f"sqlite:{db_path}")
+
+
 def get_chebi_adapter():
     """
     Return an OAK adapter for ChEBI, building/realigning ``chebi.db`` first.
@@ -420,15 +488,14 @@ def get_chebi_adapter():
     accepted whatever DB happened to be on disk).
 
     :return: OAK adapter over ``chebi.db``.
+    :raises RuntimeError: If no usable DB could be produced.
     """
-    from oaklib import get_adapter
-
     from kg_microbe.transform_utils.constants import CHEBI_SOURCE
 
-    db_path = str(Path(CHEBI_SOURCE).parent / "chebi.db")
-    _ensure_chebi_db(db_path)
-    assert_chebi_version_alignment(db_path)
-    return get_adapter(f"sqlite:{db_path}")
+    return _chebi_adapter_for(str(Path(CHEBI_SOURCE).parent / "chebi.db"))
+
+
+get_chebi_adapter.cache_clear = _chebi_adapter_for.cache_clear
 
 
 def _ensure_ncbitaxon_db(db_path: str) -> bool:
@@ -464,6 +531,9 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
             f"Rebuilding {db_path}: release {db_release} drifted from "
             f"ncbitaxon.owl {owl_release} (single-source realign)..."
         )
+    if not _semsql_build_enabled():
+        print(f"Skipping NCBITaxon SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
+        return os.path.exists(db_path)
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — NCBITaxon OWL source {owl_source} is missing")
         return os.path.exists(db_path)
@@ -475,9 +545,10 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
     if os.path.exists(db_path):
         os.remove(db_path)
     print(
-        f"Building {db_path} from {owl_source} via `semsql make` (one-time; "
-        "NCBITaxon is the heaviest source in the pipeline — expect hours and a "
-        "~13 GB result)..."
+        f"Building {db_path} from {owl_source} via `semsql make`.\n"
+        "  NCBITaxon is the heaviest source in the pipeline: expect hours and a\n"
+        "  ~13 GB result. Set KG_SEMSQL_BUILD=off to skip and use the prebuilt\n"
+        "  OAK cache instead (the version gate will warn about any drift)."
     )
     try:
         subprocess.run(  # noqa: S603

--- a/tests/test_chebi_db_build.py
+++ b/tests/test_chebi_db_build.py
@@ -14,6 +14,7 @@ shrunk.
 
 import sqlite3
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -241,6 +242,78 @@ class TestChebiBuild:
         assert ou._ensure_chebi_db(str(tmp_path / "chebi.db")) is False
         assert not owl.exists()
         assert not (tmp_path / "chebi.owl.partial").exists()
+
+    def test_stub_db_is_not_reported_usable(self, tmp_path, monkeypatch):
+        """
+        A 0-byte chebi.db must not pass as usable on the no-build paths (F1).
+
+        os.path.exists is True for a stub, so the min-size guard used to apply
+        only to a freshly built result. A stub yields an adapter with no
+        entailed_edge table and collapses every ChEBI term to the default
+        category — the failure _GO_DB_MIN_SIZE exists to prevent.
+        """
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        db.write_bytes(b"")  # threshold left at the real 100 MB
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+        assert ou._ensure_chebi_db(str(db)) is False
+
+    def test_stub_db_rejected_under_opt_out(self, tmp_path, monkeypatch):
+        """The KG_SEMSQL_BUILD=off path must apply the same size guard."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        db.write_bytes(b"")
+        monkeypatch.setenv("KG_SEMSQL_BUILD", "off")
+        assert ou._ensure_chebi_db(str(db)) is False
+
+    def test_reuse_check_reads_release_from_the_archive(self, tmp_path, monkeypatch):
+        """
+        Drift must be detected when only chebi.owl.gz is on disk (F2).
+
+        The reuse branch reads chebi.owl, which a fresh checkout does not have —
+        so the release came back None, the drift check short-circuited, and the
+        stale DB was kept with the gate silently no-oping.
+        """
+        import gzip as gz
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 251)  # older release, DB large enough to be "reusable"
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert len(calls) == 1, "drift against the .gz release should trigger a rebuild"
+
+    def test_gate_reads_release_from_the_archive(self, tmp_path, monkeypatch, capsys):
+        """The version gate must also see the release when only the .gz exists (F2)."""
+        import gzip as gz
+
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+        assert "chebi.owl=253" in capsys.readouterr().out
+
+    def test_failed_build_restores_the_previous_db(self, tmp_path, monkeypatch):
+        """A build that dies must not leave the caller with nothing (F3)."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db_path = _make_db(tmp_path, 251)  # drifted but working
+        db = Path(db_path)
+        original = db.read_bytes()
+        _fake_build(monkeypatch, db, fail=True)
+
+        result = ou._ensure_chebi_db(db_path)
+        assert db.exists(), "the working DB must be restored after a failed build"
+        assert db.read_bytes() == original
+        assert result is True, "the restored DB is still usable"
+        assert not Path(f"{db_path}.prev").exists(), "the keep-aside copy should be gone"
 
     def test_missing_semsql_keeps_existing_db(self, tmp_path, monkeypatch, capsys):
         """Without semsql, keep whatever DB is present instead of deleting it."""

--- a/tests/test_chebi_db_build.py
+++ b/tests/test_chebi_db_build.py
@@ -202,6 +202,46 @@ class TestChebiBuild:
         assert "253" in owl.read_text(encoding="utf-8")
         assert len(calls) == 1
 
+    def test_dangling_symlink_target_is_cleared(self, tmp_path, monkeypatch):
+        """A broken symlink must not redirect the build to the link's target (#1)."""
+        import pathlib
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        db = tmp_path / "chebi.db"
+        db.symlink_to(elsewhere / "chebi.db")
+
+        def run(cmd, **kwargs):
+            """Write to the target name the way semsql does, following any symlink."""
+            with open(pathlib.Path(kwargs["cwd"]) / "chebi.db", "wb") as f:
+                f.write(b"0" * 32)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert not db.is_symlink()
+        assert list(elsewhere.iterdir()) == [], "nothing should reach the link target"
+
+    def test_truncated_archive_degrades_gracefully(self, tmp_path, monkeypatch):
+        """A truncated chebi.owl.gz raises EOFError, which must still be caught (#2)."""
+        import gzip as gz
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        archive = tmp_path / "chebi.owl.gz"
+        with gz.open(archive, "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253) * 500)
+        archive.write_bytes(archive.read_bytes()[: archive.stat().st_size // 2])
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+
+        assert ou._ensure_chebi_db(str(tmp_path / "chebi.db")) is False
+        assert not owl.exists()
+        assert not (tmp_path / "chebi.owl.partial").exists()
+
     def test_missing_semsql_keeps_existing_db(self, tmp_path, monkeypatch, capsys):
         """Without semsql, keep whatever DB is present instead of deleting it."""
         monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
@@ -294,6 +334,20 @@ class TestAdapterEntryPoint:
         monkeypatch.setattr("oaklib.get_adapter", lambda spec: pytest.fail("must not open a missing DB"))
         with pytest.raises(RuntimeError, match="No usable ChEBI SemSQL DB"):
             ou.get_chebi_adapter()
+
+    def test_standalone_category_lookup_degrades_instead_of_raising(self, tmp_path, monkeypatch):
+        """
+        get_chebi_category() with no adapter must not abort the caller (#7).
+
+        The bulk transform builds its adapter up front, so a missing DB fails
+        loudly there. But this helper's contract is "return a category", and
+        before the adapter was centralised it degraded to the default. Keep that.
+        """
+        from kg_microbe.transform_utils.constants import SMALL_MOLECULE_CATEGORY
+
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        monkeypatch.setattr(ou, "_ensure_chebi_db", lambda _: False)
+        assert ou.get_chebi_category("CHEBI:16828") == SMALL_MOLECULE_CATEGORY
 
     def test_adapter_work_happens_once(self, tmp_path, monkeypatch):
         """Repeat calls reuse the memoized adapter rather than re-ensuring (#618)."""

--- a/tests/test_chebi_db_build.py
+++ b/tests/test_chebi_db_build.py
@@ -42,6 +42,14 @@ def _make_db(tmp_path, release, *, subject="obo:chebi.owl", name="chebi.db"):
     return path
 
 
+@pytest.fixture(autouse=True)
+def _clear_adapter_cache():
+    """Drop the memoized ChEBI adapter so tests can't see each other's."""
+    ou.get_chebi_adapter.cache_clear()
+    yield
+    ou.get_chebi_adapter.cache_clear()
+
+
 def _fake_build(monkeypatch, db_path, *, size=16, fail=False):
     """Stand in for `semsql make`, recording the call and writing a fake DB."""
     calls = []
@@ -226,6 +234,38 @@ class TestChebiBuild:
         _fake_build(monkeypatch, db, size=16)  # threshold stays at 100 MB
         assert ou._ensure_chebi_db(str(db)) is False
 
+    def test_opt_out_skips_the_build(self, tmp_path, monkeypatch, capsys):
+        """KG_SEMSQL_BUILD=off must not start a 30-minute build (#613)."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 251)  # drifted, so a build would otherwise run
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.setenv("KG_SEMSQL_BUILD", "off")
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert calls == [], "opt-out must skip semsql entirely"
+        assert "opt-out" in capsys.readouterr().out
+
+    def test_decompression_is_atomic(self, tmp_path, monkeypatch):
+        """An interrupted decompression must not leave a truncated OWL (#615)."""
+        import gzip as gz
+
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+
+        def boom(src, dst, *a, **k):
+            """Fail part-way through the copy, as a full disk or Ctrl-C would."""
+            dst.write(b"<owl:versionIRI rdf:resource=")
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(ou.shutil, "copyfileobj", boom)
+        assert ou._ensure_chebi_db(str(tmp_path / "chebi.db")) is False
+        assert not owl.exists(), "a partial decompression must not appear at the real path"
+        assert not (tmp_path / "chebi.owl.partial").exists(), "temp file should be cleaned up"
+
 
 class TestAdapterEntryPoint:
 
@@ -246,3 +286,40 @@ class TestAdapterEntryPoint:
         assert seen["ensured"] == expected
         assert seen["gated"] == expected
         assert seen["adapter"] == f"sqlite:{expected}"
+
+    def test_failed_ensure_raises_actionable_error(self, tmp_path, monkeypatch):
+        """An unbuildable DB must not be handed to OAK as a missing path (#616)."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        monkeypatch.setattr(ou, "_ensure_chebi_db", lambda _: False)
+        monkeypatch.setattr("oaklib.get_adapter", lambda spec: pytest.fail("must not open a missing DB"))
+        with pytest.raises(RuntimeError, match="No usable ChEBI SemSQL DB"):
+            ou.get_chebi_adapter()
+
+    def test_adapter_work_happens_once(self, tmp_path, monkeypatch):
+        """Repeat calls reuse the memoized adapter rather than re-ensuring (#618)."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        counts = {"ensure": 0, "gate": 0, "adapter": 0}
+
+        def ensure(_):
+            """Count ensure invocations."""
+            counts["ensure"] += 1
+            return True
+
+        def gate(_):
+            """Count gate invocations."""
+            counts["gate"] += 1
+
+        def adapter(_):
+            """Count adapter constructions."""
+            counts["adapter"] += 1
+            return object()
+
+        monkeypatch.setattr(ou, "_ensure_chebi_db", ensure)
+        monkeypatch.setattr(ou, "assert_chebi_version_alignment", gate)
+        monkeypatch.setattr("oaklib.get_adapter", adapter)
+
+        first = ou.get_chebi_adapter()
+        second = ou.get_chebi_adapter()
+
+        assert first is second
+        assert counts == {"ensure": 1, "gate": 1, "adapter": 1}

--- a/tests/test_chebi_db_build.py
+++ b/tests/test_chebi_db_build.py
@@ -1,0 +1,248 @@
+"""
+Tests for building chebi.db from the chebi.owl we ship, and gating its release.
+
+Third application of the GO single-source rule (#604), after GO and NCBITaxon.
+ChEBI is the awkward case: it versions by an incrementing integer
+(``versionIRI .../obo/chebi/253/chebi.owl``) rather than an OBO ``YYYY-MM-DD``
+stamp, so the shared date-based reader returns None for it and any gate built on
+that reader silently passes. These tests pin the ChEBI-specific reader, the
+builder, and the gate.
+
+No test runs a real `semsql make`: the build is mocked and size thresholds
+shrunk.
+"""
+
+import sqlite3
+import subprocess
+
+import pytest
+
+from kg_microbe.utils import ontology_utils as ou
+
+OWL_VERSION_IRI = '<owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/chebi/{v}/chebi.owl"/>\n'
+OWL_VERSION_INFO = "<owl:versionInfo>{v}</owl:versionInfo>\n"
+
+
+def _write_owl(tmp_path, monkeypatch, body):
+    """Write a chebi.owl with `body` and point CHEBI_SOURCE at it."""
+    path = tmp_path / "chebi.owl"
+    path.write_text(body, encoding="utf-8")
+    monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", path)
+    return path
+
+
+def _make_db(tmp_path, release, *, subject="obo:chebi.owl", name="chebi.db"):
+    """Build a minimal SemSQL-shaped DB stamped with `release`."""
+    path = str(tmp_path / name)
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE statements (subject TEXT, predicate TEXT, object TEXT, value TEXT)")
+    conn.execute("INSERT INTO statements VALUES (?, 'owl:versionInfo', NULL, ?)", (subject, str(release)))
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _fake_build(monkeypatch, db_path, *, size=16, fail=False):
+    """Stand in for `semsql make`, recording the call and writing a fake DB."""
+    calls = []
+
+    def run(cmd, **kwargs):
+        """Record the invocation, then emit a fake DB (or fail)."""
+        calls.append((cmd, kwargs.get("cwd")))
+        if fail:
+            raise subprocess.CalledProcessError(1, cmd)
+        db_path.write_bytes(b"0" * size)
+
+    monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+    monkeypatch.setattr(ou.subprocess, "run", run)
+    return calls
+
+
+class TestChebiReleaseReader:
+
+    """ChEBI's integer stamp must be read where the date reader cannot."""
+
+    def test_reads_version_iri(self, tmp_path):
+        """The release comes out of the versionIRI path segment."""
+        path = tmp_path / "chebi.owl"
+        path.write_text(OWL_VERSION_IRI.format(v=253), encoding="utf-8")
+        assert ou._chebi_release_from_owl(path) == "253"
+
+    def test_reads_version_info(self, tmp_path):
+        """Falls back to owl:versionInfo when there is no versionIRI."""
+        path = tmp_path / "chebi.owl"
+        path.write_text(OWL_VERSION_INFO.format(v=251), encoding="utf-8")
+        assert ou._chebi_release_from_owl(path) == "251"
+
+    def test_date_reader_cannot_see_it(self, tmp_path):
+        """Regression note: this is why a date-based gate silently no-ops."""
+        path = tmp_path / "chebi.owl"
+        path.write_text(OWL_VERSION_IRI.format(v=253), encoding="utf-8")
+        assert ou._obo_release_from_head(path) is None
+        assert ou._chebi_release_from_owl(path) == "253"
+
+    def test_unstamped_returns_none(self, tmp_path):
+        """No stamp means None, which makes the gate and builder conservative."""
+        path = tmp_path / "chebi.owl"
+        path.write_text("no version here", encoding="utf-8")
+        assert ou._chebi_release_from_owl(path) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """An absent OWL is not an error for the reader."""
+        assert ou._chebi_release_from_owl(tmp_path / "absent.owl") is None
+
+    def test_db_release_read(self, tmp_path):
+        """_chebi_db_release reads the stamp off the ontology subject."""
+        assert ou._chebi_db_release(_make_db(tmp_path, 253)) == "253"
+
+    def test_db_release_ignores_term_subject(self, tmp_path):
+        """A version-shaped value on a CHEBI: term must not be mistaken for the release."""
+        path = str(tmp_path / "chebi.db")
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE statements (subject TEXT, predicate TEXT, object TEXT, value TEXT)")
+        conn.execute("INSERT INTO statements VALUES ('CHEBI:16828', 'owl:versionInfo', NULL, '999')")
+        conn.execute("INSERT INTO statements VALUES ('obo:chebi.owl', 'owl:versionInfo', NULL, '253')")
+        conn.commit()
+        conn.close()
+        assert ou._chebi_db_release(path) == "253"
+
+    def test_db_release_none_on_garbage(self, tmp_path):
+        """A non-SQLite file yields None rather than raising."""
+        path = tmp_path / "chebi.db"
+        path.write_text("not a database", encoding="utf-8")
+        assert ou._chebi_db_release(str(path)) is None
+
+
+class TestChebiGate:
+
+    """The gate must fire on drift and stay quiet otherwise."""
+
+    def test_aligned_is_silent(self, tmp_path, monkeypatch, capsys):
+        """Matching releases produce no output."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 253))
+        assert capsys.readouterr().out == ""
+
+    def test_mismatch_warns_by_default(self, tmp_path, monkeypatch, capsys):
+        """Default is warn, so a fallback DB of another release can't abort a build."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+        out = capsys.readouterr().out
+        assert "WARNING" in out and "chebi.owl=253" in out and "chebi.db=251" in out
+
+    def test_mismatch_raises_in_strict_mode(self, tmp_path, monkeypatch):
+        """Explicit strict escalates the same mismatch to a failure."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        with pytest.raises(RuntimeError, match="ChEBI source version mismatch"):
+            ou.assert_chebi_version_alignment(_make_db(tmp_path, 251), strict=True)
+
+    def test_env_var_escalates(self, tmp_path, monkeypatch):
+        """KG_CHEBI_VERSION_CHECK=strict flips the default."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        monkeypatch.setenv("KG_CHEBI_VERSION_CHECK", "strict")
+        with pytest.raises(RuntimeError):
+            ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+
+    def test_unreadable_stamp_is_a_noop(self, tmp_path, monkeypatch, capsys):
+        """An unstamped OWL must not warn (nothing to compare)."""
+        _write_owl(tmp_path, monkeypatch, "no version here")
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+        assert capsys.readouterr().out == ""
+
+
+class TestChebiBuild:
+
+    """Build behaviour mirrors _ensure_go_db / _ensure_ncbitaxon_db."""
+
+    def test_aligned_db_is_reused(self, tmp_path, monkeypatch):
+        """No rebuild when the DB already matches the OWL."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 253)
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert calls == []
+
+    def test_drifted_db_is_rebuilt(self, tmp_path, monkeypatch, capsys):
+        """A DB at a different ChEBI release is rebuilt from the OWL."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        source = _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 251)
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert calls == [(["semsql", "make", "chebi.db"], str(source.parent))]
+        assert "drifted" in capsys.readouterr().out
+
+    def test_decompresses_archive_when_owl_absent(self, tmp_path, monkeypatch):
+        """Semsql needs chebi.owl; the download only ships chebi.owl.gz."""
+        import gzip as gz
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+
+        db = tmp_path / "chebi.db"
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert owl.exists(), "chebi.owl.gz should have been decompressed"
+        assert "253" in owl.read_text(encoding="utf-8")
+        assert len(calls) == 1
+
+    def test_missing_semsql_keeps_existing_db(self, tmp_path, monkeypatch, capsys):
+        """Without semsql, keep whatever DB is present instead of deleting it."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db_path = _make_db(tmp_path, 251)
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+
+        assert ou._ensure_chebi_db(db_path) is True
+        assert "semsql" in capsys.readouterr().out
+
+    def test_missing_owl_and_archive_warns(self, tmp_path, monkeypatch, capsys):
+        """Neither OWL nor archive means no build; report it."""
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", tmp_path / "chebi.owl")
+        assert ou._ensure_chebi_db(str(tmp_path / "chebi.db")) is False
+        assert "missing" in capsys.readouterr().out
+
+    def test_failed_build_returns_false(self, tmp_path, monkeypatch, capsys):
+        """A semsql crash is reported, not raised."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _fake_build(monkeypatch, db, fail=True)
+        assert ou._ensure_chebi_db(str(db)) is False
+        assert "failed to build" in capsys.readouterr().out
+
+    def test_undersized_result_is_rejected(self, tmp_path, monkeypatch):
+        """A stub-sized build result is not reported as usable."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _fake_build(monkeypatch, db, size=16)  # threshold stays at 100 MB
+        assert ou._ensure_chebi_db(str(db)) is False
+
+
+class TestAdapterEntryPoint:
+
+    """Both category-fixing paths must go through one ensured adapter."""
+
+    def test_get_chebi_adapter_ensures_and_gates(self, tmp_path, monkeypatch):
+        """get_chebi_adapter builds/realigns, runs the gate, then opens the DB."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        seen = {}
+
+        monkeypatch.setattr(ou, "_ensure_chebi_db", lambda p: seen.setdefault("ensured", p) or True)
+        monkeypatch.setattr(ou, "assert_chebi_version_alignment", lambda p: seen.setdefault("gated", p))
+        monkeypatch.setattr("oaklib.get_adapter", lambda spec: seen.setdefault("adapter", spec))
+
+        ou.get_chebi_adapter()
+
+        expected = str(tmp_path / "chebi.db")
+        assert seen["ensured"] == expected
+        assert seen["gated"] == expected
+        assert seen["adapter"] == f"sqlite:{expected}"

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -29,6 +29,8 @@ KNOWN_TAGS = {
     "kegg",
     "gtdb",
     "metatraits",
+    "metatraits_gtdb",
+    "bactotraits",
     "schema",
 }
 
@@ -62,6 +64,127 @@ class TestYamlTagging:
         """The bulk-download gate keys off this exact tag string."""
         tags = {e["tag"] for e in _entries() if e.get("tag")}
         assert download_module.MEDIADIVE_TAG in tags
+
+
+class TestPendingHosting:
+
+    """
+    Sources with a placeholder URL must be skipped, not attempted.
+
+    kghub-downloader aborts the whole run on the first download error, so leaving
+    a REPLACE_ME_ URL in the config would break `kg download` for everyone.
+    """
+
+    def _pending(self):
+        """Return the entries whose URL is still a hosting placeholder."""
+        return [e for e in _entries() if download_module.PENDING_HOSTING_MARKER in e["url"]]
+
+    def test_pending_entries_are_tagged(self):
+        """A placeholder entry still needs a tag so -t reaches it once hosted."""
+        untagged = [e["local_name"] for e in self._pending() if not e.get("tag")]
+        assert untagged == []
+
+    def _capture_config(self, tmp_path, **kwargs):
+        """
+        Run download() and return the config entries as the downloader saw them.
+
+        Read inside the call: download() deletes its temp config on the way out.
+        """
+        captured = {}
+
+        def record(**call_kwargs):
+            """Parse the config file while it still exists."""
+            with open(call_kwargs["yaml_file"]) as f:
+                captured["entries"] = yaml.safe_load(f)
+
+        with patch.object(download_module, "download_from_yaml", side_effect=record):
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=False,
+                **kwargs,
+            )
+        return captured["entries"]
+
+    def test_pending_entries_are_filtered_out(self, tmp_path):
+        """The config handed to the downloader must contain no placeholder URL."""
+        entries = self._capture_config(tmp_path)
+        assert entries, "filtered config should still contain the ready entries"
+        assert not [e for e in entries if download_module.PENDING_HOSTING_MARKER in e["url"]]
+
+    def test_ready_entries_survive_filtering(self, tmp_path):
+        """Filtering must drop only the placeholders."""
+        entries = self._capture_config(tmp_path)
+        assert len(entries) == len(_entries()) - len(self._pending())
+
+    def test_filtered_entries_keep_their_fields(self, tmp_path):
+        """Round-tripping the config must not lose url/local_name/tag."""
+        entries = self._capture_config(tmp_path)
+        assert all({"url", "local_name", "tag"} <= set(e) for e in entries)
+
+    def test_temp_config_is_cleaned_up(self, tmp_path):
+        """The filtered copy is a temp file; it must not be left behind."""
+        with patch.object(download_module, "download_from_yaml") as mock_yaml:
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=False,
+            )
+        used_yaml = mock_yaml.call_args.kwargs["yaml_file"]
+        assert used_yaml != str(DOWNLOAD_YAML)
+        assert not Path(used_yaml).exists()
+
+    def test_temp_config_cleaned_up_on_error(self, tmp_path):
+        """A failed download must not leak the temp config either."""
+        seen = {}
+
+        def boom(**kwargs):
+            """Record the config path, then fail like a dead URL would."""
+            seen["yaml"] = kwargs["yaml_file"]
+            raise RuntimeError("download exploded")
+
+        with patch.object(download_module, "download_from_yaml", side_effect=boom):
+            with pytest.raises(RuntimeError, match="exploded"):
+                download_module.download(
+                    yaml_file=str(DOWNLOAD_YAML),
+                    output_dir=str(tmp_path),
+                    snippet_only=False,
+                )
+        assert not Path(seen["yaml"]).exists()
+
+    def test_skipped_sources_are_reported(self, tmp_path, capsys):
+        """A silent skip looks like a download of a file that never arrived."""
+        with patch.object(download_module, "download_from_yaml"):
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=False,
+            )
+        out = capsys.readouterr().out
+        assert "not hosted yet" in out
+        for entry in self._pending():
+            assert entry["local_name"] in out
+
+    def test_unaffected_tag_run_uses_the_original_config(self, tmp_path):
+        """A run selecting no pending entry needs no filtered copy."""
+        with patch.object(download_module, "download_from_yaml") as mock_yaml:
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=False,
+                tags=("ontologies",),
+            )
+        assert mock_yaml.call_args.kwargs["yaml_file"] == str(DOWNLOAD_YAML)
+
+    def test_pending_tag_is_still_a_valid_tag(self, tmp_path):
+        """`-t metatraits_gtdb` must not be rejected as unknown while unhosted."""
+        with patch.object(download_module, "download_from_yaml"):
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=False,
+                tags=("metatraits_gtdb",),
+            )
 
 
 class TestTagPlumbing:

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -175,10 +175,14 @@ class TestPendingHosting:
         assert seen["path"] == config
 
     def test_pending_tag_is_still_a_valid_tag(self, tmp_path):
-        """A tag whose only entries are unhosted must not be rejected as unknown."""
+        """A tag whose only entries are unhosted must be accepted, not rejected as unknown."""
         config = self._config(tmp_path)
+        # Reaching the downloader at all proves _validate_tags accepted the tag;
+        # a rejection would have raised ValueError before this point.
         seen = self._run(tmp_path, config, tags=("metatraits_gtdb",))
-        assert seen["entries"] == [] or "unhosted.tsv.gz" not in str(seen["entries"])
+        assert "path" in seen, "download_from_yaml should still have been called"
+        names = [e["local_name"] for e in seen["entries"]]
+        assert "unhosted.tsv.gz" not in names, "the pending entry must be filtered out"
 
 
 class TestTagPlumbing:

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -195,6 +195,40 @@ class TestPendingHosting:
         assert "unhosted.tsv.gz" not in names, "the pending entry must be filtered out"
 
 
+class TestCliErrorHandling:
+
+    """The CLI must report bad tags as usage errors without hiding real crashes."""
+
+    def test_unknown_tag_is_a_usage_error(self, tmp_path):
+        """A bad -t is user error: exit 2, no traceback."""
+        from click.testing import CliRunner
+
+        from kg_microbe.run import download as download_cmd
+
+        result = CliRunner().invoke(download_cmd, ["-y", str(DOWNLOAD_YAML), "-o", str(tmp_path), "-t", "nosuchtag"])
+        assert result.exit_code == 2
+        assert "Unknown download tag" in result.output
+
+    def test_unrelated_valueerror_is_not_mislabelled(self, tmp_path):
+        """
+        A ValueError from deep in the download must not be reported as a bad tag.
+
+        JSONDecodeError and pydantic's ValidationError are both ValueError
+        subclasses, so a blanket `except ValueError` turned a corrupt
+        mediadive.json into 'Error: Invalid value: ...' against -t, swallowing the
+        traceback that pointed at the real cause.
+        """
+        from click.testing import CliRunner
+
+        from kg_microbe.run import download as download_cmd
+
+        with patch.object(download_module, "download_from_yaml", side_effect=ValueError("boom in json")):
+            result = CliRunner().invoke(download_cmd, ["-y", str(DOWNLOAD_YAML), "-o", str(tmp_path)])
+        assert result.exit_code != 2, "should not be reported as a usage error"
+        assert isinstance(result.exception, ValueError)
+        assert "boom in json" in str(result.exception)
+
+
 class TestTagPlumbing:
 
     """Tags must reach kghub-downloader, and gate the MediaDive bulk step."""

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -75,64 +75,67 @@ class TestPendingHosting:
     a REPLACE_ME_ URL in the config would break `kg download` for everyone.
     """
 
-    def _pending(self):
-        """Return the entries whose URL is still a hosting placeholder."""
-        return [e for e in _entries() if download_module.PENDING_HOSTING_MARKER in e["url"]]
+    # The mechanism is exercised against a synthetic config rather than
+    # download.yaml, which normally has no placeholders left: every file is
+    # hosted. Tying these to the real file made them pass only while something
+    # happened to be unhosted.
+    @staticmethod
+    def _config(tmp_path, *, pending=True):
+        """Write a small config with one ready entry and optionally one pending."""
+        entries = [{"url": "https://example.org/ready.tsv", "local_name": "ready.tsv", "tag": "ontologies"}]
+        if pending:
+            entries.append(
+                {
+                    "url": f"gdrive:{download_module.PENDING_HOSTING_MARKER}thing",
+                    "local_name": "unhosted.tsv.gz",
+                    "tag": "metatraits_gtdb",
+                }
+            )
+        path = tmp_path / "config.yaml"
+        with open(path, "w") as f:
+            yaml.safe_dump(entries, f, sort_keys=False)
+        return str(path)
 
-    def test_pending_entries_are_tagged(self):
-        """A placeholder entry still needs a tag so -t reaches it once hosted."""
-        untagged = [e["local_name"] for e in self._pending() if not e.get("tag")]
-        assert untagged == []
-
-    def _capture_config(self, tmp_path, **kwargs):
-        """
-        Run download() and return the config entries as the downloader saw them.
-
-        Read inside the call: download() deletes its temp config on the way out.
-        """
+    def _run(self, tmp_path, config, **kwargs):
+        """Run download() against `config`, capturing what the downloader saw."""
         captured = {}
 
         def record(**call_kwargs):
             """Parse the config file while it still exists."""
+            captured["path"] = call_kwargs["yaml_file"]
             with open(call_kwargs["yaml_file"]) as f:
                 captured["entries"] = yaml.safe_load(f)
 
         with patch.object(download_module, "download_from_yaml", side_effect=record):
             download_module.download(
-                yaml_file=str(DOWNLOAD_YAML),
-                output_dir=str(tmp_path),
+                yaml_file=config,
+                output_dir=str(tmp_path / "out"),
                 snippet_only=False,
                 **kwargs,
             )
-        return captured["entries"]
+        return captured
+
+    def test_real_config_pending_entries_are_tagged(self):
+        """Any placeholder left in download.yaml still needs a tag."""
+        pending = [e for e in _entries() if download_module.PENDING_HOSTING_MARKER in e["url"]]
+        assert [e["local_name"] for e in pending if not e.get("tag")] == []
 
     def test_pending_entries_are_filtered_out(self, tmp_path):
         """The config handed to the downloader must contain no placeholder URL."""
-        entries = self._capture_config(tmp_path)
-        assert entries, "filtered config should still contain the ready entries"
-        assert not [e for e in entries if download_module.PENDING_HOSTING_MARKER in e["url"]]
-
-    def test_ready_entries_survive_filtering(self, tmp_path):
-        """Filtering must drop only the placeholders."""
-        entries = self._capture_config(tmp_path)
-        assert len(entries) == len(_entries()) - len(self._pending())
+        seen = self._run(tmp_path, self._config(tmp_path))
+        assert [e["local_name"] for e in seen["entries"]] == ["ready.tsv"]
 
     def test_filtered_entries_keep_their_fields(self, tmp_path):
         """Round-tripping the config must not lose url/local_name/tag."""
-        entries = self._capture_config(tmp_path)
-        assert all({"url", "local_name", "tag"} <= set(e) for e in entries)
+        seen = self._run(tmp_path, self._config(tmp_path))
+        assert all({"url", "local_name", "tag"} <= set(e) for e in seen["entries"])
 
     def test_temp_config_is_cleaned_up(self, tmp_path):
         """The filtered copy is a temp file; it must not be left behind."""
-        with patch.object(download_module, "download_from_yaml") as mock_yaml:
-            download_module.download(
-                yaml_file=str(DOWNLOAD_YAML),
-                output_dir=str(tmp_path),
-                snippet_only=False,
-            )
-        used_yaml = mock_yaml.call_args.kwargs["yaml_file"]
-        assert used_yaml != str(DOWNLOAD_YAML)
-        assert not Path(used_yaml).exists()
+        config = self._config(tmp_path)
+        seen = self._run(tmp_path, config)
+        assert seen["path"] != config
+        assert not Path(seen["path"]).exists()
 
     def test_temp_config_cleaned_up_on_error(self, tmp_path):
         """A failed download must not leak the temp config either."""
@@ -146,45 +149,36 @@ class TestPendingHosting:
         with patch.object(download_module, "download_from_yaml", side_effect=boom):
             with pytest.raises(RuntimeError, match="exploded"):
                 download_module.download(
-                    yaml_file=str(DOWNLOAD_YAML),
-                    output_dir=str(tmp_path),
+                    yaml_file=self._config(tmp_path),
+                    output_dir=str(tmp_path / "out"),
                     snippet_only=False,
                 )
         assert not Path(seen["yaml"]).exists()
 
     def test_skipped_sources_are_reported(self, tmp_path, capsys):
         """A silent skip looks like a download of a file that never arrived."""
-        with patch.object(download_module, "download_from_yaml"):
-            download_module.download(
-                yaml_file=str(DOWNLOAD_YAML),
-                output_dir=str(tmp_path),
-                snippet_only=False,
-            )
+        self._run(tmp_path, self._config(tmp_path))
         out = capsys.readouterr().out
         assert "not hosted yet" in out
-        for entry in self._pending():
-            assert entry["local_name"] in out
+        assert "unhosted.tsv.gz" in out
+
+    def test_no_placeholders_means_original_config(self, tmp_path):
+        """With everything hosted, no filtered copy is made at all."""
+        config = self._config(tmp_path, pending=False)
+        seen = self._run(tmp_path, config)
+        assert seen["path"] == config
 
     def test_unaffected_tag_run_uses_the_original_config(self, tmp_path):
         """A run selecting no pending entry needs no filtered copy."""
-        with patch.object(download_module, "download_from_yaml") as mock_yaml:
-            download_module.download(
-                yaml_file=str(DOWNLOAD_YAML),
-                output_dir=str(tmp_path),
-                snippet_only=False,
-                tags=("ontologies",),
-            )
-        assert mock_yaml.call_args.kwargs["yaml_file"] == str(DOWNLOAD_YAML)
+        config = self._config(tmp_path)
+        seen = self._run(tmp_path, config, tags=("ontologies",))
+        assert seen["path"] == config
 
     def test_pending_tag_is_still_a_valid_tag(self, tmp_path):
-        """`-t metatraits_gtdb` must not be rejected as unknown while unhosted."""
-        with patch.object(download_module, "download_from_yaml"):
-            download_module.download(
-                yaml_file=str(DOWNLOAD_YAML),
-                output_dir=str(tmp_path),
-                snippet_only=False,
-                tags=("metatraits_gtdb",),
-            )
+        """A tag whose only entries are unhosted must not be rejected as unknown."""
+        config = self._config(tmp_path)
+        seen = self._run(tmp_path, config, tags=("metatraits_gtdb",))
+        assert seen["entries"] == [] or "unhosted.tsv.gz" not in str(seen["entries"])
 
 
 class TestTagPlumbing:

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -60,6 +60,16 @@ class TestYamlTagging:
         used = {e["tag"] for e in _entries() if e.get("tag")}
         assert KNOWN_TAGS - used == set(), f"documented but unused tag(s): {sorted(KNOWN_TAGS - used)}"
 
+    def test_urls_have_no_surrounding_whitespace(self):
+        """A stray space becomes part of the URL handed to urllib (#623)."""
+        offenders = [e["local_name"] for e in _entries() if e["url"] != e["url"].strip()]
+        assert offenders == [], f"entries with padded URLs: {offenders}"
+
+    def test_local_names_have_no_surrounding_whitespace(self):
+        """Same hazard for the destination path."""
+        offenders = [e["local_name"] for e in _entries() if e["local_name"] != e["local_name"].strip()]
+        assert offenders == []
+
     def test_mediadive_tag_matches_the_constant(self):
         """The bulk-download gate keys off this exact tag string."""
         tags = {e["tag"] for e in _entries() if e.get("tag")}

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -1,0 +1,150 @@
+"""Tests for tag-filtered downloads (`kg download -t <tag>`)."""
+
+from importlib import import_module
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+# kg_microbe/__init__.py does `from .download import download`, so the name
+# kg_microbe.download resolves to the *function*, not the module. Fetch the
+# module from sys.modules so patch.object targets the right object.
+download_module = import_module("kg_microbe.download")
+
+DOWNLOAD_YAML = Path(__file__).parent.parent / "download.yaml"
+
+# Tags documented in download.yaml's header. Kept here so a typo'd tag on a new
+# entry fails loudly instead of creating a near-duplicate group.
+KNOWN_TAGS = {
+    "tools",
+    "ontologies",
+    "stubs",
+    "mappings",
+    "bacdive",
+    "mediadive",
+    "madin",
+    "rhea",
+    "cog",
+    "kegg",
+    "gtdb",
+    "metatraits",
+    "schema",
+}
+
+
+def _entries():
+    """Return the active (uncommented) resource entries in download.yaml."""
+    with open(DOWNLOAD_YAML) as f:
+        return yaml.safe_load(f) or []
+
+
+class TestYamlTagging:
+
+    """Every active download entry must be reachable via -t."""
+
+    def test_every_entry_has_a_tag(self):
+        """An untagged entry can never be selected by -t, so require one."""
+        untagged = [e.get("local_name") or e.get("url") for e in _entries() if not e.get("tag")]
+        assert untagged == [], f"download.yaml entries missing a tag: {untagged}"
+
+    def test_tags_are_from_the_documented_set(self):
+        """Guard against typos silently creating a new one-entry group."""
+        used = {e["tag"] for e in _entries() if e.get("tag")}
+        assert used - KNOWN_TAGS == set(), f"undocumented tag(s): {sorted(used - KNOWN_TAGS)}"
+
+    def test_documented_tags_are_all_used(self):
+        """A documented tag that matches nothing would be a dead option."""
+        used = {e["tag"] for e in _entries() if e.get("tag")}
+        assert KNOWN_TAGS - used == set(), f"documented but unused tag(s): {sorted(KNOWN_TAGS - used)}"
+
+    def test_mediadive_tag_matches_the_constant(self):
+        """The bulk-download gate keys off this exact tag string."""
+        tags = {e["tag"] for e in _entries() if e.get("tag")}
+        assert download_module.MEDIADIVE_TAG in tags
+
+
+class TestTagPlumbing:
+
+    """Tags must reach kghub-downloader, and gate the MediaDive bulk step."""
+
+    def _run(self, tmp_path, **kwargs):
+        """Call download() with both downstream side effects mocked out."""
+        with (
+            patch.object(download_module, "download_from_yaml") as mock_yaml,
+            patch.object(download_module, "_post_download_mediadive_bulk") as mock_bulk,
+        ):
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=False,
+                **kwargs,
+            )
+        return mock_yaml, mock_bulk
+
+    def test_tags_are_forwarded(self, tmp_path):
+        """-t values must be handed to download_from_yaml."""
+        mock_yaml, _ = self._run(tmp_path, tags=("ontologies", "gtdb"))
+        assert mock_yaml.call_args.kwargs["tags"] == ["ontologies", "gtdb"]
+
+    def test_no_tags_means_everything(self, tmp_path):
+        """Omitting -t must not filter (None, not an empty list)."""
+        mock_yaml, _ = self._run(tmp_path)
+        assert mock_yaml.call_args.kwargs["tags"] is None
+
+    def test_empty_tags_tuple_means_everything(self, tmp_path):
+        """Click passes () when -t is absent; that must mean 'all', not 'none'."""
+        mock_yaml, _ = self._run(tmp_path, tags=())
+        assert mock_yaml.call_args.kwargs["tags"] is None
+
+    def test_mediadive_bulk_skipped_when_tag_excluded(self, tmp_path):
+        """`-t ontologies` must not start an hour of MediaDive API calls."""
+        _, mock_bulk = self._run(tmp_path, tags=("ontologies",))
+        mock_bulk.assert_not_called()
+
+    def test_mediadive_bulk_runs_when_tag_included(self, tmp_path):
+        """`-t mediadive` must still do the follow-on bulk download."""
+        _, mock_bulk = self._run(tmp_path, tags=("mediadive",))
+        mock_bulk.assert_called_once()
+
+    def test_mediadive_bulk_runs_without_tags(self, tmp_path):
+        """An unfiltered run keeps its existing behaviour."""
+        _, mock_bulk = self._run(tmp_path)
+        mock_bulk.assert_called_once()
+
+    def test_unknown_tag_raises(self, tmp_path):
+        """An unknown tag downloads nothing, which looks like success — so fail."""
+        with patch.object(download_module, "download_from_yaml") as mock_yaml:
+            with pytest.raises(ValueError, match="Unknown download tag"):
+                download_module.download(
+                    yaml_file=str(DOWNLOAD_YAML),
+                    output_dir=str(tmp_path),
+                    snippet_only=False,
+                    tags=("ontolgies",),  # typo
+                )
+        mock_yaml.assert_not_called()
+
+    def test_error_lists_available_tags(self, tmp_path):
+        """The message should tell the user what they could have typed."""
+        with patch.object(download_module, "download_from_yaml"):
+            with pytest.raises(ValueError, match="ontologies"):
+                download_module.download(
+                    yaml_file=str(DOWNLOAD_YAML),
+                    output_dir=str(tmp_path),
+                    snippet_only=False,
+                    tags=("nope",),
+                )
+
+    def test_snippet_mode_still_skips_bulk(self, tmp_path):
+        """Snippet mode skipped the bulk step before tags existed; keep that."""
+        with (
+            patch.object(download_module, "download_from_yaml"),
+            patch.object(download_module, "_post_download_mediadive_bulk") as mock_bulk,
+        ):
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=True,
+                tags=("mediadive",),
+            )
+        mock_bulk.assert_not_called()

--- a/tests/test_go_version_alignment.py
+++ b/tests/test_go_version_alignment.py
@@ -239,6 +239,7 @@ def _stub_go_transform(tmp_path, monkeypatch):
     calls = {"convert": 0}
 
     def fake_convert(path, ont):
+        """Stand in for ROBOT owl->json: count the call, write a fresh go.json."""
         calls["convert"] += 1
         (Path(path) / f"{ont}.json").write_text(_JSON.format(d="2026-05-19"), encoding="utf-8")
 

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -1,8 +1,10 @@
 """Tests for mediadive_bulk_download utility."""
 
+import inspect
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from importlib import import_module
 from unittest.mock import MagicMock, patch
 
 import requests
@@ -14,10 +16,16 @@ from kg_microbe.utils.mediadive_bulk_download import (
     _make_session,
     _reset_sessions,
     download_detailed_media,
+    download_mediadive_bulk,
     download_medium_strains,
     get_json_from_api,
     setup_cache,
 )
+
+# kg_microbe/__init__.py does `from .download import download`, so the name
+# kg_microbe.download resolves to the *function*, not the module. Fetch the
+# module from sys.modules so patch.object targets the right object.
+download_module = import_module("kg_microbe.download")
 
 
 class TestDefaults:
@@ -132,6 +140,38 @@ class TestCacheThreadSafety:
         assert cache_path.exists()
         assert not legacy.exists(), "legacy cache should be moved, not left behind"
 
+    def test_clear_discards_cached_responses(self, tmp_path):
+        """clear=True must drop cached responses so the API is re-queried."""
+        setup_cache(tmp_path)
+        session = _make_session()
+        session.cache.responses["some-key"] = "cached-value"
+        assert len(session.cache.responses) == 1
+
+        setup_cache(tmp_path, clear=True)
+
+        assert len(_make_session().cache.responses) == 0
+
+    def test_clear_removes_wal_sidecar_files(self, tmp_path):
+        """WAL mode leaves -wal/-shm files behind; clearing must not orphan them."""
+        cache_path = setup_cache(tmp_path)
+        for suffix in ("-wal", "-shm"):
+            cache_path.with_name(cache_path.name + suffix).write_bytes(b"stale")
+
+        setup_cache(tmp_path, clear=True)
+
+        for suffix in ("-wal", "-shm"):
+            sidecar = cache_path.with_name(cache_path.name + suffix)
+            assert not sidecar.exists() or sidecar.read_bytes() != b"stale"
+
+    def test_clear_is_off_by_default(self, tmp_path):
+        """Without clear=True, an existing cache survives setup_cache."""
+        setup_cache(tmp_path)
+        _make_session().cache.responses["keep-me"] = "cached-value"
+
+        setup_cache(tmp_path)
+
+        assert "keep-me" in _make_session().cache.responses
+
     def test_cwd_cache_is_untouched_by_default(self, tmp_path, monkeypatch):
         """
         setup_cache must not move files outside cache_dir unless asked.
@@ -149,6 +189,38 @@ class TestCacheThreadSafety:
 
         assert bystander.exists(), "default setup_cache must not touch the CWD"
         assert bystander.read_bytes() == b"do not move me"
+
+
+class TestIgnoreCachePlumbing:
+
+    """
+    Verify `kg download --ignore-cache` reaches the HTTP response cache.
+
+    Rebuilding the bulk JSON files from a warm HTTP cache reproduces the old
+    data byte for byte, so --ignore-cache has to clear that cache too.
+    """
+
+    def _write_basic_media(self, tmp_path):
+        """Create the mediadive.json that _post_download_mediadive_bulk looks for."""
+        (tmp_path / "mediadive.json").write_text('{"data": [{"id": 1}]}')
+
+    def test_ignore_cache_is_forwarded(self, tmp_path):
+        """ignore_cache=True must reach download_mediadive_bulk."""
+        self._write_basic_media(tmp_path)
+        with patch.object(download_module, "download_mediadive_bulk") as mock_bulk:
+            download_module._post_download_mediadive_bulk(str(tmp_path), ignore_cache=True)
+        assert mock_bulk.call_args.kwargs["ignore_cache"] is True
+
+    def test_default_leaves_cache_intact(self, tmp_path):
+        """Without --ignore-cache, cached HTTP responses must be reused."""
+        self._write_basic_media(tmp_path)
+        with patch.object(download_module, "download_mediadive_bulk") as mock_bulk:
+            download_module._post_download_mediadive_bulk(str(tmp_path))
+        assert mock_bulk.call_args.kwargs["ignore_cache"] is False
+
+    def test_bulk_download_accepts_ignore_cache(self):
+        """download_mediadive_bulk must expose ignore_cache for the CLI to pass."""
+        assert "ignore_cache" in inspect.signature(download_mediadive_bulk).parameters
 
 
 class TestRetryAfter:

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -196,6 +196,22 @@ class TestCacheThreadSafety:
 
         assert "keep-me" in _make_session().cache.responses
 
+    def test_migration_moves_wal_sidecars(self, tmp_path, monkeypatch):
+        """WAL sidecars must travel with the DB, not be orphaned in the CWD (#622)."""
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        legacy = cwd / CACHE_FILENAME
+        legacy.write_bytes(b"")
+        for suffix in ("-wal", "-shm"):
+            legacy.with_name(legacy.name + suffix).write_bytes(b"sidecar")
+
+        cache_path = setup_cache(tmp_path / "out", migrate_legacy=True)
+
+        for suffix in ("-wal", "-shm"):
+            assert not legacy.with_name(legacy.name + suffix).exists(), f"{suffix} orphaned in CWD"
+        assert cache_path.exists()
+
     def test_cwd_cache_is_untouched_by_default(self, tmp_path, monkeypatch):
         """
         setup_cache must not move files outside cache_dir unless asked.

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -2,16 +2,21 @@
 
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import requests
 
 from kg_microbe.utils.mediadive_bulk_download import (
+    CACHE_FILENAME,
     DEFAULT_MAX_WORKERS,
     USER_AGENT,
+    _make_session,
+    _reset_sessions,
     download_detailed_media,
     download_medium_strains,
     get_json_from_api,
+    setup_cache,
 )
 
 
@@ -42,6 +47,108 @@ class TestDefaults:
         with patch("kg_microbe.utils.mediadive_bulk_download.get_json_from_api", return_value=[{"strain": "A"}]):
             result = download_medium_strains(media_list, max_workers=2)
         assert isinstance(result, dict)
+
+
+class TestCacheThreadSafety:
+
+    """
+    Verify HTTP sessions are never shared across threads.
+
+    requests_cache's SQLiteDict holds one sqlite3.Connection for all callers and
+    takes no lock on reads, so sharing a CachedSession across a ThreadPoolExecutor
+    raises "database disk image is malformed" against an intact database. Each
+    thread must get its own session, and therefore its own connection.
+    """
+
+    def teardown_method(self):
+        """Disable caching and drop per-thread sessions between tests."""
+        setup_cache(None)
+
+    def test_setup_cache_creates_db_in_given_dir(self, tmp_path):
+        """The cache database belongs next to the bulk output, not in the CWD."""
+        cache_path = setup_cache(tmp_path)
+        assert cache_path == tmp_path / CACHE_FILENAME
+        assert cache_path.exists()
+
+    def test_each_thread_gets_its_own_session(self, tmp_path):
+        """_make_session must return a distinct session per calling thread."""
+        setup_cache(tmp_path)
+        n_threads = 5
+
+        def grab(_):
+            """Return this thread's session object."""
+            return _make_session()
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            sessions = list(executor.map(grab, range(n_threads * 4)))
+
+        by_thread = {id(s) for s in sessions}
+        assert len(by_thread) == n_threads, "sessions must not be shared between threads"
+        assert all(s.headers["User-Agent"] == USER_AGENT for s in sessions)
+
+    def test_each_session_has_its_own_sqlite_connection(self, tmp_path):
+        """Distinct sessions must not end up sharing one sqlite3.Connection."""
+        setup_cache(tmp_path)
+        n_threads = 4
+
+        def open_connection(_):
+            """Force this thread's backend to open its connection, and return it."""
+            session = _make_session()
+            with session.cache.responses.connection() as con:
+                return id(con)
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            connection_ids = set(executor.map(open_connection, range(n_threads * 4)))
+
+        assert len(connection_ids) == n_threads
+
+    def test_repeated_calls_reuse_the_same_thread_session(self, tmp_path):
+        """Within one thread, _make_session must be idempotent (no session churn)."""
+        setup_cache(tmp_path)
+        assert _make_session() is _make_session()
+
+    def test_caching_is_not_installed_globally(self, tmp_path):
+        """setup_cache must not monkeypatch requests.Session for the whole process."""
+        setup_cache(tmp_path)
+        assert type(requests.Session()) is requests.Session
+        assert not hasattr(requests.Session(), "cache")
+
+    def test_disabled_cache_yields_plain_sessions(self):
+        """With caching off, sessions are plain requests.Session objects."""
+        setup_cache(None)
+        _reset_sessions()
+        assert type(_make_session()) is requests.Session
+
+    def test_existing_cache_is_adopted_when_requested(self, tmp_path, monkeypatch):
+        """With migrate_legacy=True, a cache left in the CWD by the old code is reused."""
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        legacy = cwd / CACHE_FILENAME
+        legacy.write_bytes(b"")
+
+        cache_path = setup_cache(tmp_path / "out", migrate_legacy=True)
+
+        assert cache_path.exists()
+        assert not legacy.exists(), "legacy cache should be moved, not left behind"
+
+    def test_cwd_cache_is_untouched_by_default(self, tmp_path, monkeypatch):
+        """
+        setup_cache must not move files outside cache_dir unless asked.
+
+        Regression guard: an unconditional migration meant any setup_cache call —
+        including from a test suite — would relocate a real cache sitting in the CWD.
+        """
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        bystander = cwd / CACHE_FILENAME
+        bystander.write_bytes(b"do not move me")
+
+        setup_cache(tmp_path / "out")
+
+        assert bystander.exists(), "default setup_cache must not touch the CWD"
+        assert bystander.read_bytes() == b"do not move me"
 
 
 class TestRetryAfter:

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -110,6 +110,30 @@ class TestCacheThreadSafety:
 
         assert len(connection_ids) == n_threads
 
+    def test_reset_closes_sessions_from_other_threads(self, tmp_path):
+        """Discarded sessions must be closed, not left to garbage collection (#617)."""
+        setup_cache(tmp_path)
+        closed = []
+
+        def build_and_track(_):
+            """Create this thread's session and wrap close() to record the call."""
+            session = _make_session()
+            original = session.close
+
+            def close():
+                """Record that close was called, then really close."""
+                closed.append(id(session))
+                original()
+
+            session.close = close
+            return id(session)
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            ids = set(executor.map(build_and_track, range(9)))
+
+        _reset_sessions()
+        assert set(closed) == ids, "every per-thread session should have been closed"
+
     def test_repeated_calls_reuse_the_same_thread_session(self, tmp_path):
         """Within one thread, _make_session must be idempotent (no session churn)."""
         setup_cache(tmp_path)

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -13,6 +13,7 @@ from kg_microbe.utils.mediadive_bulk_download import (
     CACHE_FILENAME,
     DEFAULT_MAX_WORKERS,
     USER_AGENT,
+    _delete_cache,
     _make_session,
     _reset_sessions,
     download_detailed_media,
@@ -78,37 +79,51 @@ class TestCacheThreadSafety:
         assert cache_path == tmp_path / CACHE_FILENAME
         assert cache_path.exists()
 
+    # These assert injectivity (no object seen from two different threads) rather
+    # than an exact count. ThreadPoolExecutor spawns workers lazily, so with fast
+    # tasks fewer than max_workers threads ever run and `== n_threads` failed
+    # ~75% of runs in isolation while passing under a slower full-suite run.
     def test_each_thread_gets_its_own_session(self, tmp_path):
-        """_make_session must return a distinct session per calling thread."""
+        """_make_session must never hand the same session to two threads."""
         setup_cache(tmp_path)
         n_threads = 5
 
         def grab(_):
-            """Return this thread's session object."""
-            return _make_session()
+            """Return (thread id, session) for this call."""
+            session = _make_session()
+            return threading.get_ident(), session
 
         with ThreadPoolExecutor(max_workers=n_threads) as executor:
-            sessions = list(executor.map(grab, range(n_threads * 4)))
+            results = list(executor.map(grab, range(n_threads * 20)))
 
-        by_thread = {id(s) for s in sessions}
-        assert len(by_thread) == n_threads, "sessions must not be shared between threads"
-        assert all(s.headers["User-Agent"] == USER_AGENT for s in sessions)
+        owners = {}
+        for tid, session in results:
+            owners.setdefault(id(session), set()).add(tid)
+        shared = {sid: tids for sid, tids in owners.items() if len(tids) > 1}
+        assert shared == {}, f"sessions shared across threads: {shared}"
+        assert len({tid for tid, _ in results}) > 1, "test did not exercise concurrency"
+        assert all(s.headers["User-Agent"] == USER_AGENT for _, s in results)
 
     def test_each_session_has_its_own_sqlite_connection(self, tmp_path):
-        """Distinct sessions must not end up sharing one sqlite3.Connection."""
+        """A sqlite3.Connection must never be reached from two threads."""
         setup_cache(tmp_path)
         n_threads = 4
 
         def open_connection(_):
-            """Force this thread's backend to open its connection, and return it."""
+            """Force this thread's backend to open its connection; return (tid, id)."""
             session = _make_session()
             with session.cache.responses.connection() as con:
-                return id(con)
+                return threading.get_ident(), id(con)
 
         with ThreadPoolExecutor(max_workers=n_threads) as executor:
-            connection_ids = set(executor.map(open_connection, range(n_threads * 4)))
+            results = list(executor.map(open_connection, range(n_threads * 20)))
 
-        assert len(connection_ids) == n_threads
+        owners = {}
+        for tid, con_id in results:
+            owners.setdefault(con_id, set()).add(tid)
+        shared = {cid: tids for cid, tids in owners.items() if len(tids) > 1}
+        assert shared == {}, f"connections shared across threads: {shared}"
+        assert len({tid for tid, _ in results}) > 1, "test did not exercise concurrency"
 
     def test_reset_closes_sessions_from_other_threads(self, tmp_path):
         """Discarded sessions must be closed, not left to garbage collection (#617)."""
@@ -176,16 +191,24 @@ class TestCacheThreadSafety:
         assert len(_make_session().cache.responses) == 0
 
     def test_clear_removes_wal_sidecar_files(self, tmp_path):
-        """WAL mode leaves -wal/-shm files behind; clearing must not orphan them."""
+        """
+        WAL mode leaves -wal/-shm files behind; clearing must not orphan them.
+
+        Asserts on the state right after _delete_cache. Going through
+        setup_cache(clear=True) instead would be vacuous: it calls _make_backend()
+        immediately afterwards, which reopens the DB in WAL mode and recreates the
+        sidecars, so the assertion passed even with the deletion reverted.
+        """
         cache_path = setup_cache(tmp_path)
         for suffix in ("-wal", "-shm"):
             cache_path.with_name(cache_path.name + suffix).write_bytes(b"stale")
 
-        setup_cache(tmp_path, clear=True)
+        _delete_cache(cache_path)
 
+        assert not cache_path.exists()
         for suffix in ("-wal", "-shm"):
             sidecar = cache_path.with_name(cache_path.name + suffix)
-            assert not sidecar.exists() or sidecar.read_bytes() != b"stale"
+            assert not sidecar.exists(), f"{sidecar.name} survived the clear"
 
     def test_clear_is_off_by_default(self, tmp_path):
         """Without clear=True, an existing cache survives setup_cache."""

--- a/tests/test_metatraits_gzip_tolerance.py
+++ b/tests/test_metatraits_gzip_tolerance.py
@@ -58,6 +58,28 @@ class TestOpenMaybeGzipped:
         with mt._open_jsonl(path) as f:
             assert "tax_name" in f.read()
 
+    def test_probe_handle_is_closed_on_fallback(self, tmp_path, monkeypatch):
+        """The failed gzip probe must not leak its handle (#621)."""
+        path = tmp_path / "sample.tsv.gz"
+        _write_plain(path, "hello\n")
+        opened = []
+
+        real_gzip_open = mt.gzip.open
+
+        def tracking_open(*args, **kwargs):
+            """Wrap gzip.open so we can see whether the probe handle gets closed."""
+            handle = real_gzip_open(*args, **kwargs)
+            opened.append(handle)
+            return handle
+
+        monkeypatch.setattr(mt.gzip, "open", tracking_open)
+
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+        assert len(opened) == 1, "the gzip probe should have run once"
+        assert opened[0].closed, "the probe handle must be closed before falling back"
+
 
 class TestCrosswalkLoading:
 

--- a/tests/test_metatraits_gzip_tolerance.py
+++ b/tests/test_metatraits_gzip_tolerance.py
@@ -1,0 +1,96 @@
+"""
+Tests that Drive-hosted MetaTraits inputs survive arriving decompressed.
+
+Google Drive silently serves some uploads decompressed, so a file named `*.gz`
+can be plain text. This already happened to `ncbi_*_summary.jsonl.gz`, which sit
+in `data/raw` as plain JSON under a `.gz` name. Any read of a Drive-hosted input
+must tolerate both forms.
+"""
+
+import gzip
+
+from kg_microbe.transform_utils.metatraits import metatraits as mt
+
+CROSSWALK_HEADER = "taxonID NCBI\ttaxonID GTDB\tspecies (NCBI)\tgenus (GTDB)\tspecies (GTDB)\n"
+CROSSWALK_ROW = "562\t599451526\tEscherichia coli\tEscherichia\tEscherichia coli\n"
+
+
+def _write_gzipped(path, text):
+    """Write real gzip-compressed text."""
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        f.write(text)
+
+
+def _write_plain(path, text):
+    """Write plain text under whatever name the caller chose (e.g. a .gz name)."""
+    path.write_text(text, encoding="utf-8")
+
+
+class TestOpenMaybeGzipped:
+
+    """_open_maybe_gzipped must read both real gzip and misnamed plain text."""
+
+    def test_reads_real_gzip(self, tmp_path):
+        """A genuinely compressed .gz still works."""
+        path = tmp_path / "sample.tsv.gz"
+        _write_gzipped(path, "hello\n")
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+    def test_reads_plain_text_named_gz(self, tmp_path):
+        """A .gz that Drive decompressed must not raise BadGzipFile."""
+        path = tmp_path / "sample.tsv.gz"
+        _write_plain(path, "hello\n")
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+    def test_reads_uncompressed_name(self, tmp_path):
+        """A file with no .gz suffix opens as plain text."""
+        path = tmp_path / "sample.tsv"
+        _write_plain(path, "hello\n")
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+    def test_open_jsonl_delegates(self, tmp_path):
+        """_open_jsonl keeps its tolerant behaviour after the refactor."""
+        path = tmp_path / "sample.jsonl.gz"
+        _write_plain(path, '{"tax_name": "x"}\n')
+        with mt._open_jsonl(path) as f:
+            assert "tax_name" in f.read()
+
+
+class TestCrosswalkLoading:
+
+    """
+    NCBI2GTDB.tsv.gz must load whether or not it arrives compressed.
+
+    _load_ncbi_gtdb_mappings wraps its read in `except Exception`, so a
+    BadGzipFile there does not crash the transform — it silently produces zero
+    mappings and the NCBI->GTDB fallback quietly stops working. That silent
+    degradation is the regression these tests guard.
+    """
+
+    def _load_from(self, tmp_path, monkeypatch, writer):
+        """Point the loader at a temp NCBI2GTDB file written by `writer`."""
+        writer(tmp_path / "NCBI2GTDB.tsv.gz", CROSSWALK_HEADER + CROSSWALK_ROW)
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+        return transform._load_ncbi_gtdb_mappings()
+
+    def test_loads_from_real_gzip(self, tmp_path, monkeypatch):
+        """The normal case: a properly compressed crosswalk."""
+        mappings = self._load_from(tmp_path, monkeypatch, _write_gzipped)
+        assert mappings["escherichia coli"]["gtdb_genus"] == "Escherichia"
+
+    def test_loads_from_decompressed_gz(self, tmp_path, monkeypatch):
+        """The Drive case: same content, not actually compressed."""
+        mappings = self._load_from(tmp_path, monkeypatch, _write_plain)
+        assert mappings["escherichia coli"]["gtdb_genus"] == "Escherichia", (
+            "a decompressed .gz must still yield mappings, not silently zero"
+        )
+
+    def test_missing_file_yields_empty_mapping(self, tmp_path, monkeypatch):
+        """An absent crosswalk is tolerated (pre-existing behaviour)."""
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+        assert transform._load_ncbi_gtdb_mappings() == {}

--- a/tests/test_metatraits_gzip_tolerance.py
+++ b/tests/test_metatraits_gzip_tolerance.py
@@ -111,6 +111,51 @@ class TestCrosswalkLoading:
             "a decompressed .gz must still yield mappings, not silently zero"
         )
 
+    def test_garbage_payload_is_reported_not_announced_as_success(self, tmp_path, monkeypatch, capsys):
+        """
+        A non-gzip error page must not print the success line (F6).
+
+        Tolerating a decompressed .gz is right for the Drive-hosted inputs, but it
+        also means an HTML quota interstitial reads as an empty table. Master's
+        bare gzip.open at least raised BadGzipFile here; the tolerant reader has
+        to say something instead of "Loaded 0 ... mappings".
+        """
+        (tmp_path / "NCBI2GTDB.tsv.gz").write_text("<html><body>Quota exceeded</body></html>", encoding="utf-8")
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+
+        assert transform._load_ncbi_gtdb_mappings() == {}
+        out = capsys.readouterr().out
+        assert "Warning" in out, "an unusable crosswalk must warn"
+        assert "no usable rows" in out or "no NCBI to GTDB mappings" in out
+
+    def test_empty_file_is_reported(self, tmp_path, monkeypatch, capsys):
+        """A 0-byte download is the other realistic gdrive failure mode."""
+        (tmp_path / "NCBI2GTDB.tsv.gz").write_bytes(b"")
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+
+        assert transform._load_ncbi_gtdb_mappings() == {}
+        assert "Warning" in capsys.readouterr().out
+
+    def test_partial_read_reports_how_much_loaded(self, tmp_path, monkeypatch, capsys):
+        """A truncated body yields a partial crosswalk; the count must be stated."""
+        import gzip as gz
+
+        path = tmp_path / "NCBI2GTDB.tsv.gz"
+        rows = "".join(f"{i}\t{i}\tSpecies {i}\tGenus{i}\tSpecies {i}\n" for i in range(2000))
+        with gz.open(path, "wt", encoding="utf-8") as f:
+            f.write(CROSSWALK_HEADER + rows)
+        path.write_bytes(path.read_bytes()[: path.stat().st_size // 2])  # truncate body
+
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+        mappings = transform._load_ncbi_gtdb_mappings()
+
+        out = capsys.readouterr().out
+        assert "Could not fully load" in out
+        assert f"{len(mappings)} mappings loaded" in out
+
     def test_missing_file_yields_empty_mapping(self, tmp_path, monkeypatch):
         """An absent crosswalk is tolerated (pre-existing behaviour)."""
         monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -163,3 +163,35 @@ class TestDegradesGracefully:
         monkeypatch.setattr(ou, "_NCBITAXON_DB_MIN_SIZE", 1_000_000)
         _fake_build(monkeypatch, db, size=16)
         assert ou._ensure_ncbitaxon_db(str(db)) is False
+
+    def test_opt_out_skips_the_build(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """KG_SEMSQL_BUILD=off must not start a multi-hour build (#613)."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")  # drifted
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.setenv("KG_SEMSQL_BUILD", "off")
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert calls == [], "opt-out must skip semsql entirely"
+        assert "opt-out" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("value", ["off", "false", "0", "no", "OFF"])
+    def test_opt_out_accepts_common_spellings(self, tmp_path, owl, tiny_threshold, monkeypatch, value):
+        """Any of the usual falsey spellings disables the build."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.setenv("KG_SEMSQL_BUILD", value)
+        ou._ensure_ncbitaxon_db(str(db))
+        assert calls == []
+
+    def test_build_runs_when_opt_out_unset(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """Default behaviour is unchanged: the build still runs."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.delenv("KG_SEMSQL_BUILD", raising=False)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert len(calls) == 1

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -1,0 +1,167 @@
+"""
+Tests for building ncbitaxon.db from the ncbitaxon.owl we ship.
+
+Applies the GO single-source rule (#604) to NCBITaxon. OAK's prebuilt SemSQL
+cannot be kept aligned — upstream CDN builds lag the OBO release train by
+months — so the lookup DB is built from the same OWL the transform emits nodes
+from, making the two releases equal by construction.
+
+None of these tests run a real `semsql make`: the build is mocked and the
+size threshold shrunk, so they stay fast.
+"""
+
+import subprocess
+
+import pytest
+
+from kg_microbe.utils import ontology_utils as ou
+
+OWL_HEAD = '<owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon/{d}/ncbitaxon.owl"/>\n'
+
+
+@pytest.fixture
+def owl(tmp_path, monkeypatch):
+    """Write a stamped ncbitaxon.owl and point NCBITAXON_SOURCE at it."""
+
+    def _make(release="2026-07-12"):
+        path = tmp_path / "ncbitaxon.owl"
+        path.write_text(OWL_HEAD.format(d=release), encoding="utf-8")
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", path)
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def tiny_threshold(monkeypatch):
+    """Shrink the min-size gate so tests write bytes, not gigabytes."""
+    monkeypatch.setattr(ou, "_NCBITAXON_DB_MIN_SIZE", 8)
+
+
+def _fake_build(monkeypatch, db_path, *, size=16, fail=False):
+    """Stand in for `semsql make`, recording the call and writing a fake DB."""
+    calls = []
+
+    def run(cmd, **kwargs):
+        """Record the invocation, then emit a fake DB (or fail)."""
+        calls.append((cmd, kwargs.get("cwd")))
+        if fail:
+            raise subprocess.CalledProcessError(1, cmd)
+        db_path.write_bytes(b"0" * size)
+
+    monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+    monkeypatch.setattr(ou.subprocess, "run", run)
+    return calls
+
+
+class TestSkipsUnnecessaryBuilds:
+
+    """A 13 GB build must only run when it is actually needed."""
+
+    def test_valid_aligned_db_is_reused(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """Matching releases must not trigger a rebuild."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-07-12")
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert calls == [], "no build should run for an aligned DB"
+
+    def test_unreadable_release_does_not_force_rebuild(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """An unreadable stamp must not cause a spurious multi-hour rebuild."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: None)
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert calls == []
+
+
+class TestRebuildsOnDrift:
+
+    """The whole point: a refreshed OWL must produce a matching DB."""
+
+    def test_drifted_db_is_rebuilt(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """A DB at an older release than the OWL is rebuilt from that OWL."""
+        source = owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert len(calls) == 1
+        cmd, cwd = calls[0]
+        assert cmd == ["semsql", "make", "ncbitaxon.db"]
+        assert cwd == str(source.parent), "semsql must run beside the OWL"
+        assert "drifted" in capsys.readouterr().out
+
+    def test_missing_db_is_built(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """No DB at all means build it."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert len(calls) == 1
+
+    def test_partial_db_is_removed_before_build(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """A truncated DB must be deleted, else make treats it as up to date."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"partial")  # below the threshold
+
+        seen = {}
+
+        def run(cmd, **kwargs):
+            """Note whether the stale DB was cleared before the build ran."""
+            seen["existed_at_build_time"] = db.exists()
+            db.write_bytes(b"0" * 16)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert seen["existed_at_build_time"] is False
+
+
+class TestDegradesGracefully:
+
+    """A machine without the build toolchain must not be left broken."""
+
+    def test_missing_semsql_keeps_existing_db(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """Without semsql, report whatever DB is already present rather than deleting it."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert db.exists(), "an unbuildable DB must not be destroyed"
+        assert "semsql" in capsys.readouterr().out
+
+    def test_missing_owl_warns(self, tmp_path, monkeypatch, capsys):
+        """No OWL source means no build; say so rather than failing obscurely."""
+        monkeypatch.setattr(
+            "kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", tmp_path / "absent.owl"
+        )
+        assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
+        assert "missing" in capsys.readouterr().out
+
+    def test_failed_build_returns_false(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """A semsql crash is reported, not raised."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        _fake_build(monkeypatch, db, fail=True)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False
+        assert "failed to build" in capsys.readouterr().out
+
+    def test_undersized_result_is_rejected(self, tmp_path, owl, monkeypatch):
+        """A build that produced a stub must not be reported as usable."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        monkeypatch.setattr(ou, "_NCBITAXON_DB_MIN_SIZE", 1_000_000)
+        _fake_build(monkeypatch, db, size=16)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -143,6 +143,40 @@ class TestDegradesGracefully:
         assert db.exists(), "an unbuildable DB must not be destroyed"
         assert "semsql" in capsys.readouterr().out
 
+    def test_stub_db_is_not_reported_usable(self, tmp_path, owl, monkeypatch):
+        """A truncated DB must not pass as usable on the no-build paths (F1)."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"stub")  # threshold left at the real 1 GB
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False
+
+    def test_failed_build_restores_the_previous_db(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """A failed build must not leave the caller without the 13 GB DB (F3)."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        original = db.read_bytes()
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")  # drift → rebuild
+        _fake_build(monkeypatch, db, fail=True)
+
+        result = ou._ensure_ncbitaxon_db(str(db))
+        assert db.exists(), "the previous DB must be restored"
+        assert db.read_bytes() == original
+        assert result is True
+        assert not (tmp_path / "ncbitaxon.db.prev").exists()
+
+    def test_successful_build_discards_the_keep_aside_copy(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """On success the moved-aside DB is removed, not left doubling disk use."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+        _fake_build(monkeypatch, db)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert not (tmp_path / "ncbitaxon.db.prev").exists()
+
     def test_missing_owl_warns(self, tmp_path, monkeypatch, capsys):
         """No OWL source means no build; say so rather than failing obscurely."""
         monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", tmp_path / "absent.owl")

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -11,6 +11,7 @@ size threshold shrunk, so they stay fast.
 """
 
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -221,6 +222,80 @@ class TestDegradesGracefully:
         assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
         assert not owl_path.exists()
         assert not (tmp_path / "ncbitaxon.owl.partial").exists()
+
+    def test_dangling_symlink_target_is_cleared(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """
+        A broken symlink must not survive and redirect the build (#1).
+
+        os.path.exists is False for a dangling link, so the old check skipped the
+        removal; semsql then opened the target name for writing, followed the link
+        and deposited the ~13 GB result at the link's target instead — while the
+        size check, also following the link, reported success.
+        """
+        source = owl("2026-07-12")
+        elsewhere = tmp_path / "oak"
+        elsewhere.mkdir()
+        db = tmp_path / "ncbitaxon.db"
+        db.symlink_to(elsewhere / "ncbitaxon.db")  # target does not exist
+
+        def run(cmd, **kwargs):
+            """Write to the target name the way semsql does, following any symlink."""
+            with open(Path(kwargs["cwd"]) / "ncbitaxon.db", "wb") as f:
+                f.write(b"0" * 32)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert not db.is_symlink(), "the dangling link should have been removed"
+        assert db.stat().st_size == 32, "the build must land at the real path"
+        assert list(elsewhere.iterdir()) == [], "nothing should have been written to the link target"
+        assert source.exists()
+
+    def test_symlinked_result_is_rejected(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """If a build somehow leaves a symlink behind, don't report success."""
+        owl()
+        elsewhere = tmp_path / "elsewhere.db"
+        elsewhere.write_bytes(b"0" * 32)
+        db = tmp_path / "ncbitaxon.db"
+
+        def run(cmd, **kwargs):
+            """Leave a symlink rather than a real DB at the target."""
+            db.symlink_to(elsewhere)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False
+
+    def test_truncated_archive_degrades_gracefully(self, tmp_path, tiny_threshold, monkeypatch):
+        """A truncated .gz raises EOFError, not OSError — it must still be caught (#2)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        archive = tmp_path / "ncbitaxon.owl.gz"
+        with gz.open(archive, "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12") * 500)
+        archive.write_bytes(archive.read_bytes()[: archive.stat().st_size // 2])  # truncate
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        # Must return False rather than propagating EOFError.
+        assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
+        assert not owl_path.exists()
+        assert not (tmp_path / "ncbitaxon.owl.partial").exists(), "orphaned .partial left behind"
+
+    def test_semsql_checked_before_decompressing(self, tmp_path, tiny_threshold, monkeypatch):
+        """Don't unpack ~2 GB only to discover semsql is absent (#10)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        with gz.open(tmp_path / "ncbitaxon.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12"))
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+
+        ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db"))
+        assert not owl_path.exists(), "should not have decompressed without semsql"
 
     def test_build_runs_when_opt_out_unset(self, tmp_path, owl, tiny_threshold, monkeypatch):
         """Default behaviour is unchanged: the build still runs."""

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -187,6 +187,41 @@ class TestDegradesGracefully:
         ou._ensure_ncbitaxon_db(str(db))
         assert calls == []
 
+    def test_decompresses_archive_when_owl_absent(self, tmp_path, tiny_threshold, monkeypatch):
+        """A fresh checkout has only ncbitaxon.owl.gz; the build must still run (#620)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        with gz.open(tmp_path / "ncbitaxon.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12"))
+
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert owl_path.exists(), "ncbitaxon.owl.gz should have been decompressed"
+        assert len(calls) == 1, "the build must not be skipped as 'OWL missing'"
+
+    def test_partial_decompression_is_not_left_behind(self, tmp_path, tiny_threshold, monkeypatch):
+        """An interrupted decompression must not leave a truncated OWL (#615/#620)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        with gz.open(tmp_path / "ncbitaxon.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12"))
+
+        def boom(src, dst, *a, **k):
+            """Fail part-way through, as a full disk would."""
+            dst.write(b"<owl:versionIRI")
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(ou.shutil, "copyfileobj", boom)
+        assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
+        assert not owl_path.exists()
+        assert not (tmp_path / "ncbitaxon.owl.partial").exists()
+
     def test_build_runs_when_opt_out_unset(self, tmp_path, owl, tiny_threshold, monkeypatch):
         """Default behaviour is unchanged: the build still runs."""
         owl()

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -144,9 +144,7 @@ class TestDegradesGracefully:
 
     def test_missing_owl_warns(self, tmp_path, monkeypatch, capsys):
         """No OWL source means no build; say so rather than failing obscurely."""
-        monkeypatch.setattr(
-            "kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", tmp_path / "absent.owl"
-        )
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", tmp_path / "absent.owl")
         assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
         assert "missing" in capsys.readouterr().out
 

--- a/tests/test_stub_source_single_source.py
+++ b/tests/test_stub_source_single_source.py
@@ -1,0 +1,85 @@
+"""
+Tests that each stub-import ontology has exactly one declared source.
+
+Part of #604. A stub source read via ROBOT MIREOT against an OWL must not also
+have a SemSQL ``.db`` download, and vice versa: two independently-versioned
+copies of the same ontology can drift with nothing to detect it, which is how
+``po.db.gz`` came to be downloaded (and never decompressed) while PO's hierarchy
+was actually built from ``po.owl``.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from kg_microbe.transform_utils.ontologies_stubs.ontologies_stubs_transform import (
+    STUB_ONTOLOGY_SOURCES,
+)
+
+DOWNLOAD_YAML = Path(__file__).parent.parent / "download.yaml"
+
+
+def _local_names():
+    """Return the set of local_name values declared in download.yaml."""
+    with open(DOWNLOAD_YAML) as f:
+        return {e["local_name"] for e in (yaml.safe_load(f) or [])}
+
+
+class TestPoIsOwlOnly:
+
+    """PO's hierarchy comes from the OWL; no SemSQL DB should be fetched."""
+
+    def test_po_stub_uses_owl_mireot(self):
+        """The invariant that makes po.db unnecessary."""
+        po = STUB_ONTOLOGY_SOURCES["PO"]
+        assert po["source_type"] == "owl_mireot"
+        assert po["owl_filename"] == "po.owl"
+        assert "db_filename" not in po
+
+    def test_po_owl_is_downloaded(self):
+        """The source PO actually reads must be declared."""
+        assert "po.owl" in _local_names()
+
+    def test_po_semsql_db_is_not_downloaded(self):
+        """A PO SemSQL DB would be a second, ungated copy of PO."""
+        assert "po.db.gz" not in _local_names()
+        assert "po.db" not in _local_names()
+
+
+class TestNoStubHasTwoSources:
+
+    """Generalise the rule across every stub source."""
+
+    def test_owl_backed_stubs_have_no_db_download(self):
+        """An owl_mireot source must not also ship a SemSQL DB."""
+        offenders = []
+        names = _local_names()
+        for prefix, cfg in STUB_ONTOLOGY_SOURCES.items():
+            if cfg.get("source_type") != "owl_mireot":
+                continue
+            stem = Path(cfg["owl_filename"]).stem
+            if f"{stem}.db.gz" in names or f"{stem}.db" in names:
+                offenders.append(prefix)
+        assert offenders == [], f"owl-backed stubs with a redundant .db download: {offenders}"
+
+    def test_db_backed_stubs_have_no_owl_download(self):
+        """A SemSQL-backed source must not also ship an OWL of the same ontology."""
+        offenders = []
+        names = _local_names()
+        for prefix, cfg in STUB_ONTOLOGY_SOURCES.items():
+            db_filename = cfg.get("db_filename")
+            if not db_filename:
+                continue
+            stem = Path(db_filename).stem
+            if f"{stem}.owl" in names or f"{stem}.owl.gz" in names:
+                offenders.append(prefix)
+        assert offenders == [], f"db-backed stubs with a redundant OWL download: {offenders}"
+
+    def test_every_stub_declares_a_source(self):
+        """No stub entry should be missing both an OWL and a DB."""
+        missing = [
+            prefix
+            for prefix, cfg in STUB_ONTOLOGY_SOURCES.items()
+            if not cfg.get("owl_filename") and not cfg.get("db_filename") and not cfg.get("nt_filename")
+        ]
+        assert missing == [], f"stub sources with nothing to read: {missing}"


### PR DESCRIPTION
Started as a fix for a `kg download` crash and grew to cover the data-acquisition
gaps it exposed. 12 commits, each independently reviewable.

## 1. MediaDive cache corruption (`96c1b3e`, `ca0b8e6`)

`kg download` died at request 3 of 3338 with
`sqlite3.DatabaseError: database disk image is malformed`, against a cache that
was provably intact — `PRAGMA integrity_check` OK, full 6044-row scan fine from
the same interpreter, and an mtime showing the run never wrote to it.

Cause is in `requests_cache`'s SQLite backend: `SQLiteDict` holds a **single**
`sqlite3.Connection` for all callers (opened `check_same_thread=False`) and
takes no lock on reads. `download_detailed_media` created one session in the
main thread and shared it across a `ThreadPoolExecutor`, so five workers issued
concurrent `execute()` calls on one connection — which corrupts its pager state
and makes SQLite report `SQLITE_CORRUPT` about a healthy file.

Each thread now builds its own `CachedSession`, so its own connection; several
connections to one SQLite file is supported usage, and cached responses are
still shared via the database. Also replaces the global
`requests_cache.install_cache()` monkeypatch with explicit module-scoped
caching, moves the DB out of the repo root into `data/raw/mediadive/`, and makes
`--ignore-cache` actually clear the response cache (it previously rebuilt the
bulk JSON from the same cached responses, so the flag could not refresh
anything).

Verified by replaying 1500 cached URLs through 5 threads against a copy of the
real 51 MB cache: 1500 hits, 0 errors, 0 network.

## 2. Tag-filtered downloads (`0789241`, `2b58fdf`, `7f6b401`, `cb40845`, `708be03`)

`kg download` had no way to fetch a subset — all 62 entries or `-i`, which
re-downloads everything. `kghub-downloader` already supports tag filtering; it
was unwired end to end. All active entries are now tagged across 15 groups, with
a repeatable `-t/--tag`.

Two things the bare library filter gets wrong for us: an unknown tag downloads
zero files and exits 0 (now rejected up front, listing valid tags), and the
MediaDive bulk step fired whenever `mediadive.json` existed — so
`kg download -t ontologies` would have started an hour of MediaDive API calls
(now gated on the tag).

Six previously-unfetchable inputs (five MetaTraits/GTDB files behind a dead
endpoint, BactoTraits behind a broken TLS chain) are now declared normally and
pinned to hosted copies, with their expected md5 recorded inline. Sources whose
replacement is not hosted yet use a `REPLACE_ME_` placeholder that
`kg download` skips and reports, so a placeholder can never abort a run.
Verified end to end: all six fetch and reproduce their pinned checksums.

Research note: the `gtdb_*`/`NCBI2GTDB`/`GTDB2NCBI` files are **not** GTDB
downloads, despite the names — GTDB publishes only taxonomy, metadata, trees
and MSA files. They are MetaTraits (EMBL) products keyed by GTDB taxonomy. Two
are still live upstream but deliberately pinned rather than fetched, because
that location is an unversioned personal directory regenerated in place.

## 3. Every ontology is now single-source (`55b9df8`, `5025515`, `ca04e11`)

Extends the GO single-source rule (#604) to the remaining lookup DBs, which were
acquired independently of the OWL the transforms emit nodes from.

- **NCBITaxon** had a real 2-month gap: `ncbitaxon.owl` 2026-07-12 vs the OAK
  cache's 2026-05-13. Not closable by refreshing — the upstream CDN's newest
  build was 2026-05-24, so the documented remediation would have re-downloaded
  2.3 GB and landed back at the same release. Now built from our OWL via
  `semsql make`; the real 13.1 GB build completed and both stamps read
  2026-07-12.
- **ChEBI** could not even be checked: it versions by an integer
  (`versionIRI .../chebi/253/chebi.owl`), invisible to the date-based reader, so
  a gate built on it would pass silently forever. Confirmed against the real
  file — the new reader returns `253` where the shared one returns `None`. Both
  category-fixing call sites also went through
  `get_adapter(f"sqlite:{CHEBI_SOURCE}")` wrapped in a bare `except`, which
  could not work as written (`CHEBI_SOURCE` is an `.owl` path), meaning the
  fallback silently accepted whatever `chebi.db` was on disk.
- **PO** had nothing to sync: its stub import is `owl_mireot` against `po.owl`,
  nothing reads `po.db`, and the downloaded `po.db.gz` was never decompressed.
  Removed the dead source instead, and corrected a comment that claimed the
  opposite.

## Review round

Reviewed after opening; 7 issues filed, 6 fixed in `d5ba68b` (#613, #615, #616,
#617, #618, #619). Highlights:

- **#613** — the new `semsql` builds could start unprompted from an ordinary
  `kg transform` and run for hours. `KG_SEMSQL_BUILD=off` now declines, falling
  back to a prebuilt DB with the gate warning about the drift.
- **#615** — `chebi.owl.gz` was decompressed onto its final path, so an interrupt
  left a truncated ~1 GB OWL that nothing could detect (the version stamp is in
  the head and still parses). Now temp-file + `os.replace`.
- **#616** — `get_chebi_adapter` ignored a failed build and handed OAK a missing
  path; now raises with remediation.

**#614 is left open**: `_ensure_ncbitaxon_db_ready()` — and so the NCBITaxon
build — runs only under `if use_mp:`. A sequential `metatraits` run keeps the lazy
OAK fetch, so `ncbitaxon.owl`/`.db` can still diverge there; the gate detects it
and warns, but nothing prevents it. The single-source guarantee above is therefore
**conditional on multiprocessing mode** for NCBITaxon. Moving that call interacts
with the worker-concurrency rationale and deserves its own change.

## Testing

`poetry run tox` fully green: **519 passed**, format/lint/codespell/docstr-coverage
all OK. 108 new tests. One test that had been failing on `master` for an unrelated
reason (missing `ncbitaxon.db`) now passes.

The decompressed-crosswalk guard was mutation-tested — restoring the old
`gzip.open` makes it fail.

## Note on data files

This branch touches no data under `data/`. The `ncbitaxon.db` build and the
copied reference inputs are local artifacts, all gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
