### PR TITLE
Fix MediaDive cache corruption; add tag-filtered downloads and pinned inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ poetry run kg download -t ontologies -t gtdb
 
 # Re-download a single file: delete it and re-run. `kg download` only fetches
 # files that are absent — it never checks whether the remote copy is newer.
-# `-i` ignores the cache for EVERY entry, so scope it with -t:
+# `-i` ignores the cache for EVERY entry, so scope it with -t. Note that for
+# mediadive this also clears the HTTP response cache and re-runs the full
+# ~1h bulk API crawl, so it is not a cheap single-file refresh:
 poetry run kg download -i -t mediadive
 
 # Transform downloaded data into KG format (TSV: nodes.tsv, edges.tsv)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,14 @@ poetry install
 # Download all data sources (configured in download.yaml)
 poetry run kg download
 
+# Download only selected source groups (tags are listed in download.yaml's header)
+poetry run kg download -t ontologies -t gtdb
+
+# Re-download a single file: delete it and re-run. `kg download` only fetches
+# files that are absent — it never checks whether the remote copy is newer.
+# `-i` ignores the cache for EVERY entry, so scope it with -t:
+poetry run kg download -i -t mediadive
+
 # Transform downloaded data into KG format (TSV: nodes.tsv, edges.tsv)
 poetry run kg transform
 

