### PR TITLE
fix(kg-model-review): make custom_curies.yaml the source of truth for registered prefixes

### DIFF
--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -204,6 +204,7 @@ STANDARD_PREFIXES = {
     "kgmicrobe.activity", "kgmicrobe.trait", "kgmicrobe.compound",
     "kgmicrobe.assay", "kgmicrobe.pathway", "kgmicrobe.carbon_substrate",
     "kgmicrobe.ingredient",  # mediadive: un-mapped ingredient placeholders
+    "kgmicrobe.medium",      # bacdive/mediadive: growth media not in MediaDive catalog
     "MICRO",                 # Microbiology Ontology (mediadive ingredients)
     "UniProtKB", "PR", "SO", "RHEA", "OBI", "IAO", "BFO",
     "PATO", "CL", "NCIT", "DOID", "MESH", "OMIM", "orphanet",
@@ -282,18 +283,28 @@ class Finding:
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 def load_registered_prefixes() -> set:
-    """Load all registered prefixes from custom_curies.yaml."""
+    """Load all registered prefixes from ``custom_curies.yaml``.
+
+    Top-level YAML keys are the CURIE prefixes the file registers (e.g.
+    ``"kgmicrobe.medium"`` on line 361). The prior loader walked sections but
+    only added the string ``"KGM"`` regardless of what it found, so a legitimate
+    registration in ``custom_curies.yaml`` still produced an unregistered-prefix
+    warning here. Now every top-level string key becomes a recognized prefix,
+    making ``custom_curies.yaml`` the actual source of truth for custom prefix
+    registration.
+    """
     prefixes = set(STANDARD_PREFIXES)
     if CUSTOM_CURIES_FILE.exists():
         with open(CUSTOM_CURIES_FILE) as f:
             data = yaml.safe_load(f)
         if isinstance(data, dict):
-            for section in data.values():
-                if isinstance(section, dict):
-                    for key in section:
-                        # KGM slugs map to KGM: prefix
-                        prefixes.add("KGM")
-                        break
+            for key, section in data.items():
+                if isinstance(key, str) and key:
+                    prefixes.add(key)
+                # Keep the historical KGM alias so slugs under any section
+                # map to the KGM: prefix that transforms mint.
+                if isinstance(section, dict) and section:
+                    prefixes.add("KGM")
     return prefixes
 
 


### PR DESCRIPTION
## Summary

Two related fixes so the kg-model-review skill recognizes every prefix that \`kg_microbe/transform_utils/custom_curies.yaml\` registers.

## Context

Running \`/kg-model-review --merged\` on the merged KG after PR #639 landed surfaced two WARNING findings for \`kgmicrobe.medium\`:

\`\`\`
[Prefix  ] ⚠️  WARNING: Unregistered prefixes in id: ['kgmicrobe.medium']
[Prefix  ] ⚠️  WARNING: Unregistered prefixes in edges: ['kgmicrobe.medium']
\`\`\`

\`kgmicrobe.medium\` is already registered in \`custom_curies.yaml\` on line 361 with three class entries (\`macconkey_agar\`, \`blood_agar\`, \`emb_agar\`). So the yaml file was fine — the reviewer's loader wasn't reading it correctly.

## Changes

- \`load_registered_prefixes()\` — walked yaml sections but only added the string \`"KGM"\` regardless of what it found. Now every top-level string key becomes a recognized prefix, making custom_curies.yaml the actual source of truth for custom prefix registration. Preserves the historical \`"KGM"\` alias.
- \`STANDARD_PREFIXES\` — added \`kgmicrobe.medium\` explicitly as belt-and-braces so the check is robust to yaml-load failures.

## Test plan

- [x] \`poetry run python .claude/skills/kg-model-review/kg_model_review.py --merged\` → \`Total ERRORs: 0, Total WARNINGs: 0\` (was 0/2)
- [x] No behavior change for any other prefix (loader adds keys, doesn't remove any).

🤖 Generated with [Claude Code](https://claude.com/claude-code)