### PR TITLE
Build ncbitaxon.db and chebi.db from the OWL we ship (#604)

### DIFF
--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -72,6 +72,24 @@ def _ncbitaxon_db_paths() -> Tuple[Path, Path]:
     )
 
 
+def _db_fingerprint(db_path: Path) -> Optional[Tuple[int, int]]:
+    """
+    Return (mtime_ns, size) for a DB, or None when it is absent.
+
+    Used to tell "this call built a new DB" from "the DB that was already there",
+    which decides whether the OAK-cache fallback may replace it. Checking "is a
+    real file" instead would also match a pre-existing DB and strand the run.
+
+    :param db_path: Path to fingerprint.
+    :return: (mtime_ns, size), or None if the path cannot be stat'ed.
+    """
+    try:
+        st = db_path.stat()
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
 def _validate_ncbitaxon_db(db_path: Path) -> Tuple[bool, str]:
     """
     Validate that db_path is a healthy NCBITaxon SQLite DB.
@@ -123,6 +141,7 @@ def _ensure_ncbitaxon_db_ready() -> None:
     # so lookups and emitted nodes are the same release by construction (#604).
     # A no-op when semsql or the OWL is unavailable, which leaves the OAK-cache
     # fallback below as the last resort.
+    before = _db_fingerprint(local_db)
     if _ensure_ncbitaxon_db(str(local_db)):
         built_ok, built_reason = _validate_ncbitaxon_db(local_db)
         if built_ok:
@@ -132,6 +151,17 @@ def _ensure_ncbitaxon_db_ready() -> None:
         # returns True on its reuse path, so this branch is usually reporting a
         # DB that was already present and still fails validation.
         print(f"  NCBITaxon DB at {local_db} still invalid after ensure ({built_reason})")
+        # Only a DB this call actually produced is worth protecting from the
+        # symlink fallback. Comparing the fingerprint is the honest test — "is a
+        # real file" would also match the pre-existing DB that has now failed
+        # validation twice, and keeping that would strand the run.
+        if _db_fingerprint(local_db) != before:
+            raise RuntimeError(
+                f"Built a fresh NCBITaxon DB at {local_db} but it failed validation "
+                f"({built_reason}). Not replacing it with the OAK cache, since that "
+                "would discard a build that takes hours. Inspect or delete it and "
+                "re-run."
+            )
 
     # Fallback: adopt OAK's prebuilt cache. Its release is whatever the upstream
     # CDN last published and may lag ncbitaxon.owl; assert_ncbitaxon_version_alignment
@@ -139,19 +169,12 @@ def _ensure_ncbitaxon_db_ready() -> None:
     if oak_cache.exists():
         cache_ok, cache_reason = _validate_ncbitaxon_db(oak_cache)
         if cache_ok:
-            # Never trade a real local DB for the symlink. _validate_ncbitaxon_db
-            # wraps an OAK query in a bare `except Exception`, so a transient
-            # adapter error would otherwise delete a 13 GB build that took hours
-            # and replace it with the very artifact this design avoids.
-            if local_db.is_symlink():
+            # Safe to replace: a DB built by this call is handled above (it
+            # raises rather than reaching here), so whatever is here now is a
+            # pre-existing file that failed validation both before and after the
+            # ensure. Self-healing to the cache is better than stranding the run.
+            if local_db.exists() or local_db.is_symlink():
                 local_db.unlink()
-            elif local_db.exists():
-                print(
-                    f"  Keeping the existing {local_db} rather than replacing it with "
-                    f"the OAK cache; it failed validation ({reason}) — delete it "
-                    "manually if it is genuinely corrupt."
-                )
-                return
             local_db.symlink_to(oak_cache)
             print(f"  Repaired symlink: {local_db} -> {oak_cache}")
             return

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -50,6 +50,10 @@ from kg_microbe.utils.metpo_predicates import (  # noqa: E402
 )
 from kg_microbe.utils.microbial_trait_mappings import load_microbial_trait_mappings  # noqa: E402
 from kg_microbe.utils.oak_utils import search_by_label  # noqa: E402
+
+# _NCBITAXON_DB_MIN_SIZE is single-sourced in ontology_utils, beside the
+# builder that enforces it (_ensure_ncbitaxon_db).
+from kg_microbe.utils.ontology_utils import _NCBITAXON_DB_MIN_SIZE  # noqa: E402
 from kg_microbe.utils.pandas_utils import drop_duplicates  # noqa: E402
 
 # Input file names (transform accepts either ncbi_* or metatraits_* convention)
@@ -58,11 +62,6 @@ METATRAITS_INPUT_FILES = [
     "ncbi_species_summary.jsonl.gz",
     "metatraits_species_summary.jsonl.gz",
 ]
-
-
-# Minimum plausible size for a healthy NCBITaxon OAK DB. Full file is ~12 GB;
-# any smaller and it's a partial extract/download, regardless of SQLite header.
-_NCBITAXON_DB_MIN_SIZE = 1_000_000_000  # 1 GB
 
 
 def _ncbitaxon_db_paths() -> Tuple[Path, Path]:
@@ -108,6 +107,8 @@ def _ensure_ncbitaxon_db_ready() -> None:
 
     Raises RuntimeError with remediation steps if no valid DB can be found.
     """
+    from kg_microbe.utils.ontology_utils import _ensure_ncbitaxon_db
+
     local_db, oak_cache = _ncbitaxon_db_paths()
 
     # Happy path: symlink resolves to a valid DB.
@@ -118,12 +119,39 @@ def _ensure_ncbitaxon_db_ready() -> None:
 
     print(f"  NCBITaxon DB at {local_db} invalid ({reason}); attempting repair")
 
-    # Attempt repair from OAK cache.
+    # Preferred repair: build from the ncbitaxon.owl this run emits nodes from,
+    # so lookups and emitted nodes are the same release by construction (#604).
+    # A no-op when semsql or the OWL is unavailable, which leaves the OAK-cache
+    # fallback below as the last resort.
+    if _ensure_ncbitaxon_db(str(local_db)):
+        built_ok, built_reason = _validate_ncbitaxon_db(local_db)
+        if built_ok:
+            print(f"  NCBITaxon DB ready from OWL: {local_db}")
+            return
+        # Deliberately does not claim a build happened: _ensure_ncbitaxon_db also
+        # returns True on its reuse path, so this branch is usually reporting a
+        # DB that was already present and still fails validation.
+        print(f"  NCBITaxon DB at {local_db} still invalid after ensure ({built_reason})")
+
+    # Fallback: adopt OAK's prebuilt cache. Its release is whatever the upstream
+    # CDN last published and may lag ncbitaxon.owl; assert_ncbitaxon_version_alignment
+    # surfaces that gap.
     if oak_cache.exists():
         cache_ok, cache_reason = _validate_ncbitaxon_db(oak_cache)
         if cache_ok:
-            if local_db.exists() or local_db.is_symlink():
+            # Never trade a real local DB for the symlink. _validate_ncbitaxon_db
+            # wraps an OAK query in a bare `except Exception`, so a transient
+            # adapter error would otherwise delete a 13 GB build that took hours
+            # and replace it with the very artifact this design avoids.
+            if local_db.is_symlink():
                 local_db.unlink()
+            elif local_db.exists():
+                print(
+                    f"  Keeping the existing {local_db} rather than replacing it with "
+                    f"the OAK cache; it failed validation ({reason}) — delete it "
+                    "manually if it is genuinely corrupt."
+                )
+                return
             local_db.symlink_to(oak_cache)
             print(f"  Repaired symlink: {local_db} -> {oak_cache}")
             return
@@ -136,11 +164,12 @@ def _ensure_ncbitaxon_db_ready() -> None:
         f"  local: {local_db} ({reason})\n"
         f"  cache: {oak_cache} ({'missing' if not oak_cache.exists() else 'invalid'})\n"
         "Remediation:\n"
-        "  1. Remove corrupt cache: rm ~/.data/oaklib/ncbitaxon.db\n"
-        "  2. Re-download sequentially (not in parallel):\n"
-        "     poetry run python -c 'from oaklib import get_adapter; "
-        'get_adapter("sqlite:obo:ncbitaxon")\'\n'
-        "  3. Re-run the transform."
+        "  1. Remove the local DB (a symlink here is safe to delete):\n"
+        "     rm data/raw/ncbitaxon.db\n"
+        "  2. Re-run the transform; it rebuilds from ncbitaxon.owl via `semsql make`.\n"
+        "     Refreshing OAK's prebuilt cache instead does NOT realign the release,\n"
+        "     and deleting ~/.data/oaklib/ncbitaxon.db while data/raw/ncbitaxon.db\n"
+        "     symlinks to it leaves a dangling link."
     )
 
 

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -449,15 +449,12 @@ class OntologiesTransform(Transform):
             # small molecules default to CHEBI_CATEGORY (biolink:ChemicalEntity)
             print("  Fixing ChEBI categories (detecting roles/macromolecules; default → CHEBI_CATEGORY)...")
 
-            # Create ChEBI adapter once to avoid file descriptor leaks
-            from oaklib import get_adapter
+            # Create ChEBI adapter once to avoid file descriptor leaks. Goes
+            # through get_chebi_adapter so chebi.db is built from (and checked
+            # against) the chebi.owl these nodes are emitted from.
+            from kg_microbe.utils.ontology_utils import get_chebi_adapter
 
-            from kg_microbe.transform_utils.constants import CHEBI_SOURCE
-
-            try:
-                chebi_adapter = get_adapter(f"sqlite:{CHEBI_SOURCE}")
-            except Exception:
-                chebi_adapter = get_adapter("sqlite:data/raw/chebi.db")
+            chebi_adapter = get_chebi_adapter()
 
             def fix_chebi_category(row):
                 """Fix ChEBI category (SmallMolecule/ChemicalRole) and replace deprecated categories."""

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -217,7 +217,7 @@ class OntologiesTransform(Transform):
                 # first (mirrors _ensure_go_db's rebuild) — otherwise the
                 # reconversion silently keeps the old release.
                 if _derived_json_is_stale(data_file, Path(json_path)):
-                    Path(json_path).unlink()
+                    Path(json_path).unlink(missing_ok=True)
                 if not Path(json_path).is_file():
                     convert_to_json(str(self.input_base_dir), name)
                 data_file = json_path

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -88,6 +88,11 @@ def _derived_json_is_stale(owl_path: Path, json_path: Path) -> bool:
     unreadable pair yields False so unstamped ``.owl`` inputs keep the prior
     "convert only if missing" behavior.
     """
+    # _read_head falls back to `<path>.gz`, so without this guard a *missing*
+    # X.json beside a stray X.json.gz would read as stale and the caller would
+    # unlink a path that does not exist.
+    if not json_path.exists():
+        return False
     owl_release = _obo_release_from_head(owl_path)
     json_release = _obo_release_from_head(json_path)
     return bool(owl_release and json_release and owl_release != json_release)
@@ -275,18 +280,36 @@ def _usable_db(db_path: str, min_size: int) -> bool:
     """
     Report whether a SemSQL DB at ``db_path`` is present and plausibly complete.
 
