### PR TITLE
feat(microbedecoder): emit unmapped_labels.tsv curation queue

### DIFF
--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -25,7 +25,7 @@ Design decisions locked from the plan-mode Q&A:
 1. **Node identity**: attach every edge to the *existing* `lpsn:<LPSN_ID>`
    node emitted by the LPSN transform. This transform emits edges only
    (plus terminal nodes for end-products / cross-refs / provisional
-   provisional placeholders); it does not re-emit LPSN taxon nodes.
+   placeholders); it does not re-emit LPSN taxon nodes.
 2. **BacDive_* replay**: ingested with `primary_knowledge_source =
    infores:microbedecoder` so the paper's 2024-11-07 BacDive snapshot
    stays reproducible. The fresher `bacdive` transform is authoritative
@@ -105,6 +105,11 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ZIP_NAME = "microbedecoder_database.zip"
 # Filename inside the zip. MicrobeDecoder ships one CSV: `database.csv`.
 _CSV_INSIDE_ZIP = "database.csv"
+# Per-run curation report of labels that fell through the mapping chain
+# and landed as ``kgmicrobe.*`` placeholders. Follows the metatraits
+# ``unmapped_traits.tsv`` convention (per-source, in the transform's
+# output dir, TSV with a stable header).
+_UNMAPPED_REPORT_FILENAME = "unmapped_labels.tsv"
 
 # Predicate map from metabolism-source group_label to the InforES knowledge
 # source used on every emitted edge. Kept as a dict so tests can override
@@ -156,6 +161,12 @@ class MicrobeDecoderTransform(Transform):
         # and successfully-resolved CHEBI CURIEs are never stubbed here —
         # their authoritative nodes come from other transforms.
         self._seen_nodes: set = set()
