### PR TITLE
fix(kg-model-review): register bacdive, GOLD, IMG crosswalk prefixes

### DIFF
--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -218,7 +218,14 @@ STANDARD_PREFIXES = {
     # madin_etal provisional node prefixes (fallback when no ontology term found)
     "pathways", "carbon_substrates",
     # bacdive / mediadive domain-specific prefixes
+    "bacdive",                # BacDive strain ID (bare form; the transform mints these at run time)
     "bacdive.isolation_source",
+    # Genome-project crosswalk prefixes surfaced by MicrobeDecoder's
+    # pre-joined LPSN ↔ GOLD ↔ IMG ↔ NCBI ↔ GTDB ↔ BacDive close_match edges
+    # (registered as GOLD_PREFIX / IMG_PREFIX in constants.py; the authoritative
+    # nodes come from external genome catalogues, so we don't emit stubs).
+    "GOLD",                   # Genomes OnLine Database
+    "IMG",                    # JGI Integrated Microbial Genomes
     # mediadive prefixes
     "mediadive.medium", "mediadive.ingredient", "mediadive.solution", "mediadive.medium-type",
     "CAS-RN", "cas", "PubChem", "pubchem.compound", "PUBCHEM.COMPOUND",


### PR DESCRIPTION
## Summary

The kg-model-review skill's \`STANDARD_PREFIXES\` allowlist was missing three prefixes that real transforms emit as edge targets:

- **\`bacdive\`** — the bacdive transform mints strain CURIEs from the bare prefix (\`BACDIVE_PREFIX = \"bacdive:\"\` in constants.py); the whitelist previously only listed the dotted variant \`bacdive.isolation_source\`.
- **\`GOLD\`** — MicrobeDecoder's LPSN ↔ GOLD identity crosswalk (constants.py \`GOLD_PREFIX = \"GOLD:\"\`, real Bioregistry prefix).
- **\`IMG\`** — same crosswalk, JGI Integrated Microbial Genomes (\`IMG_PREFIX = \"IMG:\"\`).

All three are legitimate \`biolink:close_match\` edge targets — authoritative nodes come from external genome catalogues so we deliberately don't stub them, and the review rightly requires the prefix be registered somewhere.

## Verification

Ran \`kg-model-review --transform microbedecoder\` before/after:

- **Before**: \`⚠️  WARNING: Unregistered prefixes in edges: ['GOLD', 'IMG', 'bacdive']\`, Total WARNINGs: 1
- **After**: \`ℹ️  INFO: All edge prefixes registered\`, Total WARNINGs: 0

No behavior change for any other prefix (loader adds three new entries, doesn't remove any).

🤖 Generated with [Claude Code](https://claude.com/claude-code)