-    Every "we could not build; use what's there" exit must go through this rather
-    than bare ``os.path.exists``: a 0-byte or truncated ``chebi.db`` passes an
-    existence check, yields an adapter with no ``entailed_edge`` table, and makes
-    every ChEBI term fall through to the default category — the same silent
-    miscategorisation ``_GO_DB_MIN_SIZE`` was introduced to prevent. A symlinked
-    result is rejected too: it means a build landed somewhere else.
+    For the **post-build** check only: a symlink here means ``semsql`` followed a
+    stale link and the result landed somewhere else, so it is rejected. Use
+    :func:`_present_db` on the "could not build; use what's there" exits, where a
+    symlink is a legitimate way to supply a prebuilt DB.
+
+    :param db_path: Path to the DB.
+    :param min_size: Smallest plausible size for a complete build.
+    :return: True if the file is a usable, locally-built DB.
+    """
+    return _present_db(db_path, min_size) and not os.path.islink(db_path)
+
+
+def _present_db(db_path: str, min_size: int) -> bool:
+    """
+    Report whether a DB is present and plausibly complete, symlinks included.
+
+    Enforcing the size floor here is what stops a 0-byte or truncated
+    ``chebi.db`` from being accepted: it passes a bare ``os.path.exists``, yields
+    an adapter with no ``entailed_edge`` table, and makes every ChEBI term fall
+    through to the default category — the same silent miscategorisation
+    ``_GO_DB_MIN_SIZE`` was introduced to prevent.
+
+    Symlinks are accepted because pointing at a prebuilt DB is supported —
+    :func:`get_chebi_adapter`'s own error text suggests doing exactly that.
 
     :param db_path: Path to the DB.
     :param min_size: Smallest plausible size for a complete build.
     :return: True if the file is usable.
     """
-    return os.path.exists(db_path) and not os.path.islink(db_path) and os.path.getsize(db_path) >= min_size
+    return os.path.exists(db_path) and os.path.getsize(db_path) >= min_size
 
 
 def _read_head(path: Path, nbytes: int) -> Optional[str]:
@@ -331,17 +354,27 @@ def _clear_build_target(db_path: str) -> Optional[str]:
 
     A real file is moved aside rather than deleted, so a build that fails (OOM is
     a live risk on the 13 GB NCBITaxon build) can put it back instead of leaving
-    the caller with nothing.
+    the caller with nothing. The cost is peak disk during a rebuild: old + new,
+    so ~28 GB for NCBITaxon and ~3 GB for ChEBI, where deleting first needed only
+    the new copy. An orphaned ``<db>.prev`` from a killed process is adopted by
+    the next run rather than left forever.
 
     :param db_path: Build target to clear.
     :return: Path the previous DB was moved to, or None if there was nothing to keep.
     """
+    kept = f"{db_path}.prev"
     if not os.path.lexists(db_path):
+        # A previous run was killed between the move-aside and the build. Nothing
+        # else ever looks at .prev, so without this it is orphaned forever — for
+        # NCBITaxon a permanently stranded 14 GB file, with the DB still missing.
+        if os.path.exists(kept):
+            print(f"  Recovering {kept} left by an interrupted build")
+            os.replace(kept, db_path)
+            return _clear_build_target(db_path)
         return None
     if os.path.islink(db_path):
         os.remove(db_path)
         return None
-    kept = f"{db_path}.prev"
     if os.path.lexists(kept):
         os.remove(kept)
     os.replace(db_path, kept)
@@ -513,7 +546,7 @@ def _ensure_chebi_db(db_path: str) -> bool:
 
     min_size = _CHEBI_DB_MIN_SIZE
     owl_source = Path(CHEBI_SOURCE) if CHEBI_SOURCE else None
-    if _usable_db(db_path, min_size):
+    if _present_db(db_path, min_size):
         owl_release = _chebi_release_from_owl(owl_source) if owl_source else None
         db_release = _chebi_db_release(db_path)
         if not (owl_release and db_release and owl_release != db_release):