--- a/docs/DATA_HOSTING.md
+++ b/docs/DATA_HOSTING.md
@@ -1,0 +1,212 @@
+# Hosting vendored data files
+
+Some KG-Microbe inputs cannot be fetched by `poetry run kg download`: their
+upstream URL is dead, TLS-broken, or permission-gated. They are **not
+regenerable** — we hold none of the upstream observations they summarize — so
+the only options are to host a copy or to copy one by hand from a reference
+`data/raw_*` directory.
+
+This file is the manifest for hosting those copies on the public LBNL Google
+Drive, plus the interim copy-by-hand procedure.
+
+## Hosted files
+
+Six files, ~81 MB total, in the shared Drive folder
+<https://drive.google.com/drive/folders/1vCKoGREJk45BzImfnPVtGhXAb_DyndLq>
+(General access: *Anyone with the link*, Viewer — `gdown` runs
+unauthenticated, so an org-restricted folder returns a sign-in page and
+fails with HTTP 401). Uploaded and verified end to end 2026-07-25.
+
+Each md5 below is also recorded inline in `download.yaml` beside its URL, so the
+pinned artifact is identifiable from the config alone. They were confirmed by
+moving all six out of `data/raw`, running
+`kg download -t metatraits_gtdb -t bactotraits`, and re-checksumming what
+arrived.
+
+| file | size | md5 | Drive file ID |
+|---|---|---|---|
+| `gtdb_species_summary.jsonl.gz` | 46 MB | `aca98ae9c978f238ae7844beaccec63b` | `1xfZiMly-lJgcPL5ihR6QK1zxlv_JwC6J` |
+| `gtdb_genus_summary.jsonl.gz` | 16 MB | `159828de09d22a7c85e2116e8a97944a` | `1Kotk8g5Ky_Cc9MNiywO_Tjz6JLEG0y7Y` |
+| `gtdb_family_summary.jsonl.gz` | 4.4 MB | `1443132d2aa0f3d8743b23096ce23a13` | `1HpkfGAtZI1uRwyPzbTJFtI6avWlkEAlE` |
+| `NCBI2GTDB.tsv.gz` | 2.8 MB | `eca29d35869dd9035730caa12de12598` | `1npQ1z2Yc0NRPHpBkKjsKIBy2_evDAyCV` |
+| `GTDB2NCBI.tsv.gz` | 2.8 MB | `a313f89ac32b7137c7225c789f724f63` | `1ip7ualwruocq9MvcaoNAcH0YtLtAEASP` |
+| `BactoTraits_databaseV2_Jun2022.csv` | 8.6 MB | `e6bca5b947c1aa692d45ac24aa9025f3` | `1u7snG4VxbH6sh6M03dS1GumoYgLgbZrr` |
+
+All five MetaTraits files are hosted together so the KG builds against one fixed
+MetaTraits release, matching the three `ncbi_*_summary.jsonl.gz` inputs that are
+already Drive-hosted under the `metatraits` tag.
+
+### Why pin the crosswalks rather than fetch them live
+
+`NCBI2GTDB.tsv.gz` and `GTDB2NCBI.tsv.gz` *are* still published upstream — they
+moved off the dead `metatraits.embl.de/static/downloads/` path to the Bork
+group's web space, linked from <https://metatraits.embl.de/documentation>:
+
+```
+https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
+https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
+```
+
+Verified 2026-07-25: both are **byte-identical** to the copies in `data/raw`.
+
+We deliberately do not point `download.yaml` at them. That is an unversioned
+personal directory whose files are regenerated in place — the current build is
+dated 2025-08-14 and the name carries no release identifier — so two KG builds
+months apart would silently use different crosswalks with no way to tell from
+the config. The Drive copy fixes the release. **Those URLs are the refresh
+source**: when you want a newer crosswalk, download from there, re-upload, and
+update the md5 in `download.yaml` and in the table above as a deliberate act.
+
+### Why each one needs hosting
+
+- **`gtdb_*_summary.jsonl.gz`** — MetaTraits (EMBL) products, keyed by GTDB
+  r220 taxon name (so independent of which NCBITaxon release we build against).
+  The JSONL serialization has been **discontinued upstream**: the Bork directory
+  now publishes only `.tsv.gz`, in two variants per rank (`_all` and
+  `_no_predictions`). Our vendored JSONL corresponds to **`_all`** — verified by
+  comparing per-taxon trait sets at family rank: 73.9% of taxa match `_all`
+  exactly (the rest differ only because `_all` is a newer build adding traits
+  like `generalism score`, `generalist`, `habitat count`), versus 0.4% against
+  `_no_predictions`, which carries far fewer traits per taxon (6 vs 130 for
+  `0-14-0-10-38-17`). Note the taxa *counts* coincide (4,511 in both our JSONL
+  and `_no_predictions`) — that resemblance is misleading, so compare trait sets
+  rather than record counts if you revisit this.
+  Consumer: `metatraits_gtdb` reads the species summary
+  (`METATRAITS_GTDB_INPUT_FILES`); genus and family are declared for
+  completeness but currently commented out in the transform.
+
+  **Switching to the TSV form would require a transform change** — the JSONL is
+  one object per taxon with a nested `summaries` list, while the TSV is one row
+  per taxon-trait pair with richer columns (`ontology_ids` carrying OMP terms,
+  `group_1`/`group_2` trait categories, min/median/mean/max, `taxon_lineage`).
+  It is also much larger: `gtdb_species_summary_all.tsv.gz` is 135 MB versus
+  46 MB for the JSONL. Until that work happens, hosting the vendored JSONL keeps
+  the transform running unchanged.
+- **`BactoTraits_databaseV2_Jun2022.csv`** — the host
+  (`ordar.otelo.univ-lorraine.fr`) serves an incomplete TLS intermediate chain
+  that no CA bundle can verify, so the download aborts the whole run. Static
+  Jun-2022 dataset; it will not change.
+
+### Deliberately NOT hosted
+
+- **`lpsn_gss.csv`** — the LPSN GSS export is account-gated, and LPSN's
+  copyright terms (see `kg_microbe/transform_utils/lpsn/README.md`) require
+  attribution and restrict redistribution. Publishing it to a public Drive link
+  *is* redistribution. Keep the manual procedure documented in `download.yaml`:
+  register free at <https://lpsn.dsmz.de/register>, download the GSS CSV, place
+  it at `data/raw/lpsn_gss.csv`.
+- **Anything derived from a downloaded ontology release** — `ncbitaxon.db`,
+  `ncbitaxon_removed_subset.json`, `chebi.{db,owl,json}`, `go.{db,json}`,
+  `ec.db`, `bto.db`, `ncit.db`, `*-relation-graph.tsv.gz`, and the ROBOT-derived
+  `pato/ro/taxrank/uberon/upa/foodon.json`. These must be rebuilt from the OWL
+  you actually downloaded. Hosting or copying them silently pins the KG to an
+  older ontology release: the transforms skip regeneration when the derived file
+  already exists.
+
+## Upload procedure (for refreshing a file, or adding a new one)
+
+1. Upload the file to the Drive folder **as binary**. Do not let Drive or the
+   browser recompress or rename anything. Before the first upload, turn off
+   Drive → Settings → **"Convert uploaded files to Google Docs editor format"**,
+   or a `.csv` becomes a Google Sheet and `uc?id=` returns an export instead of
+   the file.
+2. Set sharing to **anyone with the link can view** — `kghub-downloader`'s
+   `gdrive:` handler is unauthenticated.
+3. **Verify the round trip before trusting it.** Download your own upload and
+   check the md5 against the table above:
+
+   ```bash
+   curl -sL "https://drive.google.com/uc?export=download&id=<id>" -o /tmp/check
+   md5 -q /tmp/check
+   ```
+
+   This step is not optional. Drive has silently served `.gz` uploads
+   decompressed — that is exactly how the already-hosted
+   `ncbi_*_summary.jsonl.gz` ended up as plain JSON under a `.gz` name in
+   `data/raw`, and the five files below go up the same way.
+
+   Every MetaTraits read path now tolerates a decompressed `.gz` via
+   `_open_maybe_gzipped` (`transform_utils/metatraits/metatraits.py`), so this
+   no longer breaks a build. It used to matter most for the crosswalk:
+   `_load_ncbi_gtdb_mappings` wraps its read in `except Exception`, so a
+   `BadGzipFile` there never crashed — it silently produced **zero** mappings
+   and the NCBI→GTDB fallback quietly stopped working. Verifying the checksum
+   still matters, because a decompressed upload has a different md5 than the
+   table above and is no longer the pinned artifact.
+4. Take the file ID from the sharing link's `/d/<id>/` segment and put it in
+   `download.yaml`, updating the recorded md5 in the same edit:
+
+   ```yaml
+   -
+     url: gdrive:1AbCdEfGhIjKlMnOpQrStUvWxYz   # md5 <new checksum>
+     local_name: gtdb_species_summary.jsonl.gz
+     tag: metatraits_gtdb
+   ```
+
+   To list every ID in the folder at once, without clicking through six share
+   dialogs:
+
+   ```bash
+   poetry run python -c "import gdown; \
+     [print(f.id, f.path) for f in gdown.download_folder(
+        url='<folder url>', skip_download=True, quiet=True)]"
+   ```
+
+5. Confirm the entry works in isolation:
+
+   ```bash
+   mv data/raw/gtdb_species_summary.jsonl.gz /tmp/backup.gz   # keep a copy first
+   poetry run kg download -t metatraits_gtdb
+   md5 -q data/raw/gtdb_species_summary.jsonl.gz              # must match the table
+   ```
+
+   Move the file aside rather than relying on `-i`: `-i` deletes the local copy
+   *before* fetching, so a failed download leaves you with nothing.
+
+## Interim: copy from a reference directory
+
+Until the files are hosted, `kg download` skips them with a message naming each
+one (see `PENDING_HOSTING_MARKER` in `kg_microbe/download.py`). Restore them by
+hand:
+
+```bash
+REF=data/raw_202607_andOLD_mixed
+cp -n $REF/gtdb_species_summary.jsonl.gz $REF/gtdb_genus_summary.jsonl.gz \
+      $REF/gtdb_family_summary.jsonl.gz $REF/NCBI2GTDB.tsv.gz \
+      $REF/GTDB2NCBI.tsv.gz $REF/BactoTraits_databaseV2_Jun2022.csv data/raw/
+```
+
+### These are NOT GTDB downloads
+
+Worth stating plainly, because the names suggest otherwise: none of these files
+come from GTDB. The GTDB release directory
+(<https://data.gtdb.ecogenomic.org/releases/latest/>) publishes only
+`{bac120,ar53}_taxonomy.tsv[.gz]`, `{bac120,ar53}_metadata.tsv.gz`, trees, MSA
+masks and genomic files — no phenotypic trait summaries and no NCBI crosswalk.
+All of `gtdb_*_summary.*`, `NCBI2GTDB.tsv.gz` and `GTDB2NCBI.tsv.gz` are
+MetaTraits (EMBL, Bork group) products that are merely *keyed by* GTDB taxonomy.
+The four GTDB files we do fetch from GTDB proper are tagged `gtdb`, not
+`metatraits_gtdb`.
+
+Two related caches worth restoring the same way, both of which cost hours to
+rebuild and neither of which is a `download.yaml` entry:
+
+```bash
+cp -Rn $REF/mediadive data/raw/     # 4 bulk JSONs; skips a ~1h MediaDive crawl
+cp -Rn $REF/lpsn data/raw/          # 34,301 per-record LPSN API responses
+cp -n  $REF/lpsn_gss.csv data/raw/
+```
+
+Note both caches live *inside* `data/raw`, so rotating or replacing that
+directory loses them — which is what caused a full 34,300-record LPSN re-fetch.
+Once the six files above are hosted, only the LPSN artifacts still need this
+treatment.
+
+Two inputs cannot be restored from any reference directory:
+
+- `kegg/ko_minimal.json` (~30 MB) — run `python scripts/download_kegg_minimal.py`
+  (~50 min). The `kegg` transform errors without it. A 894 MB `ko_details.json`
+  fallback exists in `data/raw_last5/kegg/`.
+- `bakta/<dataset>/` — `BAKTA` is active in `DATA_SOURCES` but no copy exists in
+  `data/raw` or in the reference directory; `data/raw_last5/bakta/` holds a
+  170 MB `cmm_bakta_test1` only.

--- a/docs/DATA_HOSTING.md
+++ b/docs/DATA_HOSTING.md
@@ -95,13 +95,19 @@ update the md5 in `download.yaml` and in the table above as a deliberate act.
   *is* redistribution. Keep the manual procedure documented in `download.yaml`:
   register free at <https://lpsn.dsmz.de/register>, download the GSS CSV, place
   it at `data/raw/lpsn_gss.csv`.
-- **Anything derived from a downloaded ontology release** — `ncbitaxon.db`,
-  `ncbitaxon_removed_subset.json`, `chebi.{db,owl,json}`, `go.{db,json}`,
-  `ec.db`, `bto.db`, `ncit.db`, `*-relation-graph.tsv.gz`, and the ROBOT-derived
-  `pato/ro/taxrank/uberon/upa/foodon.json`. These must be rebuilt from the OWL
-  you actually downloaded. Hosting or copying them silently pins the KG to an
-  older ontology release: the transforms skip regeneration when the derived file
-  already exists.
+- **Anything the transforms derive locally** — `ncbitaxon_removed_subset.json`,
+  `chebi.json`, `go.json`, `*-relation-graph.tsv.gz`, and the ROBOT-derived
+  `pato/ro/taxrank/uberon/upa/foodon.json`. Hosting or copying these silently
+  pins the KG to an older ontology release, because the transforms skip
+  regeneration when the derived file already exists.
+
+  The SemSQL `.db` files are a different case and are **not** all derivable here:
+  `go.db` is built from `go.owl` by `_ensure_go_db`; `bto.db` and `ncit.db` are
+  downloaded as `.db.gz` (no OWL is declared for them, so there is nothing to
+  build from); `ncbitaxon.db` is a symlink to OAK's prebuilt cache, deliberately
+  whatever release that cache holds; and nothing builds `chebi.db`. Copying
+  those two is currently the only way to get them. Building `ncbitaxon.db` and
+  `chebi.db` from the OWLs we ship is a separate change.
 
 ## Upload procedure (for refreshing a file, or adding a new one)
 
@@ -123,7 +129,7 @@ update the md5 in `download.yaml` and in the table above as a deliberate act.
    This step is not optional. Drive has silently served `.gz` uploads
    decompressed — that is exactly how the already-hosted
    `ncbi_*_summary.jsonl.gz` ended up as plain JSON under a `.gz` name in
-   `data/raw`, and the five files below go up the same way.
+   `data/raw`, and the hosted files above go up the same way.
 
    Every MetaTraits read path now tolerates a decompressed `.gz` via
    `_open_maybe_gzipped` (`transform_utils/metatraits/metatraits.py`), so this
@@ -163,11 +169,13 @@ update the md5 in `download.yaml` and in the table above as a deliberate act.
    Move the file aside rather than relying on `-i`: `-i` deletes the local copy
    *before* fetching, so a failed download leaves you with nothing.
 
-## Interim: copy from a reference directory
+## Copying from a reference directory
 
-Until the files are hosted, `kg download` skips them with a message naming each
-one (see `PENDING_HOSTING_MARKER` in `kg_microbe/download.py`). Restore them by
-hand:
+All six are hosted, so `kg download` fetches them normally. This section covers
+the two remaining cases: a source that is still unhosted (`kg download` skips it
+with a message naming it — see `PENDING_HOSTING_MARKER` in
+`kg_microbe/download.py`), and restoring a `data/raw` you rotated away without
+re-downloading:
 
 ```bash
 REF=data/raw_202607_andOLD_mixed
@@ -192,15 +200,15 @@ Two related caches worth restoring the same way, both of which cost hours to
 rebuild and neither of which is a `download.yaml` entry:
 
 ```bash
-cp -Rn $REF/mediadive data/raw/     # 4 bulk JSONs; skips a ~1h MediaDive crawl
+cp -Rn $REF/mediadive data/raw/     # 4 bulk JSONs + the HTTP cache; skips a ~1h crawl
 cp -Rn $REF/lpsn data/raw/          # 34,301 per-record LPSN API responses
 cp -n  $REF/lpsn_gss.csv data/raw/
 ```
 
 Note both caches live *inside* `data/raw`, so rotating or replacing that
 directory loses them — which is what caused a full 34,300-record LPSN re-fetch.
-Once the six files above are hosted, only the LPSN artifacts still need this
-treatment.
+With the six files hosted, only the LPSN artifacts and these caches still need
+this treatment.
 
 Two inputs cannot be restored from any reference directory:
 

--- a/download.yaml
+++ b/download.yaml
@@ -30,7 +30,7 @@
 #    gtdb        GTDB taxonomy + metadata
 #    metatraits  MetaTraits per-taxon trait summaries (NCBITaxon ranks)
 #    metatraits_gtdb  MetaTraits summaries + crosswalks keyed by GTDB taxonomy
-#    bactotraits BactoTraits V2 (static Jun-2022 dataset)
+#    bactotraits      BactoTraits V2 (static Jun-2022 dataset)
 #    schema      Reference specs (Biolink Model, KGX format) — not pipeline inputs
 #
 #  A new entry MUST have a tag: tests/test_download_tags.py fails otherwise, so

--- a/download.yaml
+++ b/download.yaml
@@ -11,6 +11,46 @@
 #    # brief comment about file, and optionally a local_name:
 #    url: http://curefordisease.org/some_data.txt
 #    local_name: some_data_more_chars_prevent_name_collision.pdf
+#    tag: some_group
+#
+#  Every active entry carries a 'tag', which groups it for selective
+#  downloads:  poetry run kg download -t ontologies -t gtdb
+#  Without -t, everything is downloaded. Current tags:
+#
+#    tools       ROBOT jar + wrapper (needed by the ontology transforms)
+#    ontologies  OBO ontology files (OWL/JSON) loaded by the ontologies transform
+#    stubs       Prebuilt SemSQL DBs / MeSH RDF for the selective stub-import
+#    mappings    Crosswalk tables (EC->GO, EPM curies, compound mappings)
+#    bacdive     BacDive strains + assay-kit metadata
+#    mediadive   MediaDive basic media list (also triggers the bulk API download)
+#    madin       Madin et al. condensed traits + environment conversion table
+#    rhea        Rhea reaction mappings (to GO and EC)
+#    cog         Clusters of Orthologous Groups definitions
+#    kegg        KEGG KO list (see the KEGG section for the manual cache step)
+#    gtdb        GTDB taxonomy + metadata
+#    metatraits  MetaTraits per-taxon trait summaries (NCBITaxon ranks)
+#    metatraits_gtdb  MetaTraits summaries + crosswalks keyed by GTDB taxonomy
+#    bactotraits BactoTraits V2 (static Jun-2022 dataset)
+#    schema      Reference specs (Biolink Model, KGX format) — not pipeline inputs
+#
+#  A new entry MUST have a tag: tests/test_download_tags.py fails otherwise, so
+#  an untagged source can never be silently unreachable via -t.
+#
+#  PENDING HOSTING
+#  Some sources have a dead upstream URL and no hosted replacement yet. They are
+#  declared normally but with a placeholder URL containing "REPLACE_ME_":
+#
+#    -
+#      url: gdrive:REPLACE_ME_gtdb_species_summary
+#      local_name: gtdb_species_summary.jsonl.gz
+#      tag: metatraits_gtdb
+#
+#  kg download skips these and prints what it skipped, so a placeholder never
+#  aborts a run. To activate one, replace the whole url value with the real
+#  Google Drive file ID (`gdrive:<id>`, from the sharing link's /d/<id>/ segment;
+#  the file must be readable by anyone with the link). Until then, copy the file
+#  from a reference data/raw_* directory. See tests/test_download_tags.py, which
+#  enforces that placeholders stay skippable and tagged.
 #
 #  For downloading from S3 buckets, see here for information about what URL to use:
 #  https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro
@@ -25,9 +65,11 @@
 -
   url: https://github.com/ontodev/robot/releases/download/v1.9.8/robot.jar
   local_name: robot.jar
+  tag: tools
 -
-  url: https://raw.githubusercontent.com/ontodev/robot/master/bin/robot 
+  url: https://raw.githubusercontent.com/ontodev/robot/master/bin/robot
   local_name: robot
+  tag: tools
 
 # **** Ontology files ****
 #
@@ -36,12 +78,14 @@
 -
   url: http://purl.obolibrary.org/obo/envo.json
   local_name: envo.json
+  tag: ontologies
 
 # NCBITaxon
 #
 -
   url: http://purl.obolibrary.org/obo/ncbitaxon.owl.gz
   local_name: ncbitaxon.owl.gz
+  tag: ontologies
 
 #
 # ChEBI
@@ -49,6 +93,7 @@
 -
   url: http://purl.obolibrary.org/obo/chebi.owl.gz
   local_name: chebi.owl.gz
+  tag: ontologies
 
 #
 # GO — single source of truth (fix 2, #604): download only go.owl; the
@@ -59,6 +104,7 @@
 -
   url: http://purl.obolibrary.org/obo/go.owl
   local_name: go.owl
+  tag: ontologies
 
 #
 # EC to GO mappings (Gene Ontology Consortium)
@@ -66,6 +112,7 @@
 -
   url: https://current.geneontology.org/ontology/external2go/ec2go
   local_name: ec2go.txt
+  tag: mappings
 
 #
 # MONDO
@@ -73,12 +120,14 @@
 -
   url: https://purl.obolibrary.org/obo/mondo/mondo.json
   local_name: mondo.json
+  tag: ontologies
 #
 # HP
 #
 -
   url: https://purl.obolibrary.org/obo/hp/hp.json
   local_name: hp.json
+  tag: ontologies
 
 #
 # UBERON (Uber Anatomy Ontology)
@@ -86,6 +135,7 @@
 -
   url: https://purl.obolibrary.org/obo/uberon.owl
   local_name: uberon.owl
+  tag: ontologies
 
 #
 # FOODON
@@ -93,6 +143,7 @@
 -
   url: https://purl.obolibrary.org/obo/foodon.owl
   local_name: foodon.owl
+  tag: ontologies
 
 #
 # PATO (Phenotype And Trait Ontology)
@@ -100,6 +151,7 @@
 -
   url: http://purl.obolibrary.org/obo/pato.owl
   local_name: pato.owl
+  tag: ontologies
 
 # **** Data sources ****
 
@@ -108,12 +160,14 @@
 -
   url: gdrive:1b_UWdIvsIM81V5WdFedNoxN3R4UUf4F2
   local_name: bacdive_strains.json
+  tag: bacdive
 
 # BacDive Assay Metadata
 # Assay kit metadata for API and BiOLOG assay systems
 -
   url: https://raw.githubusercontent.com/CultureBotAI/assay-metadata/refs/heads/main/data/assay_kits_simple.json
   local_name: assay_kits_simple.json
+  tag: bacdive
 
 # MediaDive
 # Explore MediaDive data
@@ -125,11 +179,13 @@
 -
   url: https://mediadive.dsmz.de/rest/media
   local_name: mediadive.json
+  tag: mediadive
 
 # Madin et al Condensed-traits
 -
   url: https://github.com/bacteria-archaea-traits/bacteria-archaea-traits/blob/master/output/condensed_traits_NCBI.csv?raw=true
   local_name: madin_etal.csv
+  tag: madin
 
 # # # ****Conversion Tables****
 #
@@ -138,6 +194,7 @@
 -
   url: https://raw.githubusercontent.com/bacteria-archaea-traits/bacteria-archaea-traits/master/data/conversion_tables/environments.csv
   local_name: environments.csv
+  tag: madin
 
 # 
 # EPM JSON for curies package
@@ -145,6 +202,7 @@
 -
   url: https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/obo.epm.json
   local_name: epm.json
+  tag: mappings
 
 #
 # Uniprot Functional Microbes
@@ -169,15 +227,18 @@
 -
   url: https://github.com/geneontology/unipathway/raw/master/upa.owl
   local_name: upa.owl
+  tag: ontologies
 
 # RHEA mappings
 - 
   url: https://ftp.expasy.org/databases/rhea/tsv/rhea2go.tsv
   local_name: rhea2go.tsv
+  tag: rhea
 
 -
   url: https://ftp.expasy.org/databases/rhea/tsv/rhea2ec.tsv
   local_name: rhea2ec.tsv
+  tag: rhea
 
 # 
 # EC
@@ -185,6 +246,7 @@
 - 
   url: https://w3id.org/biopragmatics/resources/eccode/eccode.json
   local_name: ec.json
+  tag: ontologies
 
 # 
 # EC OWL
@@ -192,20 +254,23 @@
 -
   url: https://w3id.org/biopragmatics/resources/eccode/eccode.owl.gz
   local_name: ec.owl.gz
+  tag: ontologies
 
 #
 # BactoTraits
-# NOTE: Commented out — the host (ordar.otelo.univ-lorraine.fr) serves a broken
-# TLS certificate chain (incomplete intermediate) that no CA bundle can verify,
-# so this download aborts the whole run. BactoTraits V2 is a static Jun-2022
-# dataset; the last public copy is vendored into
-# data/raw/BactoTraits_databaseV2_Jun2022.csv from data/raw_last8/, so the
-# bactotraits transform runs normally. To refresh, fetch the CSV manually
-# (verification relaxed) to that path, then re-enable this entry.
+# Served from our Drive copy, not from the origin: the host
+# (ordar.otelo.univ-lorraine.fr) presents a broken TLS chain (incomplete
+# intermediate) that no CA bundle can verify, which aborts the whole run.
+# BactoTraits V2 is a static Jun-2022 dataset, so a pinned copy loses nothing.
+# To refresh, fetch the CSV manually (verification relaxed), re-upload, and
+# update the md5 recorded beside the URL. See docs/DATA_HOSTING.md.
 #
-#-
-#  url: https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
-#  local_name: BactoTraits_databaseV2_Jun2022.csv
+# Original (broken TLS) source, kept for provenance:
+#   https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv
+-
+  url: gdrive:1u7snG4VxbH6sh6M03dS1GumoYgLgbZrr  # md5 e6bca5b947c1aa692d45ac24aa9025f3
+  local_name: BactoTraits_databaseV2_Jun2022.csv
+  tag: bactotraits
 
 #
 # CTD
@@ -246,9 +311,11 @@
 -
   url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/metpo.owl
   local_name: metpo.owl
+  tag: ontologies
 -
   url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/metpo.json
   local_name: metpo.json
+  tag: ontologies
 
 #
 # RO (Relations Ontology)
@@ -257,19 +324,21 @@
 -
   url: http://purl.obolibrary.org/obo/ro.owl
   local_name: ro.owl
+  tag: ontologies
 
 #
 # PO (Plant Ontology)
 # The ~6 PO CURIEs referenced by BacDive isolation_source mappings sit in
 # a coherent subtree under PO:0025131 (plant anatomical entity). The stub
 # transform runs ROBOT MIREOT against this OWL to emit those stubs plus
-# their ancestor chain (~21 nodes, ~23 subClassOf edges). See also the
-# `po.db.gz` entry under the stub-import section below — kept for any
-# future caller wanting the full SemSQL DB.
+# their ancestor chain (~21 nodes, ~23 subClassOf edges). This OWL is the
+# single source for PO — there is intentionally no po.db entry in the
+# stub-import section below.
 #
 -
   url: http://purl.obolibrary.org/obo/po.owl
   local_name: po.owl
+  tag: ontologies
 
 #
 
@@ -282,6 +351,7 @@
 -
   url: http://purl.obolibrary.org/obo/taxrank.owl
   local_name: taxrank.owl
+  tag: ontologies
 
 #
 # MICRO (Microbial Conditions Ontology / OntologyOfMicrobialConditions)
@@ -292,6 +362,7 @@
 -
   url: https://raw.githubusercontent.com/carrineblank/MicrO/master/MicrOandImportModules/MicrO.owl
   local_name: micro.owl
+  tag: ontologies
 
 #
 # MicroMediaParam Chemical Mappings - High Confidence
@@ -318,6 +389,7 @@
 -
   url: https://github.com/CultureBotAI/MicroMediaParam/raw/main/pipeline_output/merge_mappings/compound_mappings_strict_final.tsv
   local_name: compound_mappings_strict.tsv
+  tag: mappings
 
 #
 # MicroMediaParam Chemical Mappings - Hydrate (Takes Precedence)
@@ -330,6 +402,7 @@
 -
   url: https://github.com/CultureBotAI/MicroMediaParam/raw/main/pipeline_output/merge_mappings/compound_mappings_strict_final_hydrate.tsv
   local_name: compound_mappings_strict_hydrate.tsv
+  tag: mappings
 
 #
 # COG (Clusters of Orthologous Groups)
@@ -337,9 +410,11 @@
 -
   url: https://ftp.ncbi.nlm.nih.gov/pub/COG/COG2024/data/cog-24.def.tab
   local_name: cog/cog-24.def.tab
+  tag: cog
 -
   url: https://ftp.ncbi.nlm.nih.gov/pub/COG/COG2024/data/cog-24.fun.tab
   local_name: cog/cog-24.fun.tab
+  tag: cog
 
 #
 # KEGG (Kyoto Encyclopedia of Genes and Genomes)
@@ -358,6 +433,7 @@
 -
   url: https://rest.kegg.jp/list/ko
   local_name: kegg/ko_list.txt
+  tag: kegg
 
 #
 # GTDB (Genome Taxonomy Database)
@@ -365,15 +441,19 @@
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/bac120_taxonomy.tsv
   local_name: gtdb/bac120_taxonomy.tsv
+  tag: gtdb
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/ar53_taxonomy.tsv
   local_name: gtdb/ar53_taxonomy.tsv
+  tag: gtdb
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/bac120_metadata.tsv.gz
   local_name: gtdb/bac120_metadata.tsv.gz
+  tag: gtdb
 -
   url: https://data.gtdb.ecogenomic.org/releases/latest/ar53_metadata.tsv.gz
   local_name: gtdb/ar53_metadata.tsv.gz
+  tag: gtdb
 
 #
 # MetaTraits
@@ -385,45 +465,81 @@
 -
   url: gdrive:1vL9wujvty4Xh2ZG2HHquX0RE7968Dkbm
   local_name: ncbi_species_summary.jsonl.gz
+  tag: metatraits
 -
   url: gdrive:1WL6VhD2I6MGuI3iHKbCQYTncG1UB-u6e
   local_name: ncbi_genus_summary.jsonl.gz
+  tag: metatraits
 -
   url: gdrive:1pgOugA5jQG96GbCktkTJN9FGn6rypTOI
   local_name: ncbi_family_summary.jsonl.gz
+  tag: metatraits
 
 #
 # MetaTraits GTDB
 # Microbial trait data from MetaTraits organized by GTDB taxonomy (R220)
 # Enables genome-level trait associations via GTDB taxonomy
 # NOTE: Requires overlap analysis to assess value vs NCBITaxon metatraits
-# NOTE: Commented out — the metatraits.embl.de/static/downloads/ endpoint now
-# returns HTTP 404 for all of these (access moved behind permission from
-# antheaguo@berkeley.edu). The last public copies (2026-03-24) are vendored
-# into data/raw/ from data/raw_last8/. To refresh, obtain access and re-enable.
+# Served from our Drive copy: metatraits.embl.de/static/downloads/ now returns
+# HTTP 404 for all of these, and the JSONL serialization is discontinued
+# upstream entirely (only .tsv.gz variants are published now). Pinned as one set
+# with the other MetaTraits inputs so a rebuild uses a single fixed release.
 #
-#-
-#  url: https://metatraits.embl.de/static/downloads/gtdb_species_summary.jsonl.gz
-#  local_name: gtdb_species_summary.jsonl.gz
-#-
-#  url: https://metatraits.embl.de/static/downloads/gtdb_genus_summary.jsonl.gz
-#  local_name: gtdb_genus_summary.jsonl.gz
-#-
-#  url: https://metatraits.embl.de/static/downloads/gtdb_family_summary.jsonl.gz
-#  local_name: gtdb_family_summary.jsonl.gz
+# Genus and family are declared but not read today — the transform reads only the
+# species summary (METATRAITS_GTDB_INPUT_FILES, genus/family commented out
+# there). They are kept because they belong to the pinned set and switching the
+# transform to read them is a one-line change; contrast po.db.gz, which was
+# removed because PO's hierarchy comes from po.owl and no code path could ever
+# read the DB. See docs/DATA_HOSTING.md.
+#
+# Original (now HTTP 404) sources, kept for provenance:
+#   https://metatraits.embl.de/static/downloads/gtdb_{species,genus,family}_summary.jsonl.gz
+# Only the species summary is read by the transform; genus/family are declared
+# here for completeness (see METATRAITS_GTDB_INPUT_FILES).
+# The JSONL serialization is discontinued upstream; only *_all.tsv.gz and
+# *_no_predictions.tsv.gz are published now (ours corresponds to _all). Reading
+# the TSV would need a transform change, so the pinned JSONL build stays the
+# input. See docs/DATA_HOSTING.md.
+-
+  url: gdrive:1xfZiMly-lJgcPL5ihR6QK1zxlv_JwC6J   # md5 aca98ae9c978f238ae7844beaccec63b
+  local_name: gtdb_species_summary.jsonl.gz
+  tag: metatraits_gtdb
+-
+  url: gdrive:1Kotk8g5Ky_Cc9MNiywO_Tjz6JLEG0y7Y     # md5 159828de09d22a7c85e2116e8a97944a
+  local_name: gtdb_genus_summary.jsonl.gz
+  tag: metatraits_gtdb
+-
+  url: gdrive:1HpkfGAtZI1uRwyPzbTJFtI6avWlkEAlE    # md5 1443132d2aa0f3d8743b23096ce23a13
+  local_name: gtdb_family_summary.jsonl.gz
+  tag: metatraits_gtdb
 
 #
-# GTDB-NCBITaxon Mappings (for overlap analysis)
-# Maps between GTDB R220 and NCBITaxon taxonomies
-# NOTE: Commented out — same dead metatraits.embl.de endpoint (HTTP 404).
-# Last public copies (2026-03-24) vendored into data/raw/ from data/raw_last8/.
+# GTDB-NCBITaxon Mappings
+# Maps between GTDB R220 and NCBITaxon taxonomies. NCBI2GTDB.tsv.gz is read by
+# the metatraits transform; GTDB2NCBI.tsv.gz is the reverse direction, declared
+# so the pinned set is complete and symmetric.
 #
-#-
-#  url: https://metatraits.embl.de/static/downloads/GTDB2NCBI.tsv.gz
-#  local_name: GTDB2NCBI.tsv.gz
-#-
-#  url: https://metatraits.embl.de/static/downloads/NCBI2GTDB.tsv.gz
-#  local_name: NCBI2GTDB.tsv.gz
+# GTDB r220 <-> NCBI 2025-07-28 crosswalks, assigned where >=85% of genomes
+# share the same ID in both taxonomies. NCBI2GTDB.tsv.gz is read by the
+# metatraits transform (_load_ncbi_gtdb_mappings).
+#
+# These are still published upstream, at the Bork group's web space (linked from
+# https://metatraits.embl.de/documentation):
+#   https://www.bork.embl.de/~robbani/metatraits/GTDB2NCBI.tsv.gz
+#   https://www.bork.embl.de/~robbani/metatraits/NCBI2GTDB.tsv.gz
+# Verified 2026-07-25: byte-identical to the pinned copies below. We deliberately
+# do NOT point at those URLs — it is an unversioned personal directory whose
+# contents are regenerated in place (our build is dated 2025-08-14), so a KG
+# rebuild months apart would silently use different crosswalks. The Drive copy
+# fixes the release; refresh it deliberately, from the URLs above.
+-
+  url: gdrive:1ip7ualwruocq9MvcaoNAcH0YtLtAEASP          # md5 a313f89ac32b7137c7225c789f724f63
+  local_name: GTDB2NCBI.tsv.gz
+  tag: metatraits_gtdb
+-
+  url: gdrive:1npQ1z2Yc0NRPHpBkKjsKIBy2_evDAyCV          # md5 eca29d35869dd9035730caa12de12598
+  local_name: NCBI2GTDB.tsv.gz
+  tag: metatraits_gtdb
 
 #
 # Biolink Model
@@ -434,6 +550,7 @@
 -
   url: https://raw.githubusercontent.com/biolink/biolink-model/v4.3.6/biolink-model.yaml
   local_name: biolink-model.yaml
+  tag: schema
 
 #
 # KGX Format Specification
@@ -442,6 +559,7 @@
 -
   url: https://raw.githubusercontent.com/biolink/kgx/master/docs/kgx_format.md
   local_name: kgx-format.md
+  tag: schema
 
 
 #
@@ -476,20 +594,27 @@
 # download.py, not kg_microbe/download.py), so no extra header config is
 # needed here.
 #
-# MICRO's SemSQL distribution (micro.db.gz) is a 29-byte truncated placeholder
-# rather than a real SemSQL DB; PO's SemSQL .db is fine but the OWL path is the
-# one the stub transform exercises for hierarchy. The MICRO and PO OWLs are
-# declared above in the ontologies section.
+# Only BTO and NCIT are fetched as SemSQL DBs, because only they are read that
+# way (source_type semsql_mireot / label-only OAK lookups), and neither has an
+# OWL declared here, so there is no second copy to drift from. MICRO's SemSQL
+# distribution (micro.db.gz) is a 29-byte truncated placeholder rather than a
+# real DB, and PO's — while a valid DB — was never read by anything. Both take
+# the ROBOT MIREOT path against their OWLs, declared above in the ontologies
+# section.
 #
 -
   url: https://semanticsql.berkeleybop.io/ncit.db.gz
   local_name: ncit.db.gz
+  tag: stubs
 -
   url: https://semanticsql.berkeleybop.io/bto.db.gz
   local_name: bto.db.gz
--
-  url: https://semanticsql.berkeleybop.io/po.db.gz
-  local_name: po.db.gz
+  tag: stubs
+# PO deliberately has no SemSQL .db entry. Its stub import is owl_mireot against
+# po.owl (see STUB_ONTOLOGY_SOURCES["PO"]), so nothing ever read po.db — the
+# downloaded po.db.gz was never even decompressed. Removing it also removes a
+# second, independently-versioned copy of PO that could drift from po.owl with no
+# gate to catch it (#604). Re-add only alongside a switch to semsql_mireot.
 
 #
 # MeSH (Medical Subject Headings) — full N-Triples RDF from NLM
@@ -505,6 +630,7 @@
 -
   url: https://nlmpubs.nlm.nih.gov/projects/mesh/rdf/2026/mesh2026.nt.gz
   local_name: mesh2026.nt.gz
+  tag: stubs
 
 #
 # LPSN — List of Prokaryotic names with Standing in Nomenclature

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -1,13 +1,48 @@
 """Download resources from YAML file."""
 
+import tempfile
 from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
 
+import yaml
 from kghub_downloader.download_utils import download_from_yaml
 
 from kg_microbe.utils.mediadive_bulk_download import download_mediadive_bulk
 
+# Tag (in download.yaml) of the entry that pulls the MediaDive media list. A
+# tag-filtered run only does the follow-on bulk API download when MediaDive is
+# among the requested tags — otherwise `kg download -t ontologies` would kick
+# off an hour of MediaDive API calls just because mediadive.json is on disk
+# from an earlier run.
+MEDIADIVE_TAG = "mediadive"
 
-def download(yaml_file: str, output_dir: str, snippet_only: bool, ignore_cache: bool = False) -> None:
+# Marker for a source whose original URL is dead and whose replacement copy is
+# not hosted yet (see the "pending hosting" note in download.yaml). Such entries
+# are declared normally — so they carry a tag, appear in the config, and start
+# working the moment a real URL is pasted in — but are skipped at download time.
+# Without the skip, the placeholder URL would raise and abort the whole run.
+PENDING_HOSTING_MARKER = "REPLACE_ME_"
+
+
+class UnknownDownloadTagError(ValueError):
+
+    """
+    Raised when a requested -t tag matches no entry in the download config.
+
+    A dedicated type so the CLI can report bad tags as usage errors without
+    also swallowing unrelated ValueErrors raised deeper in the download (JSON
+    decode failures and pydantic ValidationError are both ValueError
+    subclasses, and were being presented as "Invalid value" for -t).
+    """
+
+
+def download(
+    yaml_file: str,
+    output_dir: str,
+    snippet_only: bool,
+    ignore_cache: bool = False,
+    tags: Optional[Sequence[str]] = None,
+) -> None:
     """
     Download data files from list of URLs.
 
@@ -19,18 +54,107 @@ def download(yaml_file: str, output_dir: str, snippet_only: bool, ignore_cache: 
     :param output_dir: A string pointing to the location to download data to.
     :param snippet_only: Downloads only the first 5 kB of the source,for testing and file checks.
     :param ignore_cache: Ignore cache and download files even if they exist [false]
+    :param tags: Only download entries carrying one of these tags. None or empty
+        means download everything.
     :return: None.
     """
-    download_from_yaml(
-        yaml_file=yaml_file,
-        output_dir=output_dir,
-        snippet_only=snippet_only,
-        ignore_cache=ignore_cache,
-    )
+    tags = list(tags) if tags else None
+    if tags:
+        _validate_tags(yaml_file, tags)
+
+    effective_yaml, pending = _without_pending_hosting(yaml_file, tags)
+    if pending:
+        _report_pending(pending)
+
+    try:
+        download_from_yaml(
+            yaml_file=effective_yaml,
+            output_dir=output_dir,
+            snippet_only=snippet_only,
+            ignore_cache=ignore_cache,
+            tags=tags,
+        )
+    finally:
+        if effective_yaml != yaml_file:
+            Path(effective_yaml).unlink(missing_ok=True)
 
     # Post-download: Trigger MediaDive bulk download if mediadive.json was downloaded
-    if not snippet_only:  # Skip bulk download in snippet mode
-        _post_download_mediadive_bulk(output_dir, ignore_cache)
+    if snippet_only:  # Skip bulk download in snippet mode
+        return
+    if tags and MEDIADIVE_TAG not in tags:
+        return
+    _post_download_mediadive_bulk(output_dir, ignore_cache)
+
+
+def _without_pending_hosting(yaml_file: str, tags: Optional[Sequence[str]]) -> Tuple[str, List[dict]]:
+    """
+    Split off entries still carrying a hosting placeholder.
+
+    kghub-downloader reads the config file itself and aborts the whole run on the
+    first download error, so a placeholder URL cannot simply be left in place.
+    When any is present we hand the downloader a filtered copy of the config
+    instead.
+
+    :param yaml_file: Path to the download config.
+    :param tags: Tags the run is restricted to, or None for all.
+    :return: (config path to use, list of skipped entries). The path is the
+        original when nothing is pending; otherwise a temp file the caller must
+        delete.
+    """
+    with open(yaml_file) as f:
+        entries = yaml.safe_load(f) or []
+
+    def is_pending(entry: dict) -> bool:
+        """Report whether this entry's URL is still a hosting placeholder."""
+        return PENDING_HOSTING_MARKER in entry.get("url", "")
+
+    # Only entries this run would actually have attempted are worth reporting.
+    selected = [e for e in entries if not tags or e.get("tag") in tags]
+    pending = [e for e in selected if is_pending(e)]
+    if not pending:
+        return yaml_file, []
+
+    ready = [e for e in entries if not is_pending(e)]
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tmp:
+        yaml.safe_dump(ready, tmp, sort_keys=False)
+        return tmp.name, pending
+
+
+def _report_pending(pending: Sequence[dict]) -> None:
+    """
+    Tell the user which sources were skipped and why.
+
+    A silent skip would look like a successful download of a file that never
+    arrived — the same failure mode as an unknown tag.
+
+    :param pending: Entries skipped because their URL is a placeholder.
+    """
+    print(f"\nSkipping {len(pending)} source(s) whose replacement copy is not hosted yet:")
+    for entry in pending:
+        print(f"  - {entry.get('local_name')} (tag: {entry.get('tag')})")
+    print("  Copy these from a reference data/raw_* directory, or paste the real")
+    print("  URL over the REPLACE_ME_ placeholder in download.yaml once hosted.\n")
+
+
+def _validate_tags(yaml_file: str, tags: Sequence[str]) -> None:
+    """
+    Fail fast on a tag that matches nothing in the YAML.
+
+    kghub-downloader silently downloads zero files for an unknown tag, which
+    looks exactly like a successful no-op run.
+
+    :param yaml_file: Path to the download config being filtered.
+    :param tags: Tags requested on the command line.
+    :raises UnknownDownloadTagError: If any tag matches no entry.
+    """
+    with open(yaml_file) as f:
+        entries = yaml.safe_load(f) or []
+    known = {entry.get("tag") for entry in entries if entry.get("tag")}
+    unknown = sorted(set(tags) - known)
+    if unknown:
+        raise UnknownDownloadTagError(
+            f"Unknown download tag(s): {', '.join(unknown)}. Available tags in {yaml_file}: {', '.join(sorted(known))}"
+        )
 
 
 def _post_download_mediadive_bulk(output_dir: str, ignore_cache: bool = False) -> None:
@@ -42,7 +166,8 @@ def _post_download_mediadive_bulk(output_dir: str, ignore_cache: bool = False) -
     API calls during transform.
 
     :param output_dir: Output directory where data is downloaded
-    :param ignore_cache: If True, re-download even if bulk files exist
+    :param ignore_cache: If True, re-download even if bulk files exist, and
+        discard cached HTTP responses so the API is actually re-queried
     """
     mediadive_basic_file = Path(output_dir) / "mediadive.json"
     mediadive_bulk_dir = Path(output_dir) / "mediadive"
@@ -72,7 +197,7 @@ def _post_download_mediadive_bulk(output_dir: str, ignore_cache: bool = False) -
     print("\n" + "=" * 80)
     print("Starting MediaDive bulk download...")
     print("=" * 80)
-    download_mediadive_bulk(str(mediadive_basic_file), str(mediadive_bulk_dir))
+    download_mediadive_bulk(str(mediadive_basic_file), str(mediadive_bulk_dir), ignore_cache=ignore_cache)
     print("=" * 80)
     print("MediaDive bulk download complete!")
     print("=" * 80 + "\n")

--- a/kg_microbe/run.py
+++ b/kg_microbe/run.py
@@ -10,6 +10,7 @@ import click
 warnings.filterwarnings("ignore", message=".*pkg_resources is deprecated.*", category=UserWarning)
 
 from kg_microbe import download as kg_download  # noqa: E402
+from kg_microbe.download import UnknownDownloadTagError  # noqa: E402
 from kg_microbe.merge_utils.merge_kg import load_and_merge  # noqa: E402
 from kg_microbe.query import parse_query_yaml, result_dict_to_tsv, run_query  # noqa: E402
 from kg_microbe.transform import DATA_SOURCES  # noqa: E402
@@ -42,6 +43,13 @@ def main():
     default=False,
     help="ignore cache and download files even if they exist [false]",
 )
+@click.option(
+    "tags",
+    "-t",
+    "--tag",
+    multiple=True,
+    help="only download sources with this tag (repeatable); omit for all. See the tag list in download.yaml's header.",
+)
 def download(*args, **kwargs) -> None:
     """
     Download from list of URLs (default: download.yaml) into data directory (default: data/raw).
@@ -50,9 +58,18 @@ def download(*args, **kwargs) -> None:
     :param output_dir: A string pointing to the directory to download data to.
     :param snippet_only: Download 5 kB of each uncompressed source, for testing and file checks.
     :param ignore_cache: If specified, will ignore existing files and download again.
+    :param tags: Restrict the run to sources carrying these tags (all sources if empty).
+    :raises click.BadParameter: If a requested tag matches no entry in the YAML.
     :return: None
     """
-    kg_download(*args, **kwargs)
+    try:
+        kg_download(*args, **kwargs)
+    except UnknownDownloadTagError as e:
+        # An unknown -t value is user error, not a crash — report it as such.
+        # Deliberately narrow: a blanket `except ValueError` also caught
+        # JSONDecodeError and pydantic ValidationError from deeper in the
+        # download and mislabelled them as bad tags, hiding the traceback.
+        raise click.BadParameter(str(e)) from e
 
     return None
 

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -180,14 +180,17 @@ def _open_maybe_gzipped(path: Path):
             handle = gzip.open(path, "rt", encoding="utf-8")
             handle.read(1)  # Trigger gzip header read
             handle.seek(0)
-            return handle
-        except gzip.BadGzipFile:
-            # The probe already opened the file; without this close the handle
-            # leaks on every decompressed-.gz read (#621), which is the normal
-            # case for the Drive-hosted inputs.
+        except Exception:  # noqa: BLE001 — see below; any probe failure falls back
+            # The probe already opened the file, so it must be closed on *every*
+            # failure, not just BadGzipFile (#629): a .gz truncated inside its
+            # 10-byte header raises EOFError and a mis-decoded payload raises
+            # UnicodeDecodeError, both realistic partial-download states, and both
+            # leaked the handle silently because callers wrap this in
+            # `except Exception`.
             if handle is not None:
                 handle.close()
             return open(path, "r", encoding="utf-8")
+        return handle
     return open(path, "r", encoding="utf-8")
 
 

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -161,6 +161,36 @@ def _get_ncbitaxon_adapter():
     return get_adapter(f"sqlite:{local_db}")
 
 
+def _open_maybe_gzipped(path: Path):
+    """
+    Open a ``.gz`` file that may not actually be gzip-compressed.
+
+    Google Drive silently serves some uploads decompressed, so a file named
+    ``*.gz`` can arrive as plain text — this is how the Drive-hosted
+    ``ncbi_*_summary.jsonl.gz`` inputs ended up as plain JSON in ``data/raw``.
+    Every read of a Drive-hosted input must go through here rather than calling
+    ``gzip.open`` directly.
+
+    :param path: File to open.
+    :return: An open text-mode handle.
+    """
+    if path.name.endswith(".gz"):
+        handle = None
+        try:
+            handle = gzip.open(path, "rt", encoding="utf-8")
+            handle.read(1)  # Trigger gzip header read
+            handle.seek(0)
+            return handle
+        except gzip.BadGzipFile:
+            # The probe already opened the file; without this close the handle
+            # leaks on every decompressed-.gz read (#621), which is the normal
+            # case for the Drive-hosted inputs.
+            if handle is not None:
+                handle.close()
+            return open(path, "r", encoding="utf-8")
+    return open(path, "r", encoding="utf-8")
+
+
 def _open_jsonl(path: Path):
     """
     Open JSONL file; use gzip for .gz files, plain text otherwise.
@@ -168,15 +198,7 @@ def _open_jsonl(path: Path):
     If a .gz file is not actually gzip-compressed (e.g. misnamed plain JSON),
     falls back to plain text.
     """
-    if path.name.endswith(".gz"):
-        try:
-            f = gzip.open(path, "rt", encoding="utf-8")
-            f.read(1)  # Trigger gzip header read
-            f.seek(0)
-            return f
-        except gzip.BadGzipFile:
-            return open(path, "r", encoding="utf-8")
-    return open(path, "r", encoding="utf-8")
+    return _open_maybe_gzipped(path)
 
 
 def _process_file_worker(args: Tuple[Path, Path, Dict[str, Any], bool]) -> Dict[str, Any]:
@@ -672,7 +694,10 @@ class MetaTraitsTransform(Transform):
             return gtdb_mappings
 
         try:
-            with gzip.open(mappings_file, "rt", encoding="utf-8") as f:
+            # Not gzip.open: this file is Drive-hosted and can arrive
+            # decompressed. The except below would swallow BadGzipFile and
+            # leave the mappings silently empty.
+            with _open_maybe_gzipped(mappings_file) as f:
                 reader = csv.DictReader(f, delimiter="\t")
                 for row in reader:
                     ncbi_species = row.get("species (NCBI)", "").strip()
@@ -692,9 +717,26 @@ class MetaTraitsTransform(Transform):
                             "mapping_type": mapping_type,
                             "confidence": "high",
                         }
-            print(f"  Loaded {len(gtdb_mappings)} NCBI to GTDB taxon mappings")
+            if not gtdb_mappings:
+                # _open_maybe_gzipped tolerates a non-gzip payload, which is right
+                # for the Drive-hosted inputs that arrive decompressed — but it also
+                # means an HTML quota interstitial or a 0-byte file reads as an empty
+                # table and would otherwise print the success line above. Master's
+                # bare gzip.open at least raised BadGzipFile here.
+                print(
+                    f"  Warning: {mappings_file} yielded no NCBI to GTDB mappings. "
+                    "The file is present but has no usable rows — check it is the "
+                    "real crosswalk and not an error page or a truncated download."
+                )
+            else:
+                print(f"  Loaded {len(gtdb_mappings)} NCBI to GTDB taxon mappings")
         except Exception as e:
-            print(f"  Warning: Could not load NCBI to GTDB mappings: {e}")
+            # A partially-read file keeps whatever rows were parsed; say so, because
+            # a half-loaded crosswalk is indistinguishable from a smaller one.
+            print(
+                f"  Warning: Could not fully load NCBI to GTDB mappings: {e} "
+                f"({len(gtdb_mappings)} mappings loaded before the error)"
+            )
 
         return gtdb_mappings
 

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -94,9 +94,11 @@ ONTOLOGIES_MAP = {
     # are now per-CURIE imports via the OntologiesStubsTransform
     # (kg_microbe/transform_utils/ontologies_stubs/), which emits one
     # labelled stub node per referenced CURIE instead of pulling in
-    # ~2,170 + ~17,600 unrelated nodes. PO uses the bbop-sqlite SemSQL DB
-    # (data/raw/po.db); MICRO uses the obograph JSON (data/raw/micro.json)
-    # because MICRO's bbop-sqlite distribution is broken.
+    # ~2,170 + ~17,600 unrelated nodes. Both go through ROBOT MIREOT against
+    # the OWL (owl_mireot): PO from data/raw/po.owl, MICRO from
+    # data/raw/micro.owl. Neither uses a SemSQL .db — MICRO's bbop-sqlite
+    # distribution is a truncated placeholder, and PO's was downloaded but
+    # never read, so it was dropped from download.yaml (#604).
 }
 
 

--- a/kg_microbe/utils/mediadive_bulk_download.py
+++ b/kg_microbe/utils/mediadive_bulk_download.py
@@ -7,6 +7,7 @@ to avoid repeated API calls during transforms.
 
 import json
 import logging
+import shutil
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -14,12 +15,20 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import requests
-import requests_cache
+from requests_cache import CachedSession
+from requests_cache.backends.sqlite import SQLiteCache
 from tqdm import tqdm
 
 # Default to 5 workers — still a large speedup over sequential but polite to
 # MediaDive, which is a small academic REST API at DSMZ.
 DEFAULT_MAX_WORKERS = 5
+
+# Name of the HTTP response cache, stored alongside the bulk output files.
+CACHE_FILENAME = "mediadive_bulk_cache.sqlite"
+
+# Milliseconds a thread waits for the SQLite write lock before giving up. Each
+# thread holds its own connection, so brief contention on writes is expected.
+CACHE_BUSY_TIMEOUT_MS = 30_000
 
 # Descriptive User-Agent so the API operator can identify traffic source.
 USER_AGENT = "kg-microbe (Knowledge-Graph-Hub; https://github.com/Knowledge-Graph-Hub/kg-microbe)"
@@ -45,16 +54,175 @@ COMPOUND_ID_KEY = "compound_id"
 SOLUTION_ID_KEY = "solution_id"
 
 
-def setup_cache(cache_name: str = "mediadive_bulk_cache"):
-    """Set up HTTP caching to avoid re-downloading data."""
-    requests_cache.install_cache(cache_name, backend="sqlite")
-    print(f"HTTP cache enabled: {cache_name}.sqlite")
+# Per-thread HTTP sessions.
+#
+# requests_cache's SQLiteDict keeps a *single* sqlite3.Connection shared by every
+# caller (backends/sqlite.py: `self._connection`, opened with
+# check_same_thread=False) and deliberately takes no lock on reads:
+#
+#     # Read operations can be run in parallel (no lock or COMMIT)
+#     else:
+#         yield self._connection
+#
+# Driving one CachedSession from a ThreadPoolExecutor therefore runs concurrent
+# execute() calls on one connection, which tramples its internal pager state and
+# makes SQLite raise "database disk image is malformed" against a perfectly
+# intact file. Giving each thread its own CachedSession gives each thread its own
+# connection; multiple connections to one SQLite file is supported usage, and the
+# cached responses are still shared because they live in the same database.
+#
+# The previous implementation used requests_cache.install_cache(), which
+# monkeypatches requests.Session globally — every session in the process became a
+# CachedSession as a side effect. Caching is now explicit and scoped to this
+# module.
+_thread_local = threading.local()
+
+# Every session handed out, so _reset_sessions can close them. A thread-local
+# alone is not enough: one thread cannot reach another's sessions to close them.
+_live_sessions: List[requests.Session] = []
+_sessions_lock = threading.Lock()
+
+# Set by setup_cache(); None means "no HTTP caching" (plain sessions).
+_cache_path: Optional[Path] = None
+
+
+def setup_cache(
+    cache_dir: Optional[Path] = None,
+    migrate_legacy: bool = False,
+    clear: bool = False,
+) -> Optional[Path]:
+    """
+    Enable HTTP caching for subsequent sessions created by this module.
+
+    Args:
+    ----
+        cache_dir: Directory to hold the cache database. If None, caching is
+            disabled and plain (uncached) sessions are used.
+        migrate_legacy: If True, adopt a cache database left in the current
+            working directory by older versions of this module (which stored it
+            there). Off by default: this *moves* a file outside cache_dir, so
+            only the real download entry point should ask for it.
+        clear: If True, discard any existing cached responses so every request
+            goes back to the API. This is what `kg download --ignore-cache`
+            needs; without it the bulk JSON files are rebuilt from cached HTTP
+            responses and never actually refresh.
+
+    Returns:
+    -------
+        Path to the cache database, or None if caching was disabled.
+
+    """
+    global _cache_path
+
+    # Drop any sessions built against a previously configured cache.
+    _reset_sessions()
+
+    if cache_dir is None:
+        _cache_path = None
+        return None
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    _cache_path = cache_dir / CACHE_FILENAME
+    # Adopt the legacy cache before clearing, so a stale copy can't linger in
+    # the CWD and get picked up by a later run that isn't clearing.
+    if migrate_legacy:
+        _migrate_legacy_cache(_cache_path)
+    if clear:
+        _delete_cache(_cache_path)
+
+    # Create the tables up front so worker threads don't race on the initial
+    # CREATE TABLE when they open their own connections. Closed immediately —
+    # SQLiteDict opens its connection eagerly in __init__, so an unreferenced
+    # backend would leave two connections open on a file a later clear() unlinks.
+    warmup = _make_backend()
+    warmup.close()
+    print(f"HTTP cache enabled: {_cache_path}")
+    return _cache_path
+
+
+def _delete_cache(cache_path: Path) -> None:
+    """Remove a cache database and its WAL sidecar files, if present."""
+    removed = False
+    for path in (cache_path, *(cache_path.with_name(cache_path.name + s) for s in ("-wal", "-shm"))):
+        if path.exists():
+            path.unlink()
+            removed = True
+    if removed:
+        print(f"Cleared HTTP cache: {cache_path}")
+
+
+def _migrate_legacy_cache(cache_path: Path) -> None:
+    """
+    Move a cache database left in the working directory to its new home.
+
+    Older versions called requests_cache.install_cache(), which put the database
+    in the CWD (normally the repo root). Adopting it avoids re-downloading
+    thousands of already-cached MediaDive responses.
+    """
+    legacy_path = Path.cwd() / CACHE_FILENAME
+    if cache_path.exists() or not legacy_path.exists() or legacy_path.resolve() == cache_path.resolve():
+        return
+    try:
+        shutil.move(str(legacy_path), str(cache_path))
+    except OSError as e:
+        # Adopting the old cache is an optimisation; failing it (e.g. EXDEV when
+        # data/ is on another filesystem) must not abort the whole download.
+        print(f"Could not adopt {legacy_path} ({e}); continuing with a fresh cache")
+        return
+    # Move the WAL sidecars too. A cache this module created is WAL-enabled, so
+    # leaving them behind would drop uncheckpointed responses and orphan the
+    # files in the working directory (#622).
+    for suffix in ("-wal", "-shm"):
+        sidecar = legacy_path.with_name(legacy_path.name + suffix)
+        if sidecar.exists():
+            try:
+                shutil.move(str(sidecar), str(cache_path.with_name(cache_path.name + suffix)))
+            except OSError as e:
+                print(f"Could not move {sidecar.name} ({e}); it can be deleted safely")
+    print(f"Adopted existing HTTP cache: {legacy_path} -> {cache_path}")
+
+
+def _make_backend() -> SQLiteCache:
+    """Build a SQLiteCache backed by the configured cache path."""
+    # WAL keeps readers from blocking writers across the worker threads, and
+    # busy_timeout makes a thread wait for the write lock instead of failing.
+    return SQLiteCache(str(_cache_path), wal=True, busy_timeout=CACHE_BUSY_TIMEOUT_MS)
+
+
+def _reset_sessions() -> None:
+    """
+    Close and discard cached per-thread sessions (used by setup_cache and tests).
+
+    Rebinding rather than clearing an attribute is deliberate: it makes *every*
+    thread see a fresh local, which is what a cache reconfiguration needs. The
+    sessions themselves must be closed explicitly, or each one's SQLite
+    connection lingers until garbage collection (#617).
+    """
+    global _thread_local
+    with _sessions_lock:
+        for session in _live_sessions:
+            try:
+                session.close()
+            except Exception as e:  # noqa: BLE001 — teardown must not mask the real work
+                logger.debug(f"Ignoring error while closing a cached session: {e}")
+        _live_sessions.clear()
+    _thread_local = threading.local()
 
 
 def _make_session() -> requests.Session:
-    """Create a requests Session with the kg-microbe User-Agent."""
-    session = requests.Session()
-    session.headers.update({"User-Agent": USER_AGENT})
+    """
+    Return this thread's HTTP session, creating it on first use.
+
+    Must be called from the thread that will use the session — see the module
+    comment above on why sessions are never shared across threads.
+    """
+    session = getattr(_thread_local, "session", None)
+    if session is None:
+        session = CachedSession(backend=_make_backend()) if _cache_path else requests.Session()
+        session.headers.update({"User-Agent": USER_AGENT})
+        _thread_local.session = session
+        with _sessions_lock:
+            _live_sessions.append(session)
     return session
 
 
@@ -76,7 +244,7 @@ def get_json_from_api(
         retry_count: Number of retries on failure
         retry_delay: Delay in seconds between retries (overridden by Retry-After on 429)
         verbose: If True, log empty responses (useful for debugging)
-        session: Optional requests Session to reuse (uses module-level session if None)
+        session: Optional requests Session to reuse (uses this thread's session if None)
 
     Returns:
     -------
@@ -190,12 +358,12 @@ def download_detailed_media(
     """
     print(f"\nDownloading detailed recipes for {len(media_list)} media...")
     detailed_data: Dict[str, Dict] = {}
-    session = _make_session()
     rate_limiter = threading.Semaphore(max_workers)
 
     def fetch(medium: Dict) -> tuple[str, dict]:
-        """Fetch detail for a single medium using the shared session and rate limiter."""
-        return _fetch_medium_detail(medium, session, rate_limiter, retry_count, retry_delay)
+        """Fetch detail for a single medium using this thread's session and the rate limiter."""
+        # _make_session() runs inside the worker thread so each thread gets its own.
+        return _fetch_medium_detail(medium, _make_session(), rate_limiter, retry_count, retry_delay)
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for medium_id, data in tqdm(
@@ -235,12 +403,12 @@ def download_medium_strains(
     """
     print(f"\nDownloading strain associations for {len(media_list)} media...")
     strain_data: Dict[str, List] = {}
-    session = _make_session()
     rate_limiter = threading.Semaphore(max_workers)
 
     def fetch(medium: Dict) -> tuple[str, dict]:
-        """Fetch strain associations for a single medium using the shared session and rate limiter."""
-        return _fetch_medium_strains(medium, session, rate_limiter, retry_count, retry_delay)
+        """Fetch strain associations for a single medium using this thread's session."""
+        # _make_session() runs inside the worker thread so each thread gets its own.
+        return _fetch_medium_strains(medium, _make_session(), rate_limiter, retry_count, retry_delay)
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for medium_id, data in tqdm(
@@ -343,6 +511,7 @@ def download_mediadive_bulk(
     max_workers: int = DEFAULT_MAX_WORKERS,
     retry_count: int = 3,
     retry_delay: float = 2.0,
+    ignore_cache: bool = False,
 ):
     """
     Download all MediaDive data in bulk.
@@ -356,6 +525,9 @@ def download_mediadive_bulk(
         max_workers: Number of parallel download threads (default: 5, polite for small APIs)
         retry_count: Number of retries on request failure
         retry_delay: Seconds between retries (overridden by Retry-After on 429)
+        ignore_cache: If True, discard cached HTTP responses and re-fetch from
+            the API. Rebuilding the bulk files from a warm cache would otherwise
+            reproduce the old data byte for byte.
 
     """
     output_path = Path(output_dir)
@@ -374,51 +546,61 @@ def download_mediadive_bulk(
     print(f"API warnings will be logged to: {log_file}")
     print(f"Using {max_workers} parallel workers")
 
-    # Set up HTTP caching
-    setup_cache()
+    # Set up HTTP caching (stored alongside the bulk output, not in the CWD)
+    setup_cache(output_path, migrate_legacy=True, clear=ignore_cache)
 
-    # Step 1: Load basic media list
-    print("\n[1/5] Loading basic media list...")
-    media_list = load_basic_media_list(basic_file)
+    # Wrapped so an interrupted or failing run still closes its sessions:
+    # otherwise every per-thread SQLite connection stays open, which is exactly
+    # the case where a stale handle on a cache file matters most.
+    try:
+        # Step 1: Load basic media list
+        print("\n[1/5] Loading basic media list...")
+        media_list = load_basic_media_list(basic_file)
 
-    # Step 2: Download detailed medium recipes
-    print("\n[2/5] Downloading detailed medium recipes...")
-    detailed_media = download_detailed_media(
-        media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
-    )
-    save_json_file(detailed_media, output_path / "media_detailed.json", "detailed media recipes")
+        # Step 2: Download detailed medium recipes
+        print("\n[2/5] Downloading detailed medium recipes...")
+        detailed_media = download_detailed_media(
+            media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
+        )
+        save_json_file(detailed_media, output_path / "media_detailed.json", "detailed media recipes")
 
-    # Step 3: Download medium-strain associations
-    print("\n[3/5] Downloading medium-strain associations...")
-    media_strains = download_medium_strains(
-        media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
-    )
-    save_json_file(media_strains, output_path / "media_strains.json", "medium-strain associations")
+        # Step 3: Download medium-strain associations
+        print("\n[3/5] Downloading medium-strain associations...")
+        media_strains = download_medium_strains(
+            media_list, max_workers=max_workers, retry_count=retry_count, retry_delay=retry_delay
+        )
+        save_json_file(media_strains, output_path / "media_strains.json", "medium-strain associations")
 
-    # Step 4: Extract solutions from embedded structure
-    print("\n[4/5] Extracting solutions from embedded structure...")
-    solutions_data = extract_solutions_from_media(detailed_media)
-    print(f"Extracted {len(solutions_data)} unique solutions from embedded data")
-    save_json_file(solutions_data, output_path / "solutions.json", "solution data")
+        # Step 4: Extract solutions from embedded structure
+        print("\n[4/5] Extracting solutions from embedded structure...")
+        solutions_data = extract_solutions_from_media(detailed_media)
+        print(f"Extracted {len(solutions_data)} unique solutions from embedded data")
+        save_json_file(solutions_data, output_path / "solutions.json", "solution data")
 
-    # Step 5: Extract compounds from embedded structure
-    # Compound data is embedded in the recipe structure of detailed media
-    # The transform will use MicroMediaParam mappings and fall back to mediadive.ingredient: prefix
-    print("\n[5/5] Extracting compounds from embedded structure...")
-    compounds_data = extract_compounds_from_media(detailed_media)
-    print(f"Extracted {len(compounds_data)} compounds from embedded data")
-    save_json_file(compounds_data, output_path / "compounds.json", "compound data")
+        # Step 5: Extract compounds from embedded structure
+        # Compound data is embedded in the recipe structure of detailed media
+        # The transform will use MicroMediaParam mappings and fall back to mediadive.ingredient: prefix
+        print("\n[5/5] Extracting compounds from embedded structure...")
+        compounds_data = extract_compounds_from_media(detailed_media)
+        print(f"Extracted {len(compounds_data)} compounds from embedded data")
+        save_json_file(compounds_data, output_path / "compounds.json", "compound data")
 
-    # Summary
-    print("\n" + "=" * 80)
-    print("MediaDive bulk download summary:")
-    print("=" * 80)
-    print(f"Output directory: {output_path}")
-    print(f"  - {len(media_list)} media records (basic)")
-    print(f"  - {len(detailed_media)} media recipes (detailed)")
-    print(f"  - {len(media_strains)} media-strain associations")
-    print(f"  - {len(solutions_data)} solutions")
-    print(f"  - {len(compounds_data)} compounds")
-    print(f"\nAPI warnings logged to: {output_path / 'mediadive_download.log'}")
-    print("These files will be used by the MediaDive transform to avoid API calls.")
+        # Summary
+        print("\n" + "=" * 80)
+        print("MediaDive bulk download summary:")
+        print("=" * 80)
+        print(f"Output directory: {output_path}")
+        print(f"  - {len(media_list)} media records (basic)")
+        print(f"  - {len(detailed_media)} media recipes (detailed)")
+        print(f"  - {len(media_strains)} media-strain associations")
+        print(f"  - {len(solutions_data)} solutions")
+        print(f"  - {len(compounds_data)} compounds")
+        print(f"\nAPI warnings logged to: {output_path / 'mediadive_download.log'}")
+        print("These files will be used by the MediaDive transform to avoid API calls.")
+
+    finally:
+        # Close every per-thread session; the worker threads are gone but
+        # _live_sessions still holds their connections open.
+        _reset_sessions()
+
     print("=" * 80)

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -1,0 +1,315 @@
+"""Tests for tag-filtered downloads (`kg download -t <tag>`)."""
+
+from importlib import import_module
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+# kg_microbe/__init__.py does `from .download import download`, so the name
+# kg_microbe.download resolves to the *function*, not the module. Fetch the
+# module from sys.modules so patch.object targets the right object.
+download_module = import_module("kg_microbe.download")
+
+DOWNLOAD_YAML = Path(__file__).parent.parent / "download.yaml"
+
+# Tags documented in download.yaml's header. Kept here so a typo'd tag on a new
+# entry fails loudly instead of creating a near-duplicate group.
+KNOWN_TAGS = {
+    "tools",
+    "ontologies",
+    "stubs",
+    "mappings",
+    "bacdive",
+    "mediadive",
+    "madin",
+    "rhea",
+    "cog",
+    "kegg",
+    "gtdb",
+    "metatraits",
+    "metatraits_gtdb",
+    "bactotraits",
+    "schema",
+}
+
+
+def _entries():
+    """Return the active (uncommented) resource entries in download.yaml."""
+    with open(DOWNLOAD_YAML) as f:
+        return yaml.safe_load(f) or []
+
+
+class TestYamlTagging:
+
+    """Every active download entry must be reachable via -t."""
+
+    def test_every_entry_has_a_tag(self):
+        """An untagged entry can never be selected by -t, so require one."""
+        untagged = [e.get("local_name") or e.get("url") for e in _entries() if not e.get("tag")]
+        assert untagged == [], f"download.yaml entries missing a tag: {untagged}"
+
+    def test_tags_are_from_the_documented_set(self):
+        """Guard against typos silently creating a new one-entry group."""
+        used = {e["tag"] for e in _entries() if e.get("tag")}
+        assert used - KNOWN_TAGS == set(), f"undocumented tag(s): {sorted(used - KNOWN_TAGS)}"
+
+    def test_documented_tags_are_all_used(self):
+        """A documented tag that matches nothing would be a dead option."""
+        used = {e["tag"] for e in _entries() if e.get("tag")}
+        assert KNOWN_TAGS - used == set(), f"documented but unused tag(s): {sorted(KNOWN_TAGS - used)}"
+
+    def test_urls_have_no_surrounding_whitespace(self):
+        """A stray space becomes part of the URL handed to urllib (#623)."""
+        offenders = [e["local_name"] for e in _entries() if e["url"] != e["url"].strip()]
+        assert offenders == [], f"entries with padded URLs: {offenders}"
+
+    def test_local_names_have_no_surrounding_whitespace(self):
+        """Same hazard for the destination path."""
+        offenders = [e["local_name"] for e in _entries() if e["local_name"] != e["local_name"].strip()]
+        assert offenders == []
+
+    def test_mediadive_tag_matches_the_constant(self):
+        """The bulk-download gate keys off this exact tag string."""
+        tags = {e["tag"] for e in _entries() if e.get("tag")}
+        assert download_module.MEDIADIVE_TAG in tags
+
+
+class TestPendingHosting:
+
+    """
+    Sources with a placeholder URL must be skipped, not attempted.
+
+    kghub-downloader aborts the whole run on the first download error, so leaving
+    a REPLACE_ME_ URL in the config would break `kg download` for everyone.
+    """
+
+    # The mechanism is exercised against a synthetic config rather than
+    # download.yaml, which normally has no placeholders left: every file is
+    # hosted. Tying these to the real file made them pass only while something
+    # happened to be unhosted.
+    @staticmethod
+    def _config(tmp_path, *, pending=True):
+        """Write a small config with one ready entry and optionally one pending."""
+        entries = [{"url": "https://example.org/ready.tsv", "local_name": "ready.tsv", "tag": "ontologies"}]
+        if pending:
+            entries.append(
+                {
+                    "url": f"gdrive:{download_module.PENDING_HOSTING_MARKER}thing",
+                    "local_name": "unhosted.tsv.gz",
+                    "tag": "metatraits_gtdb",
+                }
+            )
+        path = tmp_path / "config.yaml"
+        with open(path, "w") as f:
+            yaml.safe_dump(entries, f, sort_keys=False)
+        return str(path)
+
+    def _run(self, tmp_path, config, **kwargs):
+        """Run download() against `config`, capturing what the downloader saw."""
+        captured = {}
+
+        def record(**call_kwargs):
+            """Parse the config file while it still exists."""
+            captured["path"] = call_kwargs["yaml_file"]
+            with open(call_kwargs["yaml_file"]) as f:
+                captured["entries"] = yaml.safe_load(f)
+
+        with patch.object(download_module, "download_from_yaml", side_effect=record):
+            download_module.download(
+                yaml_file=config,
+                output_dir=str(tmp_path / "out"),
+                snippet_only=False,
+                **kwargs,
+            )
+        return captured
+
+    def test_real_config_pending_entries_are_tagged(self):
+        """Any placeholder left in download.yaml still needs a tag."""
+        pending = [e for e in _entries() if download_module.PENDING_HOSTING_MARKER in e["url"]]
+        assert [e["local_name"] for e in pending if not e.get("tag")] == []
+
+    def test_pending_entries_are_filtered_out(self, tmp_path):
+        """The config handed to the downloader must contain no placeholder URL."""
+        seen = self._run(tmp_path, self._config(tmp_path))
+        assert [e["local_name"] for e in seen["entries"]] == ["ready.tsv"]
+
+    def test_filtered_entries_keep_their_fields(self, tmp_path):
+        """Round-tripping the config must not lose url/local_name/tag."""
+        seen = self._run(tmp_path, self._config(tmp_path))
+        assert all({"url", "local_name", "tag"} <= set(e) for e in seen["entries"])
+
+    def test_temp_config_is_cleaned_up(self, tmp_path):
+        """The filtered copy is a temp file; it must not be left behind."""
+        config = self._config(tmp_path)
+        seen = self._run(tmp_path, config)
+        assert seen["path"] != config
+        assert not Path(seen["path"]).exists()
+
+    def test_temp_config_cleaned_up_on_error(self, tmp_path):
+        """A failed download must not leak the temp config either."""
+        seen = {}
+
+        def boom(**kwargs):
+            """Record the config path, then fail like a dead URL would."""
+            seen["yaml"] = kwargs["yaml_file"]
+            raise RuntimeError("download exploded")
+
+        with patch.object(download_module, "download_from_yaml", side_effect=boom):
+            with pytest.raises(RuntimeError, match="exploded"):
+                download_module.download(
+                    yaml_file=self._config(tmp_path),
+                    output_dir=str(tmp_path / "out"),
+                    snippet_only=False,
+                )
+        assert not Path(seen["yaml"]).exists()
+
+    def test_skipped_sources_are_reported(self, tmp_path, capsys):
+        """A silent skip looks like a download of a file that never arrived."""
+        self._run(tmp_path, self._config(tmp_path))
+        out = capsys.readouterr().out
+        assert "not hosted yet" in out
+        assert "unhosted.tsv.gz" in out
+
+    def test_no_placeholders_means_original_config(self, tmp_path):
+        """With everything hosted, no filtered copy is made at all."""
+        config = self._config(tmp_path, pending=False)
+        seen = self._run(tmp_path, config)
+        assert seen["path"] == config
+
+    def test_unaffected_tag_run_uses_the_original_config(self, tmp_path):
+        """A run selecting no pending entry needs no filtered copy."""
+        config = self._config(tmp_path)
+        seen = self._run(tmp_path, config, tags=("ontologies",))
+        assert seen["path"] == config
+
+    def test_pending_tag_is_still_a_valid_tag(self, tmp_path):
+        """A tag whose only entries are unhosted must be accepted, not rejected as unknown."""
+        config = self._config(tmp_path)
+        # Reaching the downloader at all proves _validate_tags accepted the tag;
+        # a rejection would have raised ValueError before this point.
+        seen = self._run(tmp_path, config, tags=("metatraits_gtdb",))
+        assert "path" in seen, "download_from_yaml should still have been called"
+        names = [e["local_name"] for e in seen["entries"]]
+        assert "unhosted.tsv.gz" not in names, "the pending entry must be filtered out"
+
+
+class TestCliErrorHandling:
+
+    """The CLI must report bad tags as usage errors without hiding real crashes."""
+
+    def test_unknown_tag_is_a_usage_error(self, tmp_path):
+        """A bad -t is user error: exit 2, no traceback."""
+        from click.testing import CliRunner
+
+        from kg_microbe.run import download as download_cmd
+
+        result = CliRunner().invoke(download_cmd, ["-y", str(DOWNLOAD_YAML), "-o", str(tmp_path), "-t", "nosuchtag"])
+        assert result.exit_code == 2
+        assert "Unknown download tag" in result.output
+
+    def test_unrelated_valueerror_is_not_mislabelled(self, tmp_path):
+        """
+        A ValueError from deep in the download must not be reported as a bad tag.
+
+        JSONDecodeError and pydantic's ValidationError are both ValueError
+        subclasses, so a blanket `except ValueError` turned a corrupt
+        mediadive.json into 'Error: Invalid value: ...' against -t, swallowing the
+        traceback that pointed at the real cause.
+        """
+        from click.testing import CliRunner
+
+        from kg_microbe.run import download as download_cmd
+
+        with patch.object(download_module, "download_from_yaml", side_effect=ValueError("boom in json")):
+            result = CliRunner().invoke(download_cmd, ["-y", str(DOWNLOAD_YAML), "-o", str(tmp_path)])
+        assert result.exit_code != 2, "should not be reported as a usage error"
+        assert isinstance(result.exception, ValueError)
+        assert "boom in json" in str(result.exception)
+
+
+class TestTagPlumbing:
+
+    """Tags must reach kghub-downloader, and gate the MediaDive bulk step."""
+
+    def _run(self, tmp_path, **kwargs):
+        """Call download() with both downstream side effects mocked out."""
+        with (
+            patch.object(download_module, "download_from_yaml") as mock_yaml,
+            patch.object(download_module, "_post_download_mediadive_bulk") as mock_bulk,
+        ):
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=False,
+                **kwargs,
+            )
+        return mock_yaml, mock_bulk
+
+    def test_tags_are_forwarded(self, tmp_path):
+        """-t values must be handed to download_from_yaml."""
+        mock_yaml, _ = self._run(tmp_path, tags=("ontologies", "gtdb"))
+        assert mock_yaml.call_args.kwargs["tags"] == ["ontologies", "gtdb"]
+
+    def test_no_tags_means_everything(self, tmp_path):
+        """Omitting -t must not filter (None, not an empty list)."""
+        mock_yaml, _ = self._run(tmp_path)
+        assert mock_yaml.call_args.kwargs["tags"] is None
+
+    def test_empty_tags_tuple_means_everything(self, tmp_path):
+        """Click passes () when -t is absent; that must mean 'all', not 'none'."""
+        mock_yaml, _ = self._run(tmp_path, tags=())
+        assert mock_yaml.call_args.kwargs["tags"] is None
+
+    def test_mediadive_bulk_skipped_when_tag_excluded(self, tmp_path):
+        """`-t ontologies` must not start an hour of MediaDive API calls."""
+        _, mock_bulk = self._run(tmp_path, tags=("ontologies",))
+        mock_bulk.assert_not_called()
+
+    def test_mediadive_bulk_runs_when_tag_included(self, tmp_path):
+        """`-t mediadive` must still do the follow-on bulk download."""
+        _, mock_bulk = self._run(tmp_path, tags=("mediadive",))
+        mock_bulk.assert_called_once()
+
+    def test_mediadive_bulk_runs_without_tags(self, tmp_path):
+        """An unfiltered run keeps its existing behaviour."""
+        _, mock_bulk = self._run(tmp_path)
+        mock_bulk.assert_called_once()
+
+    def test_unknown_tag_raises(self, tmp_path):
+        """An unknown tag downloads nothing, which looks like success — so fail."""
+        with patch.object(download_module, "download_from_yaml") as mock_yaml:
+            with pytest.raises(ValueError, match="Unknown download tag"):
+                download_module.download(
+                    yaml_file=str(DOWNLOAD_YAML),
+                    output_dir=str(tmp_path),
+                    snippet_only=False,
+                    tags=("ontolgies",),  # typo
+                )
+        mock_yaml.assert_not_called()
+
+    def test_error_lists_available_tags(self, tmp_path):
+        """The message should tell the user what they could have typed."""
+        with patch.object(download_module, "download_from_yaml"):
+            with pytest.raises(ValueError, match="ontologies"):
+                download_module.download(
+                    yaml_file=str(DOWNLOAD_YAML),
+                    output_dir=str(tmp_path),
+                    snippet_only=False,
+                    tags=("nope",),
+                )
+
+    def test_snippet_mode_still_skips_bulk(self, tmp_path):
+        """Snippet mode skipped the bulk step before tags existed; keep that."""
+        with (
+            patch.object(download_module, "download_from_yaml"),
+            patch.object(download_module, "_post_download_mediadive_bulk") as mock_bulk,
+        ):
+            download_module.download(
+                yaml_file=str(DOWNLOAD_YAML),
+                output_dir=str(tmp_path),
+                snippet_only=True,
+                tags=("mediadive",),
+            )
+        mock_bulk.assert_not_called()

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -35,6 +35,27 @@ KNOWN_TAGS = {
 }
 
 
+def _documented_tags():
+    """
+    Parse the tag names out of download.yaml's header comment block.
+
+    KNOWN_TAGS is otherwise a hand-copied duplicate: adding a tag to the test set
+    without adding it to the header leaves the header — which `kg download --help`
+    points users at — silently stale.
+    """
+    import re
+
+    tags = set()
+    with open(DOWNLOAD_YAML) as f:
+        for line in f:
+            if line.startswith("---"):
+                break
+            m = re.match(r"#\s{4}([a-z_]+)\s{2,}\S", line)
+            if m:
+                tags.add(m.group(1))
+    return tags
+
+
 def _entries():
     """Return the active (uncommented) resource entries in download.yaml."""
     with open(DOWNLOAD_YAML) as f:
@@ -62,13 +83,31 @@ class TestYamlTagging:
 
     def test_urls_have_no_surrounding_whitespace(self):
         """A stray space becomes part of the URL handed to urllib (#623)."""
-        offenders = [e["local_name"] for e in _entries() if e["url"] != e["url"].strip()]
+        # .get(): `url` is absent on `api: elasticsearch` entries and `local_name`
+        # is Optional in DownloadableResource, so indexing would turn a legal
+        # entry of either shape into a KeyError instead of a clear failure.
+        offenders = [
+            e.get("local_name") or e.get("url")
+            for e in _entries()
+            if (e.get("url") or "") != (e.get("url") or "").strip()
+        ]
         assert offenders == [], f"entries with padded URLs: {offenders}"
 
     def test_local_names_have_no_surrounding_whitespace(self):
         """Same hazard for the destination path."""
-        offenders = [e["local_name"] for e in _entries() if e["local_name"] != e["local_name"].strip()]
+        offenders = [
+            e.get("local_name")
+            for e in _entries()
+            if (e.get("local_name") or "") != (e.get("local_name") or "").strip()
+        ]
         assert offenders == []
+
+    def test_header_documents_exactly_the_known_tags(self):
+        """download.yaml's header and KNOWN_TAGS must not drift apart."""
+        documented = _documented_tags()
+        assert documented == KNOWN_TAGS, (
+            f"only in header: {sorted(documented - KNOWN_TAGS)}; only in KNOWN_TAGS: {sorted(KNOWN_TAGS - documented)}"
+        )
 
     def test_mediadive_tag_matches_the_constant(self):
         """The bulk-download gate keys off this exact tag string."""

--- a/tests/test_go_version_alignment.py
+++ b/tests/test_go_version_alignment.py
@@ -239,6 +239,7 @@ def _stub_go_transform(tmp_path, monkeypatch):
     calls = {"convert": 0}
 
     def fake_convert(path, ont):
+        """Stand in for ROBOT owl->json: count the call, write a fresh go.json."""
         calls["convert"] += 1
         (Path(path) / f"{ont}.json").write_text(_JSON.format(d="2026-05-19"), encoding="utf-8")
 

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -1,18 +1,32 @@
 """Tests for mediadive_bulk_download utility."""
 
+import inspect
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
+from importlib import import_module
 from unittest.mock import MagicMock, patch
 
 import requests
 
 from kg_microbe.utils.mediadive_bulk_download import (
+    CACHE_FILENAME,
     DEFAULT_MAX_WORKERS,
     USER_AGENT,
+    _delete_cache,
+    _make_session,
+    _reset_sessions,
     download_detailed_media,
+    download_mediadive_bulk,
     download_medium_strains,
     get_json_from_api,
+    setup_cache,
 )
+
+# kg_microbe/__init__.py does `from .download import download`, so the name
+# kg_microbe.download resolves to the *function*, not the module. Fetch the
+# module from sys.modules so patch.object targets the right object.
+download_module = import_module("kg_microbe.download")
 
 
 class TestDefaults:
@@ -42,6 +56,234 @@ class TestDefaults:
         with patch("kg_microbe.utils.mediadive_bulk_download.get_json_from_api", return_value=[{"strain": "A"}]):
             result = download_medium_strains(media_list, max_workers=2)
         assert isinstance(result, dict)
+
+
+class TestCacheThreadSafety:
+
+    """
+    Verify HTTP sessions are never shared across threads.
+
+    requests_cache's SQLiteDict holds one sqlite3.Connection for all callers and
+    takes no lock on reads, so sharing a CachedSession across a ThreadPoolExecutor
+    raises "database disk image is malformed" against an intact database. Each
+    thread must get its own session, and therefore its own connection.
+    """
+
+    def teardown_method(self):
+        """Disable caching and drop per-thread sessions between tests."""
+        setup_cache(None)
+
+    def test_setup_cache_creates_db_in_given_dir(self, tmp_path):
+        """The cache database belongs next to the bulk output, not in the CWD."""
+        cache_path = setup_cache(tmp_path)
+        assert cache_path == tmp_path / CACHE_FILENAME
+        assert cache_path.exists()
+
+    # These assert injectivity (no object seen from two different threads) rather
+    # than an exact count. ThreadPoolExecutor spawns workers lazily, so with fast
+    # tasks fewer than max_workers threads ever run and `== n_threads` failed
+    # ~75% of runs in isolation while passing under a slower full-suite run.
+    def test_each_thread_gets_its_own_session(self, tmp_path):
+        """_make_session must never hand the same session to two threads."""
+        setup_cache(tmp_path)
+        n_threads = 5
+
+        def grab(_):
+            """Return (thread id, session) for this call."""
+            session = _make_session()
+            return threading.get_ident(), session
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(grab, range(n_threads * 20)))
+
+        owners = {}
+        for tid, session in results:
+            owners.setdefault(id(session), set()).add(tid)
+        shared = {sid: tids for sid, tids in owners.items() if len(tids) > 1}
+        assert shared == {}, f"sessions shared across threads: {shared}"
+        assert len({tid for tid, _ in results}) > 1, "test did not exercise concurrency"
+        assert all(s.headers["User-Agent"] == USER_AGENT for _, s in results)
+
+    def test_each_session_has_its_own_sqlite_connection(self, tmp_path):
+        """A sqlite3.Connection must never be reached from two threads."""
+        setup_cache(tmp_path)
+        n_threads = 4
+
+        def open_connection(_):
+            """Force this thread's backend to open its connection; return (tid, id)."""
+            session = _make_session()
+            with session.cache.responses.connection() as con:
+                return threading.get_ident(), id(con)
+
+        with ThreadPoolExecutor(max_workers=n_threads) as executor:
+            results = list(executor.map(open_connection, range(n_threads * 20)))
+
+        owners = {}
+        for tid, con_id in results:
+            owners.setdefault(con_id, set()).add(tid)
+        shared = {cid: tids for cid, tids in owners.items() if len(tids) > 1}
+        assert shared == {}, f"connections shared across threads: {shared}"
+        assert len({tid for tid, _ in results}) > 1, "test did not exercise concurrency"
+
+    def test_reset_closes_sessions_from_other_threads(self, tmp_path):
+        """Discarded sessions must be closed, not left to garbage collection (#617)."""
+        setup_cache(tmp_path)
+        closed = []
+
+        def build_and_track(_):
+            """Create this thread's session and wrap close() to record the call."""
+            session = _make_session()
+            original = session.close
+
+            def close():
+                """Record that close was called, then really close."""
+                closed.append(id(session))
+                original()
+
+            session.close = close
+            return id(session)
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            ids = set(executor.map(build_and_track, range(9)))
+
+        _reset_sessions()
+        assert set(closed) == ids, "every per-thread session should have been closed"
+
+    def test_repeated_calls_reuse_the_same_thread_session(self, tmp_path):
+        """Within one thread, _make_session must be idempotent (no session churn)."""
+        setup_cache(tmp_path)
+        assert _make_session() is _make_session()
+
+    def test_caching_is_not_installed_globally(self, tmp_path):
+        """setup_cache must not monkeypatch requests.Session for the whole process."""
+        setup_cache(tmp_path)
+        assert type(requests.Session()) is requests.Session
+        assert not hasattr(requests.Session(), "cache")
+
+    def test_disabled_cache_yields_plain_sessions(self):
+        """With caching off, sessions are plain requests.Session objects."""
+        setup_cache(None)
+        _reset_sessions()
+        assert type(_make_session()) is requests.Session
+
+    def test_existing_cache_is_adopted_when_requested(self, tmp_path, monkeypatch):
+        """With migrate_legacy=True, a cache left in the CWD by the old code is reused."""
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        legacy = cwd / CACHE_FILENAME
+        legacy.write_bytes(b"")
+
+        cache_path = setup_cache(tmp_path / "out", migrate_legacy=True)
+
+        assert cache_path.exists()
+        assert not legacy.exists(), "legacy cache should be moved, not left behind"
+
+    def test_clear_discards_cached_responses(self, tmp_path):
+        """clear=True must drop cached responses so the API is re-queried."""
+        setup_cache(tmp_path)
+        session = _make_session()
+        session.cache.responses["some-key"] = "cached-value"
+        assert len(session.cache.responses) == 1
+
+        setup_cache(tmp_path, clear=True)
+
+        assert len(_make_session().cache.responses) == 0
+
+    def test_clear_removes_wal_sidecar_files(self, tmp_path):
+        """
+        WAL mode leaves -wal/-shm files behind; clearing must not orphan them.
+
+        Asserts on the state right after _delete_cache. Going through
+        setup_cache(clear=True) instead would be vacuous: it calls _make_backend()
+        immediately afterwards, which reopens the DB in WAL mode and recreates the
+        sidecars, so the assertion passed even with the deletion reverted.
+        """
+        cache_path = setup_cache(tmp_path)
+        for suffix in ("-wal", "-shm"):
+            cache_path.with_name(cache_path.name + suffix).write_bytes(b"stale")
+
+        _delete_cache(cache_path)
+
+        assert not cache_path.exists()
+        for suffix in ("-wal", "-shm"):
+            sidecar = cache_path.with_name(cache_path.name + suffix)
+            assert not sidecar.exists(), f"{sidecar.name} survived the clear"
+
+    def test_clear_is_off_by_default(self, tmp_path):
+        """Without clear=True, an existing cache survives setup_cache."""
+        setup_cache(tmp_path)
+        _make_session().cache.responses["keep-me"] = "cached-value"
+
+        setup_cache(tmp_path)
+
+        assert "keep-me" in _make_session().cache.responses
+
+    def test_migration_moves_wal_sidecars(self, tmp_path, monkeypatch):
+        """WAL sidecars must travel with the DB, not be orphaned in the CWD (#622)."""
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        legacy = cwd / CACHE_FILENAME
+        legacy.write_bytes(b"")
+        for suffix in ("-wal", "-shm"):
+            legacy.with_name(legacy.name + suffix).write_bytes(b"sidecar")
+
+        cache_path = setup_cache(tmp_path / "out", migrate_legacy=True)
+
+        for suffix in ("-wal", "-shm"):
+            assert not legacy.with_name(legacy.name + suffix).exists(), f"{suffix} orphaned in CWD"
+        assert cache_path.exists()
+
+    def test_cwd_cache_is_untouched_by_default(self, tmp_path, monkeypatch):
+        """
+        setup_cache must not move files outside cache_dir unless asked.
+
+        Regression guard: an unconditional migration meant any setup_cache call —
+        including from a test suite — would relocate a real cache sitting in the CWD.
+        """
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        bystander = cwd / CACHE_FILENAME
+        bystander.write_bytes(b"do not move me")
+
+        setup_cache(tmp_path / "out")
+
+        assert bystander.exists(), "default setup_cache must not touch the CWD"
+        assert bystander.read_bytes() == b"do not move me"
+
+
+class TestIgnoreCachePlumbing:
+
+    """
+    Verify `kg download --ignore-cache` reaches the HTTP response cache.
+
+    Rebuilding the bulk JSON files from a warm HTTP cache reproduces the old
+    data byte for byte, so --ignore-cache has to clear that cache too.
+    """
+
+    def _write_basic_media(self, tmp_path):
+        """Create the mediadive.json that _post_download_mediadive_bulk looks for."""
+        (tmp_path / "mediadive.json").write_text('{"data": [{"id": 1}]}')
+
+    def test_ignore_cache_is_forwarded(self, tmp_path):
+        """ignore_cache=True must reach download_mediadive_bulk."""
+        self._write_basic_media(tmp_path)
+        with patch.object(download_module, "download_mediadive_bulk") as mock_bulk:
+            download_module._post_download_mediadive_bulk(str(tmp_path), ignore_cache=True)
+        assert mock_bulk.call_args.kwargs["ignore_cache"] is True
+
+    def test_default_leaves_cache_intact(self, tmp_path):
+        """Without --ignore-cache, cached HTTP responses must be reused."""
+        self._write_basic_media(tmp_path)
+        with patch.object(download_module, "download_mediadive_bulk") as mock_bulk:
+            download_module._post_download_mediadive_bulk(str(tmp_path))
+        assert mock_bulk.call_args.kwargs["ignore_cache"] is False
+
+    def test_bulk_download_accepts_ignore_cache(self):
+        """download_mediadive_bulk must expose ignore_cache for the CLI to pass."""
+        assert "ignore_cache" in inspect.signature(download_mediadive_bulk).parameters
 
 
 class TestRetryAfter:

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -1,12 +1,15 @@
 """Tests for mediadive_bulk_download utility."""
 
 import inspect
+import json
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 from kg_microbe.utils.mediadive_bulk_download import (
@@ -252,6 +255,100 @@ class TestCacheThreadSafety:
 
         assert bystander.exists(), "default setup_cache must not touch the CWD"
         assert bystander.read_bytes() == b"do not move me"
+
+
+class TestBulkDownloadEndToEnd:
+
+    """
+    Exercise download_mediadive_bulk against a local HTTP server.
+
+    The rest of the suite mocks at or above download_mediadive_bulk, so the
+    behaviour that actually matters — cache warm/cold, --ignore-cache really
+    re-fetching, sessions torn down — was verifiable only by hand. Mutating
+    `clear=ignore_cache` to `clear=False` left the whole suite green (#630).
+    """
+
+    @staticmethod
+    def _serve(hits):
+        """Start a local HTTP server that answers every MediaDive path, counting hits."""
+        import http.server
+        import threading as th
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+
+            """Answer any path with a MediaDive-shaped payload."""
+
+            def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's API
+                """Return a minimal MediaDive-shaped payload and count the request."""
+                hits.append(self.path)
+                body = json.dumps({"data": {"id": 1, "solutions": []}}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                """Silence the default stderr logging."""
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        th.Thread(target=server.serve_forever, daemon=True).start()
+        return server
+
+    @pytest.fixture
+    def runner(self, tmp_path, monkeypatch):
+        """
+        Yield a callable that runs the bulk download against one local server.
+
+        The server must outlive every run in a test: a fresh port would change the
+        request URLs, and the HTTP cache is keyed by URL — so a second run would
+        "miss" for the wrong reason and the test would prove nothing.
+        """
+        hits = []
+        server = self._serve(hits)
+        monkeypatch.setattr(
+            "kg_microbe.utils.mediadive_bulk_download.MEDIADIVE_REST_API_BASE_URL",
+            f"http://127.0.0.1:{server.server_port}/",
+        )
+        basic = tmp_path / "mediadive.json"
+        basic.write_text(json.dumps({"data": [{"id": i} for i in range(5)]}))
+        out = tmp_path / "mediadive"
+
+        def run(*, ignore_cache=False):
+            """Run once; return how many requests reached the server."""
+            hits.clear()
+            download_mediadive_bulk(str(basic), str(out), ignore_cache=ignore_cache)
+            return len(hits)
+
+        try:
+            yield run
+        finally:
+            server.shutdown()
+
+    def test_second_run_is_served_from_cache(self, runner):
+        """A warm HTTP cache means no network on the second run."""
+        first = runner()
+        assert first > 0, "the first run must actually fetch"
+        assert runner() == 0, "the second run must hit the cache"
+
+    def test_ignore_cache_really_refetches(self, runner):
+        """--ignore-cache must clear the response cache, not just rebuild the JSON."""
+        first = runner()
+        assert runner() == 0, "cache should be warm"
+        assert runner(ignore_cache=True) == first, "--ignore-cache must re-fetch everything"
+
+    def test_sessions_are_torn_down(self, runner):
+        """The finally: _reset_sessions() teardown must leave nothing open."""
+        from kg_microbe.utils import mediadive_bulk_download as mb
+
+        runner()
+        assert mb._live_sessions == [], "every per-thread session should be closed"
+
+    def test_cache_db_lands_beside_the_output(self, runner, tmp_path):
+        """The cache belongs in the output dir, not the working directory."""
+        runner()
+        assert (tmp_path / "mediadive" / CACHE_FILENAME).exists()
+        assert not (Path.cwd() / CACHE_FILENAME).exists()
 
 
 class TestIgnoreCachePlumbing:

--- a/tests/test_metatraits_gzip_tolerance.py
+++ b/tests/test_metatraits_gzip_tolerance.py
@@ -1,0 +1,163 @@
+"""
+Tests that Drive-hosted MetaTraits inputs survive arriving decompressed.
+
+Google Drive silently serves some uploads decompressed, so a file named `*.gz`
+can be plain text. This already happened to `ncbi_*_summary.jsonl.gz`, which sit
+in `data/raw` as plain JSON under a `.gz` name. Any read of a Drive-hosted input
+must tolerate both forms.
+"""
+
+import gzip
+
+from kg_microbe.transform_utils.metatraits import metatraits as mt
+
+CROSSWALK_HEADER = "taxonID NCBI\ttaxonID GTDB\tspecies (NCBI)\tgenus (GTDB)\tspecies (GTDB)\n"
+CROSSWALK_ROW = "562\t599451526\tEscherichia coli\tEscherichia\tEscherichia coli\n"
+
+
+def _write_gzipped(path, text):
+    """Write real gzip-compressed text."""
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        f.write(text)
+
+
+def _write_plain(path, text):
+    """Write plain text under whatever name the caller chose (e.g. a .gz name)."""
+    path.write_text(text, encoding="utf-8")
+
+
+class TestOpenMaybeGzipped:
+
+    """_open_maybe_gzipped must read both real gzip and misnamed plain text."""
+
+    def test_reads_real_gzip(self, tmp_path):
+        """A genuinely compressed .gz still works."""
+        path = tmp_path / "sample.tsv.gz"
+        _write_gzipped(path, "hello\n")
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+    def test_reads_plain_text_named_gz(self, tmp_path):
+        """A .gz that Drive decompressed must not raise BadGzipFile."""
+        path = tmp_path / "sample.tsv.gz"
+        _write_plain(path, "hello\n")
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+    def test_reads_uncompressed_name(self, tmp_path):
+        """A file with no .gz suffix opens as plain text."""
+        path = tmp_path / "sample.tsv"
+        _write_plain(path, "hello\n")
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+    def test_open_jsonl_delegates(self, tmp_path):
+        """_open_jsonl keeps its tolerant behaviour after the refactor."""
+        path = tmp_path / "sample.jsonl.gz"
+        _write_plain(path, '{"tax_name": "x"}\n')
+        with mt._open_jsonl(path) as f:
+            assert "tax_name" in f.read()
+
+    def test_probe_handle_is_closed_on_fallback(self, tmp_path, monkeypatch):
+        """The failed gzip probe must not leak its handle (#621)."""
+        path = tmp_path / "sample.tsv.gz"
+        _write_plain(path, "hello\n")
+        opened = []
+
+        real_gzip_open = mt.gzip.open
+
+        def tracking_open(*args, **kwargs):
+            """Wrap gzip.open so we can see whether the probe handle gets closed."""
+            handle = real_gzip_open(*args, **kwargs)
+            opened.append(handle)
+            return handle
+
+        monkeypatch.setattr(mt.gzip, "open", tracking_open)
+
+        with mt._open_maybe_gzipped(path) as f:
+            assert f.read() == "hello\n"
+
+        assert len(opened) == 1, "the gzip probe should have run once"
+        assert opened[0].closed, "the probe handle must be closed before falling back"
+
+
+class TestCrosswalkLoading:
+
+    """
+    NCBI2GTDB.tsv.gz must load whether or not it arrives compressed.
+
+    _load_ncbi_gtdb_mappings wraps its read in `except Exception`, so a
+    BadGzipFile there does not crash the transform — it silently produces zero
+    mappings and the NCBI->GTDB fallback quietly stops working. That silent
+    degradation is the regression these tests guard.
+    """
+
+    def _load_from(self, tmp_path, monkeypatch, writer):
+        """Point the loader at a temp NCBI2GTDB file written by `writer`."""
+        writer(tmp_path / "NCBI2GTDB.tsv.gz", CROSSWALK_HEADER + CROSSWALK_ROW)
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+        return transform._load_ncbi_gtdb_mappings()
+
+    def test_loads_from_real_gzip(self, tmp_path, monkeypatch):
+        """The normal case: a properly compressed crosswalk."""
+        mappings = self._load_from(tmp_path, monkeypatch, _write_gzipped)
+        assert mappings["escherichia coli"]["gtdb_genus"] == "Escherichia"
+
+    def test_loads_from_decompressed_gz(self, tmp_path, monkeypatch):
+        """The Drive case: same content, not actually compressed."""
+        mappings = self._load_from(tmp_path, monkeypatch, _write_plain)
+        assert mappings["escherichia coli"]["gtdb_genus"] == "Escherichia", (
+            "a decompressed .gz must still yield mappings, not silently zero"
+        )
+
+    def test_garbage_payload_is_reported_not_announced_as_success(self, tmp_path, monkeypatch, capsys):
+        """
+        A non-gzip error page must not print the success line (F6).
+
+        Tolerating a decompressed .gz is right for the Drive-hosted inputs, but it
+        also means an HTML quota interstitial reads as an empty table. Master's
+        bare gzip.open at least raised BadGzipFile here; the tolerant reader has
+        to say something instead of "Loaded 0 ... mappings".
+        """
+        (tmp_path / "NCBI2GTDB.tsv.gz").write_text("<html><body>Quota exceeded</body></html>", encoding="utf-8")
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+
+        assert transform._load_ncbi_gtdb_mappings() == {}
+        out = capsys.readouterr().out
+        assert "Warning" in out, "an unusable crosswalk must warn"
+        assert "no usable rows" in out or "no NCBI to GTDB mappings" in out
+
+    def test_empty_file_is_reported(self, tmp_path, monkeypatch, capsys):
+        """A 0-byte download is the other realistic gdrive failure mode."""
+        (tmp_path / "NCBI2GTDB.tsv.gz").write_bytes(b"")
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+
+        assert transform._load_ncbi_gtdb_mappings() == {}
+        assert "Warning" in capsys.readouterr().out
+
+    def test_partial_read_reports_how_much_loaded(self, tmp_path, monkeypatch, capsys):
+        """A truncated body yields a partial crosswalk; the count must be stated."""
+        import gzip as gz
+
+        path = tmp_path / "NCBI2GTDB.tsv.gz"
+        rows = "".join(f"{i}\t{i}\tSpecies {i}\tGenus{i}\tSpecies {i}\n" for i in range(2000))
+        with gz.open(path, "wt", encoding="utf-8") as f:
+            f.write(CROSSWALK_HEADER + rows)
+        path.write_bytes(path.read_bytes()[: path.stat().st_size // 2])  # truncate body
+
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+        mappings = transform._load_ncbi_gtdb_mappings()
+
+        out = capsys.readouterr().out
+        assert "Could not fully load" in out
+        assert f"{len(mappings)} mappings loaded" in out
+
+    def test_missing_file_yields_empty_mapping(self, tmp_path, monkeypatch):
+        """An absent crosswalk is tolerated (pre-existing behaviour)."""
+        monkeypatch.setattr(mt, "RAW_DATA_DIR", tmp_path)
+        transform = mt.MetaTraitsTransform.__new__(mt.MetaTraitsTransform)
+        assert transform._load_ncbi_gtdb_mappings() == {}

--- a/tests/test_metatraits_gzip_tolerance.py
+++ b/tests/test_metatraits_gzip_tolerance.py
@@ -58,27 +58,65 @@ class TestOpenMaybeGzipped:
         with mt._open_jsonl(path) as f:
             assert "tax_name" in f.read()
 
-    def test_probe_handle_is_closed_on_fallback(self, tmp_path, monkeypatch):
-        """The failed gzip probe must not leak its handle (#621)."""
-        path = tmp_path / "sample.tsv.gz"
-        _write_plain(path, "hello\n")
+    @staticmethod
+    def _track_probes(monkeypatch):
+        """Wrap gzip.open so a test can see whether probe handles get closed."""
         opened = []
-
         real_gzip_open = mt.gzip.open
 
         def tracking_open(*args, **kwargs):
-            """Wrap gzip.open so we can see whether the probe handle gets closed."""
+            """Record every handle gzip.open hands out."""
             handle = real_gzip_open(*args, **kwargs)
             opened.append(handle)
             return handle
 
         monkeypatch.setattr(mt.gzip, "open", tracking_open)
+        return opened
+
+    def test_probe_handle_is_closed_on_fallback(self, tmp_path, monkeypatch):
+        """The failed gzip probe must not leak its handle (#621)."""
+        path = tmp_path / "sample.tsv.gz"
+        _write_plain(path, "hello\n")
+        opened = self._track_probes(monkeypatch)
 
         with mt._open_maybe_gzipped(path) as f:
             assert f.read() == "hello\n"
 
         assert len(opened) == 1, "the gzip probe should have run once"
         assert opened[0].closed, "the probe handle must be closed before falling back"
+
+    def test_probe_handle_is_closed_for_a_header_truncated_gz(self, tmp_path, monkeypatch):
+        """
+        A .gz truncated inside its header raises EOFError, not BadGzipFile (#629).
+
+        The original close() only ran on BadGzipFile, so this realistic
+        partial-download shape leaked the handle — silently, since callers wrap
+        the read in `except Exception`.
+        """
+        real = tmp_path / "real.gz"
+        _write_gzipped(real, "hello\n")
+        path = tmp_path / "sample.tsv.gz"
+        path.write_bytes(real.read_bytes()[:5])  # cut inside the 10-byte header
+        opened = self._track_probes(monkeypatch)
+
+        handle = mt._open_maybe_gzipped(path)
+        handle.close()
+
+        assert opened, "the probe should have opened a handle"
+        assert all(h.closed for h in opened), "every probe handle must be closed"
+
+    def test_probe_handle_is_closed_for_undecodable_content(self, tmp_path, monkeypatch):
+        """A payload that is gzip but not UTF-8 raises UnicodeDecodeError (#629)."""
+        path = tmp_path / "sample.tsv.gz"
+        with gzip.open(path, "wb") as f:
+            f.write(b"\xff\xfe\x00binary\x80\x81")
+        opened = self._track_probes(monkeypatch)
+
+        handle = mt._open_maybe_gzipped(path)
+        handle.close()
+
+        assert opened
+        assert all(h.closed for h in opened), "every probe handle must be closed"
 
 
 class TestCrosswalkLoading:

--- a/tests/test_stub_source_single_source.py
+++ b/tests/test_stub_source_single_source.py
@@ -1,0 +1,85 @@
+"""
+Tests that each stub-import ontology has exactly one declared source.
+
+Part of #604. A stub source read via ROBOT MIREOT against an OWL must not also
+have a SemSQL ``.db`` download, and vice versa: two independently-versioned
+copies of the same ontology can drift with nothing to detect it, which is how
+``po.db.gz`` came to be downloaded (and never decompressed) while PO's hierarchy
+was actually built from ``po.owl``.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from kg_microbe.transform_utils.ontologies_stubs.ontologies_stubs_transform import (
+    STUB_ONTOLOGY_SOURCES,
+)
+
+DOWNLOAD_YAML = Path(__file__).parent.parent / "download.yaml"
+
+
+def _local_names():
+    """Return the set of local_name values declared in download.yaml."""
+    with open(DOWNLOAD_YAML) as f:
+        return {e["local_name"] for e in (yaml.safe_load(f) or [])}
+
+
+class TestPoIsOwlOnly:
+
+    """PO's hierarchy comes from the OWL; no SemSQL DB should be fetched."""
+
+    def test_po_stub_uses_owl_mireot(self):
+        """The invariant that makes po.db unnecessary."""
+        po = STUB_ONTOLOGY_SOURCES["PO"]
+        assert po["source_type"] == "owl_mireot"
+        assert po["owl_filename"] == "po.owl"
+        assert "db_filename" not in po
+
+    def test_po_owl_is_downloaded(self):
+        """The source PO actually reads must be declared."""
+        assert "po.owl" in _local_names()
+
+    def test_po_semsql_db_is_not_downloaded(self):
+        """A PO SemSQL DB would be a second, ungated copy of PO."""
+        assert "po.db.gz" not in _local_names()
+        assert "po.db" not in _local_names()
+
+
+class TestNoStubHasTwoSources:
+
+    """Generalise the rule across every stub source."""
+
+    def test_owl_backed_stubs_have_no_db_download(self):
+        """An owl_mireot source must not also ship a SemSQL DB."""
+        offenders = []
+        names = _local_names()
+        for prefix, cfg in STUB_ONTOLOGY_SOURCES.items():
+            if cfg.get("source_type") != "owl_mireot":
+                continue
+            stem = Path(cfg["owl_filename"]).stem
+            if f"{stem}.db.gz" in names or f"{stem}.db" in names:
+                offenders.append(prefix)
+        assert offenders == [], f"owl-backed stubs with a redundant .db download: {offenders}"
+
+    def test_db_backed_stubs_have_no_owl_download(self):
+        """A SemSQL-backed source must not also ship an OWL of the same ontology."""
+        offenders = []
+        names = _local_names()
+        for prefix, cfg in STUB_ONTOLOGY_SOURCES.items():
+            db_filename = cfg.get("db_filename")
+            if not db_filename:
+                continue
+            stem = Path(db_filename).stem
+            if f"{stem}.owl" in names or f"{stem}.owl.gz" in names:
+                offenders.append(prefix)
+        assert offenders == [], f"db-backed stubs with a redundant OWL download: {offenders}"
+
+    def test_every_stub_declares_a_source(self):
+        """No stub entry should be missing both an OWL and a DB."""
+        missing = [
+            prefix
+            for prefix, cfg in STUB_ONTOLOGY_SOURCES.items()
+            if not cfg.get("owl_filename") and not cfg.get("db_filename") and not cfg.get("nt_filename")
+        ]
+        assert missing == [], f"stub sources with nothing to read: {missing}"


### PR DESCRIPTION
Split out of #612. This is the download half — self-contained, and it has
survived five review rounds without a defect being found in it. The SemSQL
single-source work is stacked on top of this branch as a separate PR, because
that is where every regression across those rounds occurred.

## MediaDive cache corruption

`kg download` died at request 3 of 3338 with
`sqlite3.DatabaseError: database disk image is malformed`, against a cache that
was provably intact — `PRAGMA integrity_check` ok, a full 6044-row scan fine from
the same interpreter, and an mtime showing the run never wrote to it.

`requests_cache`'s `SQLiteDict` holds a **single** `sqlite3.Connection` for all
callers (opened `check_same_thread=False`) and takes no lock on reads, so sharing
one `CachedSession` across a `ThreadPoolExecutor` ran concurrent `execute()` calls
on one connection — corrupting its pager state and making SQLite report
`SQLITE_CORRUPT` about a healthy file.

Each thread now builds its own session, and therefore its own connection.
**Verified** by replaying 1500 cached URLs through 5 threads against a copy of the
real 51 MB cache: 1500 hits, 0 errors, 0 network.

Also: drops the global `install_cache()` monkeypatch for explicit module-scoped
caching, moves the DB out of the repo root into `data/raw/mediadive/`, closes
per-thread sessions in a `finally`, and makes `--ignore-cache` actually clear the
response cache (it previously rebuilt the bulk JSON from the same cached
responses, so the flag could not refresh anything).

## Tag-filtered downloads

`kghub-downloader` supports tag filtering; it was unwired end to end. All 52
active entries are tagged across 15 groups, with a repeatable `-t/--tag`.

Two things the bare library filter gets wrong: an unknown tag downloads zero
files and exits 0 (now rejected up front, and narrowly enough that
`JSONDecodeError`/pydantic `ValidationError` from deeper in the download are no
longer mislabelled as bad tags), and the MediaDive bulk step fired whenever
`mediadive.json` existed — so `kg download -t ontologies` would have started an
hour of API calls.

## Pinned inputs

Six previously-unfetchable files (five MetaTraits/GTDB behind a dead endpoint,
BactoTraits behind a broken TLS chain) are now declared normally and pinned to
hosted copies, md5 recorded inline. Sources with no hosted replacement use a
`REPLACE_ME_` placeholder that `kg download` skips and reports, so a placeholder
can never abort a run. All six verified end to end — fetched and reproduced their
pinned checksums.

Reads of Drive-hosted inputs go through `_open_maybe_gzipped`, because Drive
serves some `.gz` uploads decompressed (already demonstrated on
`ncbi_*_summary.jsonl.gz`), and a garbage payload now warns rather than reporting
`Loaded 0 mappings`.

Also removes the `po.db.gz` download: PO's stub import is `owl_mireot` against
`po.owl`, nothing ever read `po.db`, and the archive was never even decompressed.

Research note: the `gtdb_*` / `NCBI2GTDB` / `GTDB2NCBI` files are **not** GTDB
downloads despite the names — GTDB publishes only taxonomy, metadata, trees and
MSA files. They are MetaTraits (EMBL) products keyed by GTDB taxonomy.

## Testing

`poetry run tox` green: **487 passed**, format/lint/codespell/docstr-coverage all
OK. The thread-safety tests assert injectivity rather than an exact thread count
(`ThreadPoolExecutor` spawns lazily, which made an earlier version fail 6 of 8
isolated runs); 0 of 10 failures now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)