+        # Per-label tally of placeholder mintings so the end-of-run
+        # ``unmapped_labels.tsv`` can prioritise curation by frequency.
+        # Keyed by ``(placeholder_curie, category)``; value tracks the raw
+        # label, the pipe-set of source columns it appeared in, and the
+        # occurrence count. See ``_write_unmapped_report``.
+        self._unmapped: Dict[tuple, Dict[str, object]] = {}
         # End-of-run summary counters.
         self._stats: Dict[str, int] = {
             "rows_processed": 0,
@@ -257,6 +268,9 @@ class MicrobeDecoderTransform(Transform):
         # merged KG collapse duplicates cheaply.
         drop_duplicates(self.output_node_file, sort_by_column=ID_COLUMN)
         drop_duplicates(self.output_edge_file, sort_by_column=SUBJECT_COLUMN)
+        # Curation queue: per-label placeholder tally sorted by frequency
+        # descending. Matches the metatraits `unmapped_traits.tsv` pattern.
+        self._write_unmapped_report()
         self._log_summary()
 
     # ------------------------------------------------------------------
@@ -345,7 +359,9 @@ class MicrobeDecoderTransform(Transform):
             type_of_metabolism = fields.get("type_of_metabolism")
             if not is_empty_cell(type_of_metabolism):
                 for label in split_multivalue(type_of_metabolism):
-                    obj = self._resolve_metabolism_curie(label, node_writer)
+                    obj = self._resolve_metabolism_curie(
+                        label, node_writer, source_column=f"{group_label}:type_of_metabolism"
+                    )
                     edge_writer.writerow(
                         self._make_edge_row(
                             subject,
@@ -366,7 +382,7 @@ class MicrobeDecoderTransform(Transform):
                 ("minor_end_products", "minor"),
             ):
                 for label in split_multivalue(fields.get(role)):
-                    obj = self._resolve_chemical_curie(label, node_writer)
+                    obj = self._resolve_chemical_curie(label, node_writer, source_column=f"{group_label}:{role}")
                     edge_writer.writerow(
                         self._make_edge_row(
                             subject,
@@ -385,7 +401,7 @@ class MicrobeDecoderTransform(Transform):
             # organism→substrate emitter routes through, incl. madin_etal)
             # so merged-KG queries stay consistent.
             for label in split_multivalue(fields.get("substrates")):
-                obj = self._resolve_chemical_curie(label, node_writer)
+                obj = self._resolve_chemical_curie(label, node_writer, source_column=f"{group_label}:substrates")
                 edge_writer.writerow(
                     self._make_edge_row(
                         subject,
@@ -438,7 +454,12 @@ class MicrobeDecoderTransform(Transform):
     # ------------------------------------------------------------------
     # CURIE resolution
     # ------------------------------------------------------------------
-    def _resolve_chemical_curie(self, label: str, node_writer: "csv._writer") -> str:
+    def _resolve_chemical_curie(
+        self,
+        label: str,
+        node_writer: "csv._writer",
+        source_column: str,
+    ) -> str:
         """
         Resolve an end-product / substrate label to a CHEBI CURIE or placeholder.
 
@@ -446,7 +467,9 @@ class MicrobeDecoderTransform(Transform):
         a node stub; the ontologies transform owns the authoritative CHEBI
         node (per the add-transform skill's "don't stub cross-refs" rule).
         Miss → mint a ``kgmicrobe.compound:<slug>`` placeholder and emit
-        the terminal stub (nothing else will).
+        the terminal stub (nothing else will). ``source_column`` is
+        recorded in the unmapped-labels report so curators know which
+        source axis to prioritise.
         """
         curie: Optional[str] = None
         if self.chemical_loader is not None:
@@ -461,9 +484,15 @@ class MicrobeDecoderTransform(Transform):
             node_writer,
             prefix=COMPOUND_PREFIX,
             category=SMALL_MOLECULE_CATEGORY,
+            source_column=source_column,
         )
 
-    def _resolve_metabolism_curie(self, label: str, node_writer: "csv._writer") -> str:
+    def _resolve_metabolism_curie(
+        self,
+        label: str,
+        node_writer: "csv._writer",
+        source_column: str,
+    ) -> str:
         """
         Resolve a type_of_metabolism label to a pathway CURIE or placeholder.
 
@@ -479,6 +508,7 @@ class MicrobeDecoderTransform(Transform):
             node_writer,
             prefix=PATHWAY_PREFIX,
             category=METABOLISM_CATEGORY,
+            source_column=source_column,
         )
 
     def _resolve_phenotype_curie(
@@ -493,16 +523,16 @@ class MicrobeDecoderTransform(Transform):
         Category is left generic (:data:`PHENOTYPIC_CATEGORY`); the fresher
         ``bacdive`` transform provides the semantically-correct edge
         (MicrobeDecoder ingests the 2024-11-07 snapshot per the plan-mode
-        Q&A). ``source_column`` is accepted for a v2 compound-key lookup
-        where the same short string means different things under different
-        BacDive columns.
+        Q&A). ``source_column`` is recorded in the unmapped-labels report
+        so curators can distinguish the same short string (``yes``, ``0``)
+        appearing under different BacDive columns.
         """
-        del source_column  # kept in the API for a v2 compound-key lookup
         return self._mint_placeholder(
             label,
             node_writer,
             prefix=TRAIT_PREFIX,
             category=PHENOTYPIC_CATEGORY,
+            source_column=source_column,
         )
 
     def _mint_placeholder(
@@ -511,6 +541,7 @@ class MicrobeDecoderTransform(Transform):
         node_writer: "csv._writer",
         prefix: str,
         category: str,
+        source_column: str,
     ) -> str:
         """
         Return a stable ``<prefix><slug>`` CURIE and emit the terminal stub.
@@ -520,12 +551,71 @@ class MicrobeDecoderTransform(Transform):
         registered as a section of ``custom_curies.yaml``). The stub node
         carries the raw source label so the merged KG surfaces something
         human-readable even before the label gets a proper METPO / CHEBI
-        mapping.
+        mapping. ``source_column`` is tallied into ``self._unmapped`` so
+        the end-of-run ``unmapped_labels.tsv`` report knows which source
+        column(s) contributed this placeholder.
         """
         curie = f"{prefix}{slugify_label(label)}"
         self._ensure_terminal_node(curie, category, label, node_writer)
         self._stats["unmatched_labels"] += 1
+        # Aggregate per placeholder CURIE. Same CURIE from multiple
+        # columns keeps them all in the ``source_columns`` set so the
+        # curation report shows the union.
+        key = (curie, category)
+        entry = self._unmapped.setdefault(
+            key,
+            {"label": label, "source_columns": set(), "occurrences": 0},
+        )
+        entry["source_columns"].add(source_column)  # type: ignore[union-attr]
+        entry["occurrences"] = int(entry["occurrences"]) + 1
         return curie
+
+    def _write_unmapped_report(self) -> None:
+        """
+        Emit a per-label curation queue as ``unmapped_labels.tsv``.
+
+        Sorted by occurrence count descending so the top rows are the
+        highest-leverage curation targets. Feeds the "which MicrobeDecoder
+        labels most need a canonical mapping" question the paper's
+        readers and downstream curators care about (issue #650).
+
+        Columns:
+
+        - ``placeholder_curie`` — the ``kgmicrobe.{pathway,compound,trait}:<slug>``
+          CURIE this run minted for the label
+        - ``category`` — the placeholder's biolink category
+        - ``label`` — the raw source label
+        - ``source_columns`` — pipe-delimited set of source columns this
+          label appeared under (``bergey:type_of_metabolism`` /
+          ``vpi:major_end_products`` / ``BacDive_Oxygen_tolerance`` / …)
+        - ``occurrences`` — how many edges this placeholder anchors this run
+
+        No file is written when the run produced zero placeholders (all
+        labels mapped — the aspirational state).
+        """
+        if not self._unmapped:
+            return
+        target = self.output_dir / _UNMAPPED_REPORT_FILENAME
+        rows = [
+            {
+                "placeholder_curie": curie,
+                "category": category,
+                "label": entry["label"],
+                "source_columns": "|".join(sorted(entry["source_columns"])),  # type: ignore[arg-type]
+                "occurrences": entry["occurrences"],
+            }
+            for (curie, category), entry in self._unmapped.items()
+        ]
+        # Sort by count desc, then CURIE asc for stable output.
+        rows.sort(key=lambda r: (-int(r["occurrences"]), r["placeholder_curie"]))
+        with open(target, "w", newline="") as fh:
+            writer = csv.DictWriter(
+                fh,
+                fieldnames=["placeholder_curie", "category", "label", "source_columns", "occurrences"],
+                delimiter="\t",
+            )
+            writer.writeheader()
+            writer.writerows(rows)
 
     def _ensure_terminal_node(
         self,

--- a/tests/test_microbedecoder_transform.py
+++ b/tests/test_microbedecoder_transform.py
@@ -356,6 +356,93 @@ def test_dedup_sorts_output(microbedecoder_transform):
     assert ids == sorted(ids), "nodes must be sorted by id"
 
 
+def test_unmapped_labels_report_is_written(microbedecoder_transform):
+    """
+    `unmapped_labels.tsv` lands next to nodes/edges with per-label tallies.
+
+    The report is the curation priority queue that feeds issue #650 —
+    sorted by occurrence count descending. Follows the metatraits
+    ``unmapped_traits.tsv`` convention. Each row names the placeholder
+    CURIE, its category, the raw source label, the pipe-set of source
+    columns it appeared in, and the occurrence count for this run.
+    """
+    microbedecoder_transform.run()
+    report = microbedecoder_transform.output_dir / "unmapped_labels.tsv"
+    assert report.is_file(), "run must emit unmapped_labels.tsv when placeholders were minted"
+    with open(report, newline="") as fh:
+        rows = list(csv.DictReader(fh, delimiter="\t"))
+    assert rows, "report has at least one row for the fixture's unmapped labels"
+    # Header shape
+    assert set(rows[0].keys()) == {
+        "placeholder_curie",
+        "category",
+        "label",
+        "source_columns",
+        "occurrences",
+    }
+    # Sorted by occurrences descending
+    counts = [int(r["occurrences"]) for r in rows]
+    assert counts == sorted(counts, reverse=True), "rows must be sorted by occurrences desc"
+    # `acetate` shows up in multiple Bergey/VPI/Literature columns for
+    # LPSN_ID=101 — its source_columns cell should carry the pipe-set.
+    acetate_rows = [r for r in rows if r["label"] == "acetate"]
+    assert acetate_rows, "acetate appeared in the fixture; must be in the report"
+    src_cols = acetate_rows[0]["source_columns"].split("|")
+    assert len(src_cols) >= 2, (
+        f"acetate appeared under multiple source columns in the fixture "
+        f"(bergey, vpi, literature); got source_columns={acetate_rows[0]['source_columns']}"
+    )
+
+
+def test_unmapped_labels_report_omitted_when_no_placeholders(tmp_path):
+    """
+    No report is written when every label maps cleanly (aspirational state).
+
+    Injects a chemical loader that resolves every label to a stub CHEBI
+    CURIE. The transform's fixture also carries BacDive_* and
+    Type_of_metabolism cells that route through the placeholder path
+    regardless of ChEBI, so the report file WILL still be written for
+    those. This test therefore uses a fixture-minimal transform whose
+    only unmapped-eligible content is the chemical labels the fake
+    loader resolves.
+    """
+
+    class _AlwaysResolves:
+
+        """ChemicalMappingLoader stub that resolves every label to CHEBI:0."""
+
+        def find_chebi_by_name(self, label, fuzzy_stereochemistry=True):
+            """Return a stub CHEBI CURIE for every lookup (so no placeholders)."""
+            del label, fuzzy_stereochemistry
+            return "CHEBI:15377"
+
+    # Write a minimal 1-row CSV with ONLY chemical fields populated (no
+    # Type_of_metabolism, no BacDive_* cells) so the placeholder path
+    # is only reachable for chemical labels.
+    fixture_dir = tmp_path
+    csv_path = fixture_dir / "database.csv"
+    header = [
+        "LPSN_ID",
+        "Bergey_Major_end_products",
+        "Bergey_Substrates_for_end_products",
+    ]
+    with open(csv_path, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(header)
+        w.writerow(["999", "acetate, lactate", "glucose"])
+
+    xform = MicrobeDecoderTransform(
+        input_dir=fixture_dir,
+        output_dir=tmp_path,
+        chemical_loader=_AlwaysResolves(),
+    )
+    xform.run(data_file="database.csv")
+    report = xform.output_dir / "unmapped_labels.tsv"
+    assert not report.exists(), (
+        "no report should be written when every label mapped cleanly; found unmapped_labels.tsv anyway"
+    )
+
+
 def test_mixed_encoding_csv_is_read_with_replacement(tmp_path):
     """
     The real MicrobeDecoder CSV is mixed UTF-8 + sporadic Latin-1 bytes.


### PR DESCRIPTION
## Summary

Adds a per-source \`unmapped_labels.tsv\` output to the MicrobeDecoder transform — matches the metatraits \`unmapped_traits.tsv\` pattern — so the ~5,200 unmatched labels in the live \`database.csv\` come with a priority queue instead of requiring a hand-derived count.

Directly feeds the curation issue **#650** with actionable data.

## Report shape

Columns:

| Column | Meaning |
|---|---|
| \`placeholder_curie\` | \`kgmicrobe.{pathway,compound,trait}:<slug>\` this run minted |
| \`category\` | placeholder biolink category |
| \`label\` | raw source label as it appeared in the CSV |
| \`source_columns\` | pipe-delimited SET of source columns this label appeared under |
| \`occurrences\` | count of edges this placeholder anchors this run |

Sorted by occurrences descending, then CURIE ascending (stable output).

No file is written when every label mapped cleanly.

## Live-run preview (top-15 rows against the real database.csv)

\`\`\`
kgmicrobe.pathway:chemoheterotrophy       biolink:BiologicalProcess    chemoheterotrophy          faprotax:type_of_metabolism                     10493
kgmicrobe.trait:0                         biolink:PhenotypicQuality    0                          BacDive_Motility|BacDive_Salt_concentration|BacDive_Spore_formation|BacDive_Temperature_for_growth  10227
kgmicrobe.trait:rod_shaped                biolink:PhenotypicQuality    rod-shaped                 BacDive_Cell_shape                              7988
kgmicrobe.pathway:aerobic_chemoheterotrophy biolink:BiologicalProcess  aerobic_chemoheterotrophy  faprotax:type_of_metabolism                     7875
kgmicrobe.trait:environmental             biolink:PhenotypicQuality    #Environmental             BacDive_Isolation_category_1                    7698
kgmicrobe.trait:1                         biolink:PhenotypicQuality    1                          BacDive_Cell_length|BacDive_Cell_width|BacDive_Colony_size|BacDive_Metabolite_utilization|BacDive_Motility|BacDive_Pathogenicity_animal|BacDive_Pathogenicity_human|BacDive_Pathogenicity_plant|BacDive_Salt_concentration|BacDive_Spore_formation  7489
\`\`\`

The \`source_columns\` field is the payoff — curators can see at a glance that the token \`1\` spans ten BacDive_* phenotype columns (so any mapping for it needs disambiguation), while \`chemoheterotrophy\` comes cleanly from a single FAPROTAX column.

## Files

- \`kg_microbe/transform_utils/microbedecoder/microbedecoder.py\`
  - New: \`_write_unmapped_report()\`, \`_UNMAPPED_REPORT_FILENAME = "unmapped_labels.tsv"\`
  - Signature: \`_resolve_{chemical,metabolism,phenotype}_curie\` and \`_mint_placeholder\` gain \`source_column\`
  - New instance state: \`self._unmapped: Dict[(curie, category), {label, source_columns, occurrences}]\`
- \`tests/test_microbedecoder_transform.py\`
  - \`test_unmapped_labels_report_is_written\` — file exists, header shape, sorted, source_columns aggregates
  - \`test_unmapped_labels_report_omitted_when_no_placeholders\` — no file when every label maps

No API change (resolvers were private).

## Test plan

- [x] \`poetry run pytest tests/test_microbedecoder_transform.py -v\` — 21 pass (+2)
- [x] Full suite: **766 tests pass** (was 764)
- [x] \`tox -e format -e lint -e docstr-coverage -e codespell-write\` all green
- [x] Live run against real \`database.csv\`: report emitted with 5,224 rows in 15.7 s wall-clock; top entries verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)