@@ -524,22 +557,22 @@ def _ensure_chebi_db(db_path: str) -> bool:
         )
     if not _semsql_build_enabled():
         print(f"Skipping ChEBI SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
-        return _usable_db(db_path, min_size)
+        return _present_db(db_path, min_size)
     # Checked before decompressing: without semsql there is nothing to build, and
     # unpacking ~1 GB only to then bail out is pure waste (#10).
     if shutil.which("semsql") is None:
         print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
-        return _usable_db(db_path, min_size)
+        return _present_db(db_path, min_size)
     if owl_source and not owl_source.exists():
         # semsql needs the plain OWL; the download ships chebi.owl.gz.
         archive = owl_source.with_suffix(owl_source.suffix + ".gz")
         if archive.exists():
             print(f"Decompressing {archive} for the ChEBI SemSQL build...")
             if not _decompress_atomically(archive, owl_source):
-                return _usable_db(db_path, min_size)
+                return _present_db(db_path, min_size)
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — ChEBI OWL source {owl_source} is missing")
-        return _usable_db(db_path, min_size)
+        return _present_db(db_path, min_size)
     kept = _clear_build_target(db_path)
     print(
         f"Building {db_path} from {owl_source} via `semsql make`.\n"
@@ -553,15 +586,23 @@ def _ensure_chebi_db(db_path: str) -> bool:
             check=True,
         )
     except (subprocess.CalledProcessError, OSError) as e:
+        # Expected build failures degrade: restore the old DB and report on it.
         print(f"Warning: failed to build {db_path}: {e}")
         _restore_build_target(db_path, kept)
         return _usable_db(db_path, min_size)
-    built = _usable_db(db_path, min_size)
-    if built:
-        _discard_kept_target(kept)
-    else:
+    except BaseException:  # noqa: BLE001 — KeyboardInterrupt/SIGTERM must not strand .prev
+        # Ctrl-C or a kill during a multi-hour build previously left the DB gone
+        # and a 14 GB .prev orphaned forever, since nothing ever looks at it again.
         _restore_build_target(db_path, kept)
-    return built
+        raise
+    if _usable_db(db_path, min_size):
+        _discard_kept_target(kept)
+        return True
+    # semsql can exit 0 having produced a short/misplaced file. Restore, then
+    # report on what is actually at db_path now — not the pre-restore verdict.
+    print(f"Warning: {db_path} is not a complete build; restoring the previous DB")
+    _restore_build_target(db_path, kept)
+    return _usable_db(db_path, min_size)
 
 
 @lru_cache(maxsize=None)
@@ -641,7 +682,7 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
 
     min_size = _NCBITAXON_DB_MIN_SIZE
     owl_source = Path(NCBITAXON_SOURCE) if NCBITAXON_SOURCE else None
-    if _usable_db(db_path, min_size):
+    if _present_db(db_path, min_size):
         owl_release = _obo_release_from_head(owl_source) if owl_source else None
         db_release = _ncbitaxon_db_release(db_path)
         if not (owl_release and db_release and owl_release != db_release):
@@ -652,12 +693,12 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
         )
     if not _semsql_build_enabled():
         print(f"Skipping NCBITaxon SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
-        return _usable_db(db_path, min_size)
+        return _present_db(db_path, min_size)
     # Checked before decompressing: without semsql there is nothing to build, and
     # unpacking ~2 GB only to then bail out is pure waste (#10).
     if shutil.which("semsql") is None:
         print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
-        return _usable_db(db_path, min_size)
+        return _present_db(db_path, min_size)
     if owl_source and not owl_source.exists():
         # semsql needs the plain OWL, but the download ships ncbitaxon.owl.gz and
         # NCBITAXON_SOURCE names the uncompressed path — without this a fresh
@@ -667,10 +708,10 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
         if archive.exists():
             print(f"Decompressing {archive} for the NCBITaxon SemSQL build...")
             if not _decompress_atomically(archive, owl_source):
-                return _usable_db(db_path, min_size)
+                return _present_db(db_path, min_size)
     if not (owl_source and owl_source.exists()):
         print(f"Warning: cannot build {db_path} — NCBITaxon OWL source {owl_source} is missing")
-        return _usable_db(db_path, min_size)
+        return _present_db(db_path, min_size)
     kept = _clear_build_target(db_path)
     print(
         f"Building {db_path} from {owl_source} via `semsql make`.\n"
@@ -685,15 +726,23 @@ def _ensure_ncbitaxon_db(db_path: str) -> bool:
             check=True,
         )
     except (subprocess.CalledProcessError, OSError) as e:
+        # Expected build failures degrade: restore the old DB and report on it.
         print(f"Warning: failed to build {db_path}: {e}")
         _restore_build_target(db_path, kept)
         return _usable_db(db_path, min_size)
-    built = _usable_db(db_path, min_size)
-    if built:
-        _discard_kept_target(kept)
-    else:
+    except BaseException:  # noqa: BLE001 — KeyboardInterrupt/SIGTERM must not strand .prev
+        # Ctrl-C or a kill during a multi-hour build previously left the DB gone
+        # and a 14 GB .prev orphaned forever, since nothing ever looks at it again.
         _restore_build_target(db_path, kept)
-    return built
+        raise
+    if _usable_db(db_path, min_size):
+        _discard_kept_target(kept)
+        return True
+    # semsql can exit 0 having produced a short/misplaced file. Restore, then
+    # report on what is actually at db_path now — not the pre-restore verdict.
+    print(f"Warning: {db_path} is not a complete build; restoring the previous DB")
+    _restore_build_target(db_path, kept)
+    return _usable_db(db_path, min_size)
 
 
 def _ensure_go_db(go_db_path: str) -> bool:
@@ -710,7 +759,7 @@ def _ensure_go_db(go_db_path: str) -> bool:
     """
     from kg_microbe.transform_utils.constants import GO_SOURCE
 
-    if os.path.exists(go_db_path) and os.path.getsize(go_db_path) >= _GO_DB_MIN_SIZE:
+    if _present_db(go_db_path, _GO_DB_MIN_SIZE):
         # An existing, non-stub go.db is reused — unless it has drifted from the
         # source OWL's release (single-source invariant, fix 2 #604): a refreshed
         # go.owl must rebuild go.db, else the aspect map lags the transform output
@@ -731,9 +780,7 @@ def _ensure_go_db(go_db_path: str) -> bool:
     if shutil.which("semsql") is None:
         print(f"Warning: `semsql` not on PATH; cannot build {go_db_path}")
         return False
-    # Remove a truncated/0-byte stub so semsql rebuilds cleanly.
-    if os.path.exists(go_db_path):
-        os.remove(go_db_path)
+    kept = _clear_build_target(go_db_path)
     print(
         f"Building {go_db_path} from {GO_SOURCE} via `semsql make` "
         "(one-time; a full GO SemSQL build runs relation-graph and can take "
@@ -747,8 +794,17 @@ def _ensure_go_db(go_db_path: str) -> bool:
         )
     except (subprocess.CalledProcessError, OSError) as e:
         print(f"Warning: failed to build {go_db_path}: {e}")
-        return False
-    return os.path.exists(go_db_path) and os.path.getsize(go_db_path) >= _GO_DB_MIN_SIZE
+        _restore_build_target(go_db_path, kept)
+        return _usable_db(go_db_path, _GO_DB_MIN_SIZE)
+    except BaseException:  # noqa: BLE001 — an interrupt must not strand .prev
+        _restore_build_target(go_db_path, kept)
+        raise
+    if _usable_db(go_db_path, _GO_DB_MIN_SIZE):
+        _discard_kept_target(kept)
+        return True
+    print(f"Warning: {go_db_path} is not a complete build; restoring the previous DB")
+    _restore_build_target(go_db_path, kept)
+    return _usable_db(go_db_path, _GO_DB_MIN_SIZE)
 
 
 def _load_go_namespace_map(go_db_path: str) -> Dict[str, str]:

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -1,10 +1,13 @@
 """Ontology utilities for category assignment and term processing."""
 
+import gzip
 import os
 import re
 import shutil
 import sqlite3
 import subprocess
+import zlib
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -35,6 +38,15 @@ _GO_NAMESPACE_LOAD_FAILED: bool = False
 # 0-byte stub (the failure that miscategorized every GO term as
 # biological_process this session).
 _GO_DB_MIN_SIZE = 10_000_000
+
+# Minimum plausible size for a healthy NCBITaxon SemSQL DB. A full build is
+# ~13 GB; anything smaller is a partial extract/download or an interrupted
+# `semsql make`, regardless of whether the SQLite header looks valid.
+_NCBITAXON_DB_MIN_SIZE = 1_000_000_000  # 1 GB
+
+# Minimum plausible size for a healthy ChEBI SemSQL DB. A full build is ~1-2 GB;
+# the upstream distribution is ~800 MB compressed.
+_CHEBI_DB_MIN_SIZE = 100_000_000  # 100 MB
 # OBO release stamp, e.g. ``releases/2026-05-19/`` in a versionIRI.
 _RELEASE_RE = re.compile(r"releases/(\d{4}-\d{2}-\d{2})")
 
@@ -47,10 +59,8 @@ def _obo_release_from_head(path: Path, nbytes: int = 2_000_000) -> Optional[str]
     (``meta`` versionInfo) carry the release near the file head, so a bounded
     read avoids parsing hundreds of MB. Returns None if unreadable / unstamped.
     """
-    try:
-        with open(path, encoding="utf-8", errors="ignore") as fh:
-            head = fh.read(nbytes)
-    except OSError:
+    head = _read_head(path, nbytes)
+    if head is None:
         return None
     m = _RELEASE_RE.search(head)
     if m:
@@ -230,13 +240,460 @@ def assert_ncbitaxon_version_alignment(db_path: str, strict: Optional[bool] = No
             f"ncbitaxon.db={db_release}. The metatraits transform emits nodes from "
             "ncbitaxon.owl but looks taxa up in ncbitaxon.db; a release gap can "
             "resolve lookups against taxa the transform didn't emit. To realign, "
-            "refresh the OAK SemSQL DB to the pinned release "
-            "(rm ~/.data/oaklib/ncbitaxon.db; poetry run python -c "
-            "'from oaklib import get_adapter; get_adapter(\"sqlite:obo:ncbitaxon\")')."
+            "rebuild the DB from the OWL: rm data/raw/ncbitaxon.db and re-run, and "
+            "the next transform rebuilds it via `semsql make`. Refreshing OAK's "
+            "prebuilt cache instead does NOT close the gap — those builds lag the "
+            "OBO release train by months. Do not delete ~/.data/oaklib/ncbitaxon.db "
+            "while data/raw/ncbitaxon.db symlinks to it."
         )
         if strict:
             raise RuntimeError(msg)
         print(f"WARNING: {msg}")
+
+
+def _semsql_build_enabled() -> bool:
+    """
+    Report whether SemSQL DB builds are permitted in this run.
+
+    Building ``ncbitaxon.db`` (~13 GB, hours) or ``chebi.db`` (30+ minutes) is the
+    right default for a maintainer refreshing the KG, but it is triggered by
+    ordinary ``kg transform`` commands, so anyone else needs a way to decline
+    (see #613). ``KG_SEMSQL_BUILD=off`` (or ``false``/``0``/``no``) skips the
+    build and uses whatever DB is already on disk, with the version gate warning
+    about any resulting drift.
+
+    Note the opt-out only helps when a usable DB already exists — it declines to
+    *build* one, it does not conjure one. With no DB present, ChEBI category
+    lookups still fail; supply a prebuilt ``chebi.db`` in that case.
+
+    :return: False when the opt-out is set, True otherwise.
+    """
+    return os.environ.get("KG_SEMSQL_BUILD", "").strip().lower() not in {"off", "false", "0", "no"}
+
+
+def _usable_db(db_path: str, min_size: int) -> bool:
+    """
+    Report whether a SemSQL DB at ``db_path`` is present and plausibly complete.
+
+    Every "we could not build; use what's there" exit must go through this rather
+    than bare ``os.path.exists``: a 0-byte or truncated ``chebi.db`` passes an
+    existence check, yields an adapter with no ``entailed_edge`` table, and makes
+    every ChEBI term fall through to the default category — the same silent
+    miscategorisation ``_GO_DB_MIN_SIZE`` was introduced to prevent. A symlinked
+    result is rejected too: it means a build landed somewhere else.
+
+    :param db_path: Path to the DB.
+    :param min_size: Smallest plausible size for a complete build.
+    :return: True if the file is usable.
+    """
+    return os.path.exists(db_path) and not os.path.islink(db_path) and os.path.getsize(db_path) >= min_size
+
+
+def _read_head(path: Path, nbytes: int) -> Optional[str]:
+    """
+    Read the head of ``path``, transparently falling back to ``path`` + ``.gz``.
+
+    Release stamps live in the first few KB, and the downloads ship compressed
+    (``chebi.owl.gz``, ``ncbitaxon.owl.gz``) while the ``*_SOURCE`` constants name
+    the uncompressed path. Without this fallback the release reads return None on
+    a fresh checkout, which makes both the drift check and the version gate
+    silently no-op — leaving an old DB in place, the exact drift this module
+    exists to catch.
+
+    :param path: Uncompressed path to read.
+    :param nbytes: How many characters to read.
+    :return: The head as text, or None if neither form is readable.
+    """
+    for opener, target in ((open, path), (gzip.open, path.with_name(path.name + ".gz"))):
+        if not target.exists():
+            continue
+        try:
+            with opener(target, "rt", encoding="utf-8", errors="ignore") as fh:
+                return fh.read(nbytes)
+        except (OSError, EOFError, zlib.error):
+            return None
+    return None
+
+
+def _clear_build_target(db_path: str) -> Optional[str]:
+    """
+    Remove whatever occupies the SemSQL build target, including a broken symlink.
+
+    ``os.path.exists`` follows symlinks and is False for a dangling one, so a
+    stale link would survive and ``semsql make`` — which opens the target name for
+    writing — would follow it and deposit the multi-GB result at the link's
+    target instead. The closing size check follows the link too, so the build
+    would be reported successful while the DB sat somewhere else entirely.
+
+    That state is reachable from the pipeline's own advice: the OAK-cache fallback
+    creates ``data/raw/ncbitaxon.db -> ~/.data/oaklib/ncbitaxon.db``, and the
+    remediation text tells users to ``rm`` the cache, leaving the link dangling.
+
+    A real file is moved aside rather than deleted, so a build that fails (OOM is
+    a live risk on the 13 GB NCBITaxon build) can put it back instead of leaving
+    the caller with nothing.
+
+    :param db_path: Build target to clear.
+    :return: Path the previous DB was moved to, or None if there was nothing to keep.
+    """
+    if not os.path.lexists(db_path):
+        return None
+    if os.path.islink(db_path):
+        os.remove(db_path)
+        return None
+    kept = f"{db_path}.prev"
+    if os.path.lexists(kept):
+        os.remove(kept)
+    os.replace(db_path, kept)
+    return kept
+
+
+def _restore_build_target(db_path: str, kept: Optional[str]) -> None:
+    """
+    Put back the DB moved aside by :func:`_clear_build_target` after a failed build.
+
+    :param db_path: Original DB path.
+    :param kept: Path returned by :func:`_clear_build_target`, or None.
+    """
+    if kept and os.path.exists(kept):
+        os.replace(kept, db_path)
+        print(f"  Restored the previous {db_path} after the failed build")
+
+
+def _discard_kept_target(kept: Optional[str]) -> None:
+    """
+    Delete the moved-aside DB once a build has succeeded.
+
+    :param kept: Path returned by :func:`_clear_build_target`, or None.
+    """
+    if kept and os.path.exists(kept):
+        os.remove(kept)
+
+
+def _decompress_atomically(archive: Path, destination: Path) -> bool:
+    """
+    Decompress a ``.gz`` archive to ``destination`` via a temp file + rename.
+
+    Writing straight to the destination leaves a truncated file at the real
+    filename if interrupted (#615) — and a truncated OWL is not detectable
+    downstream, because the version stamp lives in the head and still parses.
+
+    :param archive: Source ``.gz`` file.
+    :param destination: Path to place the decompressed file at.
+    :return: True if destination now holds the complete contents.
+    """
+    tmp = destination.with_name(destination.name + ".partial")
+    try:
+        with gzip.open(archive, "rb") as src, open(tmp, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        os.replace(tmp, destination)
+    # A truncated archive raises EOFError and a corrupt one zlib.error, neither of
+    # which is an OSError — catching OSError alone let those escape, defeating the
+    # "degrades gracefully" contract and orphaning a multi-GB .partial.
+    except (OSError, EOFError, zlib.error) as e:
+        print(f"Warning: failed to decompress {archive}: {e}")
+        tmp.unlink(missing_ok=True)
+        return False
+    return True
+
+
+def _chebi_release_from_owl(path: Path, nbytes: int = 2_000_000) -> Optional[str]:
+    """
+    Return the ChEBI release recorded near the top of ``chebi.owl``.
+
+    ChEBI does not use OBO's ``YYYY-MM-DD`` stamp — it versions by an
+    incrementing integer (``versionIRI .../obo/chebi/253/chebi.owl``,
+    ``<owl:versionInfo>253</owl:versionInfo>``). :func:`_obo_release_from_head`
+    only recognises dates, so it silently returns None for ChEBI and any gate
+    built on it no-ops. Hence this separate reader.
+
+    :param path: Path to ``chebi.owl``.
+    :param nbytes: Bytes to read from the head (ChEBI OWL is ~1 GB uncompressed).
+    :return: Release as a string (e.g. ``"253"``), or None if unreadable/unstamped.
+    """
+    head = _read_head(path, nbytes)
+    if head is None:
+        return None
+    m = re.search(r"versionIRI[^>]{0,160}?/chebi/(\d+)/", head)
+    if m:
+        return m.group(1)
+    m = re.search(r"<owl:versionInfo>\s*(\d+)\s*</owl:versionInfo>", head)
+    return m.group(1) if m else None
+
+
+def _chebi_db_release(db_path: str) -> Optional[str]:
+    """
+    Return the ChEBI release recorded in a SemSQL ``chebi.db``.
+
+    Mirrors :func:`_go_db_release` but accepts ChEBI's bare integer stamp
+    instead of a date. Restricted to the ontology subject so a version-shaped
+    value on a ``CHEBI:...`` term subject can't be mistaken for the release.
+
+    :param db_path: Path to ``chebi.db``.
+    :return: Release as a string, or None on read error / missing stamp.
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT value FROM statements WHERE predicate = 'owl:versionInfo' "
+                "AND value IS NOT NULL AND ("
+                "subject IN ('obo:chebi.owl', 'obo:chebi') OR subject LIKE '%/chebi.owl'"
+                ") LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    if not row or not row[0]:
+        return None
+    m = re.search(r"(\d+)", str(row[0]))
+    return m.group(1) if m else None
+
+
+def assert_chebi_version_alignment(db_path: str, strict: Optional[bool] = None) -> None:
+    """
+    Guard that the ChEBI lookup DB matches the transform's OWL release.
+
+    ``chebi.db`` decides each ChEBI node's Biolink category (SmallMolecule vs
+    ChemicalRole vs macromolecule) via ancestor lookups, while the nodes
+    themselves are emitted from ``chebi.owl``. A release gap means a term the
+    transform emits may be absent from the DB, so its category silently falls
+    back to the default — the same failure mode the GO gate exists to prevent.
+
+    Defaults to **warn** rather than raise: when ``semsql`` is unavailable the
+    pipeline legitimately falls back to a prebuilt ``chebi.db`` of a different
+    release, and aborting the run would be worse than mis-categorising a handful
+    of terms. Set ``KG_CHEBI_VERSION_CHECK=strict`` (or pass ``strict=True``) to
+    fail loud. No-op when either stamp can't be read.
+
+    :param db_path: Path to ``chebi.db``.
+    :param strict: Override the env var / default strictness.
+    :raises RuntimeError: On mismatch when strict.
+    """
+    from kg_microbe.transform_utils.constants import CHEBI_SOURCE
+
+    strict = _version_check_strict("KG_CHEBI_VERSION_CHECK", strict, default_strict=False)
+    if not CHEBI_SOURCE:
+        return
+    owl_release = _chebi_release_from_owl(Path(CHEBI_SOURCE))
+    db_release = _chebi_db_release(db_path)
+    if owl_release and db_release and owl_release != db_release:
+        msg = (
+            f"ChEBI source version mismatch: chebi.owl={owl_release} vs "
+            f"chebi.db={db_release}. Node categories are resolved against "
+            "chebi.db but nodes are emitted from chebi.owl; a release gap can "
+            "leave emitted terms uncategorised. To realign, rebuild the DB from "
+            "the OWL (rm data/raw/chebi.db; the next run rebuilds via `semsql make`)."
+        )
+        if strict:
+            raise RuntimeError(msg)
+        print(f"WARNING: {msg}")
+
+
+def _ensure_chebi_db(db_path: str) -> bool:
+    """
+    Build the ChEBI SemSQL DB from ``chebi.owl``; return True if usable.
+
+    Third application of the GO single-source rule (#604), after GO and
+    NCBITaxon. Previously ``chebi.db`` was whatever OAK had fetched or a copy
+    carried over from an older ``data/raw``, with no gate — and unlike the other
+    two it could not even be checked, because ChEBI's integer release stamp is
+    invisible to the date-based reader.
+
+    Decompresses ``chebi.owl.gz`` when only the archive is present, since
+    ``semsql make`` needs the plain OWL beside it. Rebuilds on release drift and
+    degrades to a warning (keeping any existing DB) when the OWL or ``semsql`` is
+    unavailable.
+
+    :param db_path: Target path for ``chebi.db``.
+    :return: True if a usable DB exists at db_path when this returns.
+    """
+    from kg_microbe.transform_utils.constants import CHEBI_SOURCE
+
+    min_size = _CHEBI_DB_MIN_SIZE
+    owl_source = Path(CHEBI_SOURCE) if CHEBI_SOURCE else None
+    if _usable_db(db_path, min_size):
+        owl_release = _chebi_release_from_owl(owl_source) if owl_source else None
+        db_release = _chebi_db_release(db_path)
+        if not (owl_release and db_release and owl_release != db_release):
+            return True
+        print(
+            f"Rebuilding {db_path}: release {db_release} drifted from "
+            f"chebi.owl {owl_release} (single-source realign)..."
+        )
+    if not _semsql_build_enabled():
+        print(f"Skipping ChEBI SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
+        return _usable_db(db_path, min_size)
+    # Checked before decompressing: without semsql there is nothing to build, and
+    # unpacking ~1 GB only to then bail out is pure waste (#10).
+    if shutil.which("semsql") is None:
+        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
+        return _usable_db(db_path, min_size)
+    if owl_source and not owl_source.exists():
+        # semsql needs the plain OWL; the download ships chebi.owl.gz.
+        archive = owl_source.with_suffix(owl_source.suffix + ".gz")
+        if archive.exists():
+            print(f"Decompressing {archive} for the ChEBI SemSQL build...")
+            if not _decompress_atomically(archive, owl_source):
+                return _usable_db(db_path, min_size)
+    if not (owl_source and owl_source.exists()):
+        print(f"Warning: cannot build {db_path} — ChEBI OWL source {owl_source} is missing")
+        return _usable_db(db_path, min_size)
+    kept = _clear_build_target(db_path)
+    print(
+        f"Building {db_path} from {owl_source} via `semsql make`.\n"
+        "  ChEBI runs relation-graph: expect 30+ minutes and several GB of RAM.\n"
+        "  Set KG_SEMSQL_BUILD=off to skip and use a prebuilt DB instead."
+    )
+    try:
+        subprocess.run(  # noqa: S603
+            ["semsql", "make", os.path.basename(db_path)],  # noqa: S607
+            cwd=str(owl_source.parent),
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError) as e:
+        print(f"Warning: failed to build {db_path}: {e}")
+        _restore_build_target(db_path, kept)
+        return _usable_db(db_path, min_size)
+    built = _usable_db(db_path, min_size)
+    if built:
+        _discard_kept_target(kept)
+    else:
+        _restore_build_target(db_path, kept)
+    return built
+
+
+@lru_cache(maxsize=None)
+def _chebi_adapter_for(db_path: str):
+    """
+    Build/realign ``chebi.db``, gate its release, and open an adapter over it.
+
+    Cached per path so the ensure + gate work (a 2 MB head read of ``chebi.owl``
+    plus a SQLite open) happens once per process rather than per call (#618).
+    Call :func:`get_chebi_adapter.cache_clear` to reset.
+
+    :param db_path: Path to ``chebi.db``.
+    :return: OAK adapter over ``chebi.db``.
+    :raises RuntimeError: If no usable DB could be produced.
+    """
+    from oaklib import get_adapter
+
+    if not _ensure_chebi_db(db_path):
+        # Returned, not raised: lru_cache does not memoise exceptions, so raising
+        # here would re-run the whole ensure — including a 30-minute `semsql make`
+        # — on every subsequent call. get_chebi_adapter turns this into the error.
+        return None
+    assert_chebi_version_alignment(db_path)
+    return get_adapter(f"sqlite:{db_path}")
+
+
+def get_chebi_adapter():
+    """
+    Return an OAK adapter for ChEBI, building/realigning ``chebi.db`` first.
+
+    Single entry point so the category-fixing code paths cannot diverge on how
+    the DB is obtained (they previously each did ``get_adapter("sqlite:<owl>")``
+    with an untested fallback to ``sqlite:data/raw/chebi.db``, which quietly
+    accepted whatever DB happened to be on disk).
+
+    :return: OAK adapter over ``chebi.db``.
+    :raises RuntimeError: If no usable DB could be produced.
+    """
+    from kg_microbe.transform_utils.constants import CHEBI_SOURCE
+
+    db_path = str(Path(CHEBI_SOURCE).parent / "chebi.db")
+    adapter = _chebi_adapter_for(db_path)
+    if adapter is None:
+        raise RuntimeError(
+            f"No usable ChEBI SemSQL DB at {db_path}. Install `semsql` and place "
+            "chebi.owl (or chebi.owl.gz) in data/raw so it can be built, or supply "
+            "a prebuilt chebi.db. See the warning above for which step failed."
+        )
+    return adapter
+
+
+get_chebi_adapter.cache_clear = _chebi_adapter_for.cache_clear
+
+
+def _ensure_ncbitaxon_db(db_path: str) -> bool:
+    """
+    Build the NCBITaxon SemSQL DB from ``ncbitaxon.owl``; return True if usable.
+
+    Applies the GO single-source rule (#604) to NCBITaxon. The alternative — OAK's
+    ``sqlite:obo:ncbitaxon``, which fetches whatever prebuilt SemSQL the upstream
+    CDN last published — cannot be kept aligned: those builds lag the OBO release
+    train by months (checked 2026-07-26, the newest ``ncbitaxon.db.gz`` upstream
+    was built 2026-05-24 while ``ncbitaxon.owl`` was at 2026-07-12), so refreshing
+    the cache does not close a gap, it only re-downloads 2.3 GB. Building from the
+    OWL we actually ship makes the lookup DB and the emitted nodes the same
+    release by construction.
+
+    Rebuilds when the DB's release stamp has drifted from the OWL's, mirroring
+    :func:`_ensure_go_db`. Degrades gracefully (warn + report current state) when
+    the OWL source or ``semsql`` is unavailable, so a machine without the build
+    toolchain still falls back to whatever DB is already present.
+
+    :param db_path: Target path for ``ncbitaxon.db``.
+    :return: True if a usable DB exists at db_path when this returns.
+    """
+    from kg_microbe.transform_utils.constants import NCBITAXON_SOURCE
+
+    min_size = _NCBITAXON_DB_MIN_SIZE
+    owl_source = Path(NCBITAXON_SOURCE) if NCBITAXON_SOURCE else None
+    if _usable_db(db_path, min_size):
+        owl_release = _obo_release_from_head(owl_source) if owl_source else None
+        db_release = _ncbitaxon_db_release(db_path)
+        if not (owl_release and db_release and owl_release != db_release):
+            return True
+        print(
+            f"Rebuilding {db_path}: release {db_release} drifted from "
+            f"ncbitaxon.owl {owl_release} (single-source realign)..."
+        )
+    if not _semsql_build_enabled():
+        print(f"Skipping NCBITaxon SemSQL build (KG_SEMSQL_BUILD opt-out); using {db_path} as-is")
+        return _usable_db(db_path, min_size)
+    # Checked before decompressing: without semsql there is nothing to build, and
+    # unpacking ~2 GB only to then bail out is pure waste (#10).
+    if shutil.which("semsql") is None:
+        print(f"Warning: `semsql` not on PATH; cannot build {db_path}")
+        return _usable_db(db_path, min_size)
+    if owl_source and not owl_source.exists():
+        # semsql needs the plain OWL, but the download ships ncbitaxon.owl.gz and
+        # NCBITAXON_SOURCE names the uncompressed path — without this a fresh
+        # checkout skips the build and silently falls back to OAK's prebuilt DB,
+        # defeating the single-source guarantee (#620).
+        archive = owl_source.with_suffix(owl_source.suffix + ".gz")
+        if archive.exists():
+            print(f"Decompressing {archive} for the NCBITaxon SemSQL build...")
+            if not _decompress_atomically(archive, owl_source):
+                return _usable_db(db_path, min_size)
+    if not (owl_source and owl_source.exists()):
+        print(f"Warning: cannot build {db_path} — NCBITaxon OWL source {owl_source} is missing")
+        return _usable_db(db_path, min_size)
+    kept = _clear_build_target(db_path)
+    print(
+        f"Building {db_path} from {owl_source} via `semsql make`.\n"
+        "  NCBITaxon is the heaviest source in the pipeline: expect hours and a\n"
+        "  ~13 GB result. Set KG_SEMSQL_BUILD=off to skip and use the prebuilt\n"
+        "  OAK cache instead (the version gate will warn about any drift)."
+    )
+    try:
+        subprocess.run(  # noqa: S603
+            ["semsql", "make", os.path.basename(db_path)],  # noqa: S607
+            cwd=str(owl_source.parent),
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError) as e:
+        print(f"Warning: failed to build {db_path}: {e}")
+        _restore_build_target(db_path, kept)
+        return _usable_db(db_path, min_size)
+    built = _usable_db(db_path, min_size)
+    if built:
+        _discard_kept_target(kept)
+    else:
+        _restore_build_target(db_path, kept)
+    return built
 
 
 def _ensure_go_db(go_db_path: str) -> bool:
@@ -431,18 +888,16 @@ def get_chebi_category(chebi_term_id: str, chebi_adapter: Optional[OboGraphInter
     """
     from kg_microbe.transform_utils.constants import MACROMOLECULE_CATEGORY
 
-    # Create adapter if not provided
+    # Create adapter if not provided. A standalone call degrades to the default
+    # category when no DB can be produced, matching the behaviour before the
+    # adapter was centralised; the bulk transform path passes an adapter it built
+    # itself, so there the failure stays loud.
     if chebi_adapter is None:
         try:
-            from oaklib import get_adapter
-
-            from kg_microbe.transform_utils.constants import CHEBI_SOURCE
-
-            chebi_adapter = get_adapter(f"sqlite:{CHEBI_SOURCE}")
-        except Exception:
-            from oaklib import get_adapter
-
-            chebi_adapter = get_adapter("sqlite:data/raw/chebi.db")
+            chebi_adapter = get_chebi_adapter()
+        except RuntimeError as e:
+            print(f"WARNING: {e}\n  Falling back to the default ChEBI category.")
+            return SMALL_MOLECULE_CATEGORY
 
     try:
         ancestors = list(chebi_adapter.ancestors(chebi_term_id))

--- a/tests/test_chebi_db_build.py
+++ b/tests/test_chebi_db_build.py
@@ -1,0 +1,452 @@
+"""
+Tests for building chebi.db from the chebi.owl we ship, and gating its release.
+
+Third application of the GO single-source rule (#604), after GO and NCBITaxon.
+ChEBI is the awkward case: it versions by an incrementing integer
+(``versionIRI .../obo/chebi/253/chebi.owl``) rather than an OBO ``YYYY-MM-DD``
+stamp, so the shared date-based reader returns None for it and any gate built on
+that reader silently passes. These tests pin the ChEBI-specific reader, the
+builder, and the gate.
+
+No test runs a real `semsql make`: the build is mocked and size thresholds
+shrunk.
+"""
+
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kg_microbe.utils import ontology_utils as ou
+
+OWL_VERSION_IRI = '<owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/chebi/{v}/chebi.owl"/>\n'
+OWL_VERSION_INFO = "<owl:versionInfo>{v}</owl:versionInfo>\n"
+
+
+def _write_owl(tmp_path, monkeypatch, body):
+    """Write a chebi.owl with `body` and point CHEBI_SOURCE at it."""
+    path = tmp_path / "chebi.owl"
+    path.write_text(body, encoding="utf-8")
+    monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", path)
+    return path
+
+
+def _make_db(tmp_path, release, *, subject="obo:chebi.owl", name="chebi.db"):
+    """Build a minimal SemSQL-shaped DB stamped with `release`."""
+    path = str(tmp_path / name)
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE statements (subject TEXT, predicate TEXT, object TEXT, value TEXT)")
+    conn.execute("INSERT INTO statements VALUES (?, 'owl:versionInfo', NULL, ?)", (subject, str(release)))
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clear_adapter_cache():
+    """Drop the memoized ChEBI adapter so tests can't see each other's."""
+    ou.get_chebi_adapter.cache_clear()
+    yield
+    ou.get_chebi_adapter.cache_clear()
+
+
+def _fake_build(monkeypatch, db_path, *, size=16, fail=False):
+    """Stand in for `semsql make`, recording the call and writing a fake DB."""
+    calls = []
+
+    def run(cmd, **kwargs):
+        """Record the invocation, then emit a fake DB (or fail)."""
+        calls.append((cmd, kwargs.get("cwd")))
+        if fail:
+            raise subprocess.CalledProcessError(1, cmd)
+        db_path.write_bytes(b"0" * size)
+
+    monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+    monkeypatch.setattr(ou.subprocess, "run", run)
+    return calls
+
+
+class TestChebiReleaseReader:
+
+    """ChEBI's integer stamp must be read where the date reader cannot."""
+
+    def test_reads_version_iri(self, tmp_path):
+        """The release comes out of the versionIRI path segment."""
+        path = tmp_path / "chebi.owl"
+        path.write_text(OWL_VERSION_IRI.format(v=253), encoding="utf-8")
+        assert ou._chebi_release_from_owl(path) == "253"
+
+    def test_reads_version_info(self, tmp_path):
+        """Falls back to owl:versionInfo when there is no versionIRI."""
+        path = tmp_path / "chebi.owl"
+        path.write_text(OWL_VERSION_INFO.format(v=251), encoding="utf-8")
+        assert ou._chebi_release_from_owl(path) == "251"
+
+    def test_date_reader_cannot_see_it(self, tmp_path):
+        """Regression note: this is why a date-based gate silently no-ops."""
+        path = tmp_path / "chebi.owl"
+        path.write_text(OWL_VERSION_IRI.format(v=253), encoding="utf-8")
+        assert ou._obo_release_from_head(path) is None
+        assert ou._chebi_release_from_owl(path) == "253"
+
+    def test_unstamped_returns_none(self, tmp_path):
+        """No stamp means None, which makes the gate and builder conservative."""
+        path = tmp_path / "chebi.owl"
+        path.write_text("no version here", encoding="utf-8")
+        assert ou._chebi_release_from_owl(path) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """An absent OWL is not an error for the reader."""
+        assert ou._chebi_release_from_owl(tmp_path / "absent.owl") is None
+
+    def test_db_release_read(self, tmp_path):
+        """_chebi_db_release reads the stamp off the ontology subject."""
+        assert ou._chebi_db_release(_make_db(tmp_path, 253)) == "253"
+
+    def test_db_release_ignores_term_subject(self, tmp_path):
+        """A version-shaped value on a CHEBI: term must not be mistaken for the release."""
+        path = str(tmp_path / "chebi.db")
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE statements (subject TEXT, predicate TEXT, object TEXT, value TEXT)")
+        conn.execute("INSERT INTO statements VALUES ('CHEBI:16828', 'owl:versionInfo', NULL, '999')")
+        conn.execute("INSERT INTO statements VALUES ('obo:chebi.owl', 'owl:versionInfo', NULL, '253')")
+        conn.commit()
+        conn.close()
+        assert ou._chebi_db_release(path) == "253"
+
+    def test_db_release_none_on_garbage(self, tmp_path):
+        """A non-SQLite file yields None rather than raising."""
+        path = tmp_path / "chebi.db"
+        path.write_text("not a database", encoding="utf-8")
+        assert ou._chebi_db_release(str(path)) is None
+
+
+class TestChebiGate:
+
+    """The gate must fire on drift and stay quiet otherwise."""
+
+    def test_aligned_is_silent(self, tmp_path, monkeypatch, capsys):
+        """Matching releases produce no output."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 253))
+        assert capsys.readouterr().out == ""
+
+    def test_mismatch_warns_by_default(self, tmp_path, monkeypatch, capsys):
+        """Default is warn, so a fallback DB of another release can't abort a build."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+        out = capsys.readouterr().out
+        assert "WARNING" in out and "chebi.owl=253" in out and "chebi.db=251" in out
+
+    def test_mismatch_raises_in_strict_mode(self, tmp_path, monkeypatch):
+        """Explicit strict escalates the same mismatch to a failure."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        with pytest.raises(RuntimeError, match="ChEBI source version mismatch"):
+            ou.assert_chebi_version_alignment(_make_db(tmp_path, 251), strict=True)
+
+    def test_env_var_escalates(self, tmp_path, monkeypatch):
+        """KG_CHEBI_VERSION_CHECK=strict flips the default."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        monkeypatch.setenv("KG_CHEBI_VERSION_CHECK", "strict")
+        with pytest.raises(RuntimeError):
+            ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+
+    def test_unreadable_stamp_is_a_noop(self, tmp_path, monkeypatch, capsys):
+        """An unstamped OWL must not warn (nothing to compare)."""
+        _write_owl(tmp_path, monkeypatch, "no version here")
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+        assert capsys.readouterr().out == ""
+
+
+class TestChebiBuild:
+
+    """Build behaviour mirrors _ensure_go_db / _ensure_ncbitaxon_db."""
+
+    def test_aligned_db_is_reused(self, tmp_path, monkeypatch):
+        """No rebuild when the DB already matches the OWL."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 253)
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert calls == []
+
+    def test_drifted_db_is_rebuilt(self, tmp_path, monkeypatch, capsys):
+        """A DB at a different ChEBI release is rebuilt from the OWL."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        source = _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 251)
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert calls == [(["semsql", "make", "chebi.db"], str(source.parent))]
+        assert "drifted" in capsys.readouterr().out
+
+    def test_decompresses_archive_when_owl_absent(self, tmp_path, monkeypatch):
+        """Semsql needs chebi.owl; the download only ships chebi.owl.gz."""
+        import gzip as gz
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+
+        db = tmp_path / "chebi.db"
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert owl.exists(), "chebi.owl.gz should have been decompressed"
+        assert "253" in owl.read_text(encoding="utf-8")
+        assert len(calls) == 1
+
+    def test_dangling_symlink_target_is_cleared(self, tmp_path, monkeypatch):
+        """A broken symlink must not redirect the build to the link's target (#1)."""
+        import pathlib
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        db = tmp_path / "chebi.db"
+        db.symlink_to(elsewhere / "chebi.db")
+
+        def run(cmd, **kwargs):
+            """Write to the target name the way semsql does, following any symlink."""
+            with open(pathlib.Path(kwargs["cwd"]) / "chebi.db", "wb") as f:
+                f.write(b"0" * 32)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert not db.is_symlink()
+        assert list(elsewhere.iterdir()) == [], "nothing should reach the link target"
+
+    def test_truncated_archive_degrades_gracefully(self, tmp_path, monkeypatch):
+        """A truncated chebi.owl.gz raises EOFError, which must still be caught (#2)."""
+        import gzip as gz
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        archive = tmp_path / "chebi.owl.gz"
+        with gz.open(archive, "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253) * 500)
+        archive.write_bytes(archive.read_bytes()[: archive.stat().st_size // 2])
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+
+        assert ou._ensure_chebi_db(str(tmp_path / "chebi.db")) is False
+        assert not owl.exists()
+        assert not (tmp_path / "chebi.owl.partial").exists()
+
+    def test_stub_db_is_not_reported_usable(self, tmp_path, monkeypatch):
+        """
+        A 0-byte chebi.db must not pass as usable on the no-build paths (F1).
+
+        os.path.exists is True for a stub, so the min-size guard used to apply
+        only to a freshly built result. A stub yields an adapter with no
+        entailed_edge table and collapses every ChEBI term to the default
+        category — the failure _GO_DB_MIN_SIZE exists to prevent.
+        """
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        db.write_bytes(b"")  # threshold left at the real 100 MB
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+        assert ou._ensure_chebi_db(str(db)) is False
+
+    def test_stub_db_rejected_under_opt_out(self, tmp_path, monkeypatch):
+        """The KG_SEMSQL_BUILD=off path must apply the same size guard."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        db.write_bytes(b"")
+        monkeypatch.setenv("KG_SEMSQL_BUILD", "off")
+        assert ou._ensure_chebi_db(str(db)) is False
+
+    def test_reuse_check_reads_release_from_the_archive(self, tmp_path, monkeypatch):
+        """
+        Drift must be detected when only chebi.owl.gz is on disk (F2).
+
+        The reuse branch reads chebi.owl, which a fresh checkout does not have —
+        so the release came back None, the drift check short-circuited, and the
+        stale DB was kept with the gate silently no-oping.
+        """
+        import gzip as gz
+
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 251)  # older release, DB large enough to be "reusable"
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert len(calls) == 1, "drift against the .gz release should trigger a rebuild"
+
+    def test_gate_reads_release_from_the_archive(self, tmp_path, monkeypatch, capsys):
+        """The version gate must also see the release when only the .gz exists (F2)."""
+        import gzip as gz
+
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+
+        ou.assert_chebi_version_alignment(_make_db(tmp_path, 251))
+        assert "chebi.owl=253" in capsys.readouterr().out
+
+    def test_failed_build_restores_the_previous_db(self, tmp_path, monkeypatch):
+        """A build that dies must not leave the caller with nothing (F3)."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db_path = _make_db(tmp_path, 251)  # drifted but working
+        db = Path(db_path)
+        original = db.read_bytes()
+        _fake_build(monkeypatch, db, fail=True)
+
+        result = ou._ensure_chebi_db(db_path)
+        assert db.exists(), "the working DB must be restored after a failed build"
+        assert db.read_bytes() == original
+        assert result is True, "the restored DB is still usable"
+        assert not Path(f"{db_path}.prev").exists(), "the keep-aside copy should be gone"
+
+    def test_missing_semsql_keeps_existing_db(self, tmp_path, monkeypatch, capsys):
+        """Without semsql, keep whatever DB is present instead of deleting it."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db_path = _make_db(tmp_path, 251)
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+
+        assert ou._ensure_chebi_db(db_path) is True
+        assert "semsql" in capsys.readouterr().out
+
+    def test_missing_owl_and_archive_warns(self, tmp_path, monkeypatch, capsys):
+        """Neither OWL nor archive means no build; report it."""
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", tmp_path / "chebi.owl")
+        assert ou._ensure_chebi_db(str(tmp_path / "chebi.db")) is False
+        assert "missing" in capsys.readouterr().out
+
+    def test_failed_build_returns_false(self, tmp_path, monkeypatch, capsys):
+        """A semsql crash is reported, not raised."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _fake_build(monkeypatch, db, fail=True)
+        assert ou._ensure_chebi_db(str(db)) is False
+        assert "failed to build" in capsys.readouterr().out
+
+    def test_undersized_result_is_rejected(self, tmp_path, monkeypatch):
+        """A stub-sized build result is not reported as usable."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _fake_build(monkeypatch, db, size=16)  # threshold stays at 100 MB
+        assert ou._ensure_chebi_db(str(db)) is False
+
+    def test_opt_out_skips_the_build(self, tmp_path, monkeypatch, capsys):
+        """KG_SEMSQL_BUILD=off must not start a 30-minute build (#613)."""
+        monkeypatch.setattr(ou, "_CHEBI_DB_MIN_SIZE", 8)
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        db = tmp_path / "chebi.db"
+        _make_db(tmp_path, 251)  # drifted, so a build would otherwise run
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.setenv("KG_SEMSQL_BUILD", "off")
+
+        assert ou._ensure_chebi_db(str(db)) is True
+        assert calls == [], "opt-out must skip semsql entirely"
+        assert "opt-out" in capsys.readouterr().out
+
+    def test_decompression_is_atomic(self, tmp_path, monkeypatch):
+        """An interrupted decompression must not leave a truncated OWL (#615)."""
+        import gzip as gz
+
+        owl = tmp_path / "chebi.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.CHEBI_SOURCE", owl)
+        with gz.open(tmp_path / "chebi.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_VERSION_IRI.format(v=253))
+
+        def boom(src, dst, *a, **k):
+            """Fail part-way through the copy, as a full disk or Ctrl-C would."""
+            dst.write(b"<owl:versionIRI rdf:resource=")
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(ou.shutil, "copyfileobj", boom)
+        assert ou._ensure_chebi_db(str(tmp_path / "chebi.db")) is False
+        assert not owl.exists(), "a partial decompression must not appear at the real path"
+        assert not (tmp_path / "chebi.owl.partial").exists(), "temp file should be cleaned up"
+
+
+class TestAdapterEntryPoint:
+
+    """Both category-fixing paths must go through one ensured adapter."""
+
+    def test_get_chebi_adapter_ensures_and_gates(self, tmp_path, monkeypatch):
+        """get_chebi_adapter builds/realigns, runs the gate, then opens the DB."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        seen = {}
+
+        monkeypatch.setattr(ou, "_ensure_chebi_db", lambda p: seen.setdefault("ensured", p) or True)
+        monkeypatch.setattr(ou, "assert_chebi_version_alignment", lambda p: seen.setdefault("gated", p))
+        monkeypatch.setattr("oaklib.get_adapter", lambda spec: seen.setdefault("adapter", spec))
+
+        ou.get_chebi_adapter()
+
+        expected = str(tmp_path / "chebi.db")
+        assert seen["ensured"] == expected
+        assert seen["gated"] == expected
+        assert seen["adapter"] == f"sqlite:{expected}"
+
+    def test_failed_ensure_raises_actionable_error(self, tmp_path, monkeypatch):
+        """An unbuildable DB must not be handed to OAK as a missing path (#616)."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        monkeypatch.setattr(ou, "_ensure_chebi_db", lambda _: False)
+        monkeypatch.setattr("oaklib.get_adapter", lambda spec: pytest.fail("must not open a missing DB"))
+        with pytest.raises(RuntimeError, match="No usable ChEBI SemSQL DB"):
+            ou.get_chebi_adapter()
+
+    def test_standalone_category_lookup_degrades_instead_of_raising(self, tmp_path, monkeypatch):
+        """
+        get_chebi_category() with no adapter must not abort the caller (#7).
+
+        The bulk transform builds its adapter up front, so a missing DB fails
+        loudly there. But this helper's contract is "return a category", and
+        before the adapter was centralised it degraded to the default. Keep that.
+        """
+        from kg_microbe.transform_utils.constants import SMALL_MOLECULE_CATEGORY
+
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        monkeypatch.setattr(ou, "_ensure_chebi_db", lambda _: False)
+        assert ou.get_chebi_category("CHEBI:16828") == SMALL_MOLECULE_CATEGORY
+
+    def test_adapter_work_happens_once(self, tmp_path, monkeypatch):
+        """Repeat calls reuse the memoized adapter rather than re-ensuring (#618)."""
+        _write_owl(tmp_path, monkeypatch, OWL_VERSION_IRI.format(v=253))
+        counts = {"ensure": 0, "gate": 0, "adapter": 0}
+
+        def ensure(_):
+            """Count ensure invocations."""
+            counts["ensure"] += 1
+            return True
+
+        def gate(_):
+            """Count gate invocations."""
+            counts["gate"] += 1
+
+        def adapter(_):
+            """Count adapter constructions."""
+            counts["adapter"] += 1
+            return object()
+
+        monkeypatch.setattr(ou, "_ensure_chebi_db", ensure)
+        monkeypatch.setattr(ou, "assert_chebi_version_alignment", gate)
+        monkeypatch.setattr("oaklib.get_adapter", adapter)
+
+        first = ou.get_chebi_adapter()
+        second = ou.get_chebi_adapter()
+
+        assert first is second
+        assert counts == {"ensure": 1, "gate": 1, "adapter": 1}

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -167,15 +167,95 @@ class TestDegradesGracefully:
         assert not (tmp_path / "ncbitaxon.db.prev").exists()
 
     def test_successful_build_discards_the_keep_aside_copy(self, tmp_path, owl, tiny_threshold, monkeypatch):
-        """On success the moved-aside DB is removed, not left doubling disk use."""
+        """
+        On success the moved-aside DB is removed, not left doubling disk use.
+
+        Asserts the .prev existed *during* the build and is gone after — checking
+        only the end state passes trivially with the keep-aside reverted, since
+        then no .prev is ever created.
+        """
         owl("2026-07-12")
         db = tmp_path / "ncbitaxon.db"
         db.write_bytes(b"0" * 16)
+        prev = tmp_path / "ncbitaxon.db.prev"
         monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
-        _fake_build(monkeypatch, db)
+        seen = {}
+
+        def run(cmd, **kwargs):
+            """Record whether the old DB was preserved while the build ran."""
+            seen["prev_during_build"] = prev.exists()
+            db.write_bytes(b"0" * 16)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
 
         assert ou._ensure_ncbitaxon_db(str(db)) is True
-        assert not (tmp_path / "ncbitaxon.db.prev").exists()
+        assert seen["prev_during_build"] is True, "the old DB must be kept during the build"
+        assert not prev.exists(), "and discarded once the build verifies"
+
+    def test_interrupt_restores_the_db_and_leaves_no_orphan(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """Ctrl-C during a build must not strand a 14 GB .prev with the DB gone (F3)."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        original = db.read_bytes()
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+
+        def run(cmd, **kwargs):
+            """Die the way a Ctrl-C or an OOM kill does."""
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        with pytest.raises(KeyboardInterrupt):
+            ou._ensure_ncbitaxon_db(str(db))
+        assert db.exists() and db.read_bytes() == original, "the DB must be restored"
+        assert not (tmp_path / "ncbitaxon.db.prev").exists(), "no orphaned .prev"
+
+    def test_orphaned_prev_from_an_earlier_kill_is_recovered(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """A .prev left by a previously killed run is adopted, not stranded forever."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        prev = tmp_path / "ncbitaxon.db.prev"
+        prev.write_bytes(b"0" * 16)  # DB missing, .prev orphaned
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert len(calls) == 1
+        assert not prev.exists(), "the orphan must not survive another run"
+
+    def test_short_build_result_restores_and_reports_the_restored_db(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """Semsql can exit 0 with a stub; report on what is on disk after restoring (F2)."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        original = db.read_bytes()
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+
+        def run(cmd, **kwargs):
+            """Exit 0 but leave an under-threshold file."""
+            db.write_bytes(b"x")
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        result = ou._ensure_ncbitaxon_db(str(db))
+        assert db.read_bytes() == original, "the working DB must be restored"
+        assert result is True, "and reported usable, since it is"
+
+    def test_symlinked_prebuilt_db_is_accepted_when_no_build_is_possible(
+        self, tmp_path, owl, tiny_threshold, monkeypatch
+    ):
+        """Pointing at a prebuilt DB with a symlink is supported (F4)."""
+        owl("2026-07-12")
+        real = tmp_path / "prebuilt.db"
+        real.write_bytes(b"0" * 16)
+        db = tmp_path / "ncbitaxon.db"
+        db.symlink_to(real)
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)  # cannot build
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True, "a symlinked prebuilt DB is usable"
 
     def test_missing_owl_warns(self, tmp_path, monkeypatch, capsys):
         """No OWL source means no build; say so rather than failing obscurely."""

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -1,0 +1,341 @@
+"""
+Tests for building ncbitaxon.db from the ncbitaxon.owl we ship.
+
+Applies the GO single-source rule (#604) to NCBITaxon. OAK's prebuilt SemSQL
+cannot be kept aligned — upstream CDN builds lag the OBO release train by
+months — so the lookup DB is built from the same OWL the transform emits nodes
+from, making the two releases equal by construction.
+
+None of these tests run a real `semsql make`: the build is mocked and the
+size threshold shrunk, so they stay fast.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kg_microbe.utils import ontology_utils as ou
+
+OWL_HEAD = '<owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon/{d}/ncbitaxon.owl"/>\n'
+
+
+@pytest.fixture
+def owl(tmp_path, monkeypatch):
+    """Write a stamped ncbitaxon.owl and point NCBITAXON_SOURCE at it."""
+
+    def _make(release="2026-07-12"):
+        path = tmp_path / "ncbitaxon.owl"
+        path.write_text(OWL_HEAD.format(d=release), encoding="utf-8")
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", path)
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def tiny_threshold(monkeypatch):
+    """Shrink the min-size gate so tests write bytes, not gigabytes."""
+    monkeypatch.setattr(ou, "_NCBITAXON_DB_MIN_SIZE", 8)
+
+
+def _fake_build(monkeypatch, db_path, *, size=16, fail=False):
+    """Stand in for `semsql make`, recording the call and writing a fake DB."""
+    calls = []
+
+    def run(cmd, **kwargs):
+        """Record the invocation, then emit a fake DB (or fail)."""
+        calls.append((cmd, kwargs.get("cwd")))
+        if fail:
+            raise subprocess.CalledProcessError(1, cmd)
+        db_path.write_bytes(b"0" * size)
+
+    monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+    monkeypatch.setattr(ou.subprocess, "run", run)
+    return calls
+
+
+class TestSkipsUnnecessaryBuilds:
+
+    """A 13 GB build must only run when it is actually needed."""
+
+    def test_valid_aligned_db_is_reused(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """Matching releases must not trigger a rebuild."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-07-12")
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert calls == [], "no build should run for an aligned DB"
+
+    def test_unreadable_release_does_not_force_rebuild(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """An unreadable stamp must not cause a spurious multi-hour rebuild."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: None)
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert calls == []
+
+
+class TestRebuildsOnDrift:
+
+    """The whole point: a refreshed OWL must produce a matching DB."""
+
+    def test_drifted_db_is_rebuilt(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """A DB at an older release than the OWL is rebuilt from that OWL."""
+        source = owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert len(calls) == 1
+        cmd, cwd = calls[0]
+        assert cmd == ["semsql", "make", "ncbitaxon.db"]
+        assert cwd == str(source.parent), "semsql must run beside the OWL"
+        assert "drifted" in capsys.readouterr().out
+
+    def test_missing_db_is_built(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """No DB at all means build it."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert len(calls) == 1
+
+    def test_partial_db_is_removed_before_build(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """A truncated DB must be deleted, else make treats it as up to date."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"partial")  # below the threshold
+
+        seen = {}
+
+        def run(cmd, **kwargs):
+            """Note whether the stale DB was cleared before the build ran."""
+            seen["existed_at_build_time"] = db.exists()
+            db.write_bytes(b"0" * 16)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert seen["existed_at_build_time"] is False
+
+
+class TestDegradesGracefully:
+
+    """A machine without the build toolchain must not be left broken."""
+
+    def test_missing_semsql_keeps_existing_db(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """Without semsql, report whatever DB is already present rather than deleting it."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert db.exists(), "an unbuildable DB must not be destroyed"
+        assert "semsql" in capsys.readouterr().out
+
+    def test_stub_db_is_not_reported_usable(self, tmp_path, owl, monkeypatch):
+        """A truncated DB must not pass as usable on the no-build paths (F1)."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"stub")  # threshold left at the real 1 GB
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False
+
+    def test_failed_build_restores_the_previous_db(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """A failed build must not leave the caller without the 13 GB DB (F3)."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        original = db.read_bytes()
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")  # drift → rebuild
+        _fake_build(monkeypatch, db, fail=True)
+
+        result = ou._ensure_ncbitaxon_db(str(db))
+        assert db.exists(), "the previous DB must be restored"
+        assert db.read_bytes() == original
+        assert result is True
+        assert not (tmp_path / "ncbitaxon.db.prev").exists()
+
+    def test_successful_build_discards_the_keep_aside_copy(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """On success the moved-aside DB is removed, not left doubling disk use."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")
+        _fake_build(monkeypatch, db)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert not (tmp_path / "ncbitaxon.db.prev").exists()
+
+    def test_missing_owl_warns(self, tmp_path, monkeypatch, capsys):
+        """No OWL source means no build; say so rather than failing obscurely."""
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", tmp_path / "absent.owl")
+        assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
+        assert "missing" in capsys.readouterr().out
+
+    def test_failed_build_returns_false(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """A semsql crash is reported, not raised."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        _fake_build(monkeypatch, db, fail=True)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False
+        assert "failed to build" in capsys.readouterr().out
+
+    def test_undersized_result_is_rejected(self, tmp_path, owl, monkeypatch):
+        """A build that produced a stub must not be reported as usable."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        monkeypatch.setattr(ou, "_NCBITAXON_DB_MIN_SIZE", 1_000_000)
+        _fake_build(monkeypatch, db, size=16)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False
+
+    def test_opt_out_skips_the_build(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
+        """KG_SEMSQL_BUILD=off must not start a multi-hour build (#613)."""
+        owl("2026-07-12")
+        db = tmp_path / "ncbitaxon.db"
+        db.write_bytes(b"0" * 16)
+        monkeypatch.setattr(ou, "_ncbitaxon_db_release", lambda _: "2026-05-13")  # drifted
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.setenv("KG_SEMSQL_BUILD", "off")
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert calls == [], "opt-out must skip semsql entirely"
+        assert "opt-out" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("value", ["off", "false", "0", "no", "OFF"])
+    def test_opt_out_accepts_common_spellings(self, tmp_path, owl, tiny_threshold, monkeypatch, value):
+        """Any of the usual falsey spellings disables the build."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.setenv("KG_SEMSQL_BUILD", value)
+        ou._ensure_ncbitaxon_db(str(db))
+        assert calls == []
+
+    def test_decompresses_archive_when_owl_absent(self, tmp_path, tiny_threshold, monkeypatch):
+        """A fresh checkout has only ncbitaxon.owl.gz; the build must still run (#620)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        with gz.open(tmp_path / "ncbitaxon.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12"))
+
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert owl_path.exists(), "ncbitaxon.owl.gz should have been decompressed"
+        assert len(calls) == 1, "the build must not be skipped as 'OWL missing'"
+
+    def test_partial_decompression_is_not_left_behind(self, tmp_path, tiny_threshold, monkeypatch):
+        """An interrupted decompression must not leave a truncated OWL (#615/#620)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        with gz.open(tmp_path / "ncbitaxon.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12"))
+
+        def boom(src, dst, *a, **k):
+            """Fail part-way through, as a full disk would."""
+            dst.write(b"<owl:versionIRI")
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(ou.shutil, "copyfileobj", boom)
+        assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
+        assert not owl_path.exists()
+        assert not (tmp_path / "ncbitaxon.owl.partial").exists()
+
+    def test_dangling_symlink_target_is_cleared(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """
+        A broken symlink must not survive and redirect the build (#1).
+
+        os.path.exists is False for a dangling link, so the old check skipped the
+        removal; semsql then opened the target name for writing, followed the link
+        and deposited the ~13 GB result at the link's target instead — while the
+        size check, also following the link, reported success.
+        """
+        source = owl("2026-07-12")
+        elsewhere = tmp_path / "oak"
+        elsewhere.mkdir()
+        db = tmp_path / "ncbitaxon.db"
+        db.symlink_to(elsewhere / "ncbitaxon.db")  # target does not exist
+
+        def run(cmd, **kwargs):
+            """Write to the target name the way semsql does, following any symlink."""
+            with open(Path(kwargs["cwd"]) / "ncbitaxon.db", "wb") as f:
+                f.write(b"0" * 32)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert not db.is_symlink(), "the dangling link should have been removed"
+        assert db.stat().st_size == 32, "the build must land at the real path"
+        assert list(elsewhere.iterdir()) == [], "nothing should have been written to the link target"
+        assert source.exists()
+
+    def test_symlinked_result_is_rejected(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """If a build somehow leaves a symlink behind, don't report success."""
+        owl()
+        elsewhere = tmp_path / "elsewhere.db"
+        elsewhere.write_bytes(b"0" * 32)
+        db = tmp_path / "ncbitaxon.db"
+
+        def run(cmd, **kwargs):
+            """Leave a symlink rather than a real DB at the target."""
+            db.symlink_to(elsewhere)
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        monkeypatch.setattr(ou.subprocess, "run", run)
+        assert ou._ensure_ncbitaxon_db(str(db)) is False
+
+    def test_truncated_archive_degrades_gracefully(self, tmp_path, tiny_threshold, monkeypatch):
+        """A truncated .gz raises EOFError, not OSError — it must still be caught (#2)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        archive = tmp_path / "ncbitaxon.owl.gz"
+        with gz.open(archive, "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12") * 500)
+        archive.write_bytes(archive.read_bytes()[: archive.stat().st_size // 2])  # truncate
+
+        monkeypatch.setattr(ou.shutil, "which", lambda _: "/usr/bin/semsql")
+        # Must return False rather than propagating EOFError.
+        assert ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db")) is False
+        assert not owl_path.exists()
+        assert not (tmp_path / "ncbitaxon.owl.partial").exists(), "orphaned .partial left behind"
+
+    def test_semsql_checked_before_decompressing(self, tmp_path, tiny_threshold, monkeypatch):
+        """Don't unpack ~2 GB only to discover semsql is absent (#10)."""
+        import gzip as gz
+
+        owl_path = tmp_path / "ncbitaxon.owl"
+        monkeypatch.setattr("kg_microbe.transform_utils.constants.NCBITAXON_SOURCE", owl_path)
+        with gz.open(tmp_path / "ncbitaxon.owl.gz", "wt", encoding="utf-8") as f:
+            f.write(OWL_HEAD.format(d="2026-07-12"))
+        monkeypatch.setattr(ou.shutil, "which", lambda _: None)
+
+        ou._ensure_ncbitaxon_db(str(tmp_path / "ncbitaxon.db"))
+        assert not owl_path.exists(), "should not have decompressed without semsql"
+
+    def test_build_runs_when_opt_out_unset(self, tmp_path, owl, tiny_threshold, monkeypatch):
+        """Default behaviour is unchanged: the build still runs."""
+        owl()
+        db = tmp_path / "ncbitaxon.db"
+        calls = _fake_build(monkeypatch, db)
+        monkeypatch.delenv("KG_SEMSQL_BUILD", raising=False)
+        assert ou._ensure_ncbitaxon_db(str(db)) is True
+        assert len(calls) == 1

--- a/tests/test_ncbitaxon_db_ready.py
+++ b/tests/test_ncbitaxon_db_ready.py
@@ -1,0 +1,121 @@
+"""
+Tests for the NCBITaxon pre-flight (_ensure_ncbitaxon_db_ready).
+
+Its contract, from its own docstring: when it returns, workers calling
+_get_ncbitaxon_adapter find a valid DB; when no valid DB can be found it raises.
+The whole point is to fail *before* workers fork, because a failure inside a
+worker surfaces as an unhandled exception per taxon instead of one clear error.
+
+A round-5 review found the guard added for "don't discard a freshly built DB"
+had broken both halves of that contract: it applied to any real file and it
+returned instead of falling through to the raise. These tests pin the contract.
+"""
+
+import pytest
+
+from kg_microbe.transform_utils.metatraits import metatraits as mt
+
+
+@pytest.fixture
+def paths(tmp_path, monkeypatch):
+    """Point the module at a temp local DB and OAK cache."""
+    local = tmp_path / "ncbitaxon.db"
+    cache = tmp_path / "oak" / "ncbitaxon.db"
+    cache.parent.mkdir()
+    monkeypatch.setattr(mt, "_ncbitaxon_db_paths", lambda: (local, cache))
+    return local, cache
+
+
+def _validation(results):
+    """Return a _validate_ncbitaxon_db stand-in driven by a {path: (ok, reason)} map."""
+
+    def validate(path):
+        """Look the verdict up by resolved path, defaulting to invalid."""
+        return results.get(str(path), (False, "stubbed invalid"))
+
+    return validate
+
+
+class TestPreflightContract:
+
+    """It must either leave a valid DB in place or raise."""
+
+    def test_valid_local_db_is_accepted(self, paths, monkeypatch):
+        """The happy path returns without touching anything."""
+        local, _ = paths
+        local.write_bytes(b"db")
+        monkeypatch.setattr(mt, "_validate_ncbitaxon_db", _validation({str(local): (True, "")}))
+        mt._ensure_ncbitaxon_db_ready()
+        assert not local.is_symlink()
+
+    def test_invalid_local_db_falls_back_to_the_cache(self, paths, monkeypatch):
+        """
+        A pre-existing DB that fails validation is replaced by the OAK symlink.
+
+        This is the self-healing case; the round-5 regression turned it into a
+        silent success with the corrupt DB left in place.
+        """
+        local, cache = paths
+        local.write_bytes(b"corrupt but large")
+        cache.write_bytes(b"good")
+        monkeypatch.setattr(mt, "_validate_ncbitaxon_db", _validation({str(cache): (True, "")}))
+        monkeypatch.setattr("kg_microbe.utils.ontology_utils._ensure_ncbitaxon_db", lambda _: True)
+
+        mt._ensure_ncbitaxon_db_ready()
+
+        assert local.is_symlink() and local.resolve() == cache.resolve()
+
+    def test_no_valid_db_anywhere_raises(self, paths, monkeypatch):
+        """With nothing usable it must raise, not return — workers fork after this."""
+        local, _ = paths
+        local.write_bytes(b"corrupt")
+        monkeypatch.setattr(mt, "_validate_ncbitaxon_db", _validation({}))
+        monkeypatch.setattr("kg_microbe.utils.ontology_utils._ensure_ncbitaxon_db", lambda _: True)
+
+        with pytest.raises(RuntimeError, match="NCBITaxon OAK database is missing or corrupt"):
+            mt._ensure_ncbitaxon_db_ready()
+
+    def test_freshly_built_but_invalid_db_raises_rather_than_being_discarded(self, paths, monkeypatch):
+        """
+        A build that produced an unusable DB must fail loudly, keeping the artifact.
+
+        Replacing it with the OAK symlink would throw away hours of work; returning
+        silently would hand workers a broken adapter. Neither is acceptable.
+        """
+        local, cache = paths
+        cache.write_bytes(b"good")
+        monkeypatch.setattr(mt, "_validate_ncbitaxon_db", _validation({str(cache): (True, "")}))
+
+        def build(_):
+            """Produce a new DB where there was none."""
+            local.write_bytes(b"freshly built but broken")
+            return True
+
+        monkeypatch.setattr("kg_microbe.utils.ontology_utils._ensure_ncbitaxon_db", build)
+
+        with pytest.raises(RuntimeError, match="failed validation"):
+            mt._ensure_ncbitaxon_db_ready()
+        assert local.exists() and not local.is_symlink(), "the fresh build must survive"
+
+
+class TestFingerprint:
+
+    """The built-here test must distinguish a new DB from a pre-existing one."""
+
+    def test_absent_file_has_no_fingerprint(self, tmp_path):
+        """A missing DB fingerprints as None."""
+        assert mt._db_fingerprint(tmp_path / "absent.db") is None
+
+    def test_rewrite_changes_the_fingerprint(self, tmp_path):
+        """Different content yields a different fingerprint."""
+        path = tmp_path / "x.db"
+        path.write_bytes(b"one")
+        before = mt._db_fingerprint(path)
+        path.write_bytes(b"a different length")
+        assert mt._db_fingerprint(path) != before
+
+    def test_untouched_file_keeps_its_fingerprint(self, tmp_path):
+        """An unmodified DB must not look like a fresh build."""
+        path = tmp_path / "x.db"
+        path.write_bytes(b"one")
+        assert mt._db_fingerprint(path) == mt._db_fingerprint(path)


### PR DESCRIPTION
Split out of #612 and **stacked on #627** — review/merge that one first; this
PR's diff is only the SemSQL half.

Extends the GO single-source rule (#604) to the remaining ontology lookup DBs,
which were acquired independently of the OWL the transforms emit nodes from.

## Why

**NCBITaxon** had a real 2-month gap: `ncbitaxon.owl` at 2026-07-12 against an
OAK cache at 2026-05-13. Not closable by refreshing — the upstream SemSQL CDN's
newest build was 2026-05-24, so the remediation the old error message gave would
have re-downloaded 2.3 GB and landed back at the same release. Building from our
OWL makes the two equal by construction; the real 13.1 GB build completed and
both stamps now read 2026-07-12.

**ChEBI** could not even be *checked*. It versions by an integer
(`versionIRI .../chebi/253/chebi.owl`), invisible to the date-based reader, so a
gate built on that reader would have passed silently forever — verified against
the real file, the ChEBI reader returns `253` where the shared one returns `None`.
Both category-fixing call sites also went through
`get_adapter(f"sqlite:{CHEBI_SOURCE}")` wrapped in a bare `except`, which cannot
work as written (`CHEBI_SOURCE` is an `.owl` path), so the fallback silently
accepted whatever `chebi.db` happened to be on disk.

## Also included

`KG_SEMSQL_BUILD=off` (these builds run for hours and are triggered by ordinary
`kg transform` commands), atomic `.gz` decompression, gz-aware release reads, a
min-size guard on every no-build exit, and preservation of an existing DB across
a failed build.

## Status — please review carefully

This half is where **every** regression across five review rounds of #612
occurred, which is why it was split out. Known open issues against it:

- #614 — the NCBITaxon build runs only in multiprocessing mode, so sequential
  runs can still drift (detected and warned, not prevented)
- #625 — the reuse path accepts a large-but-corrupt DB
- #626 — the pinned md5s are unenforced comments

A fifth review round raised further findings on the most recent fixes here
(pre-flight returning success for a DB it declared invalid; the success path
returning a pre-restore verdict; `.prev` orphaned on interrupt; the symlink
rejection being wrong at the no-build exits; a `.json.gz` fallback making an
`unlink()` unsafe; `_ensure_go_db` never updated). Those are addressed in the
commits that follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)