### PR TITLE
fix(microbedecoder): split multi-value crosswalk cells (#655)

### DIFF
--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -95,6 +95,7 @@ from kg_microbe.transform_utils.microbedecoder.utils import (
     iter_metabolism_columns,
     slugify_label,
     split_multivalue,
+    split_multivalue_comma_only,
 )
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.pandas_utils import drop_duplicates
@@ -313,29 +314,45 @@ class MicrobeDecoderTransform(Transform):
         node_writer: "csv._writer",
         edge_writer: "csv._writer",
     ) -> None:
-        """One `biolink:close_match` edge per non-empty crosswalk cell."""
+        """
+        Emit one ``biolink:close_match`` edge per crosswalk local-ID token.
+
+        Multi-value cells are split via :func:`split_multivalue_comma_only`
+        before CURIE construction. Without a split the source's
+        ``IMG_Genome_ID`` column — which packs multiple genome IDs per row
+        separated by commas — landed as a single malformed CURIE like
+        ``IMG:2547132264,2784746776`` on ~2.6 K edges in the first live
+        merge (issue #655).
+
+        Comma-only rather than the metabolism emitter's comma-or-semicolon
+        split, because ``GTDB_ID`` uses ``;`` as an internal rank separator
+        (``d__Bacteria;g__Bacillus;s__Bacillus subtilis``) — a semicolon
+        split would shred a single GTDB CURIE into three orphan fragments.
+        The other four crosswalk columns (NCBI, BacDive, GOLD) are
+        single-value in practice; comma-only is safe there too.
+        """
         for column, prefix, _formatter in CROSSWALK_COLUMNS:
             raw = row.get(column)
             if is_empty_cell(raw):
                 continue
-            local_id = str(raw).strip()
-            # Strip a stray leading prefix if the source already CURIE'd it
-            # (`NCBI_Taxonomy_ID` occasionally arrives as ``"NCBITaxon:562"``
-            # rather than a bare integer — normalise so downstream nodes
-            # merge cleanly).
-            if local_id.upper().startswith(prefix.upper()):
-                local_id = local_id.split(":", 1)[1]
-            object_curie = f"{prefix}{local_id}"
-            edge_writer.writerow(
-                self._make_edge_row(
-                    subject,
-                    CLOSE_MATCH_PREDICATE,
-                    object_curie,
-                    CLOSE_MATCH_RELATION,
-                    self.knowledge_source,
+            for local_id in split_multivalue_comma_only(raw):
+                # Strip a stray leading prefix if the source already CURIE'd
+                # it (``NCBI_Taxonomy_ID`` occasionally arrives as
+                # ``"NCBITaxon:562"`` rather than a bare integer — normalise
+                # so downstream nodes merge cleanly).
+                if local_id.upper().startswith(prefix.upper()):
+                    local_id = local_id.split(":", 1)[1]
+                object_curie = f"{prefix}{local_id}"
+                edge_writer.writerow(
+                    self._make_edge_row(
+                        subject,
+                        CLOSE_MATCH_PREDICATE,
+                        object_curie,
+                        CLOSE_MATCH_RELATION,
+                        self.knowledge_source,
+                    )
                 )
-            )
-            self._stats["crosswalk_edges"] += 1
+                self._stats["crosswalk_edges"] += 1
 
     # ------------------------------------------------------------------
     # Metabolism edges (Bergey / VPI / Literature / FAPROTAX)

--- a/kg_microbe/transform_utils/microbedecoder/utils.py
+++ b/kg_microbe/transform_utils/microbedecoder/utils.py
@@ -117,28 +117,57 @@ BACDIVE_SNAPSHOT_COLUMNS: Tuple[str, ...] = (
 )
 
 
-# Multi-value cell splitter. Bergey / VPI / Literature end-product columns
-# use comma-separated values ("acetate, lactate, ethanol"), occasionally with
-# semicolons in the raw source text. Whitespace is collapsed; empties are
-# dropped. The strict=False regex is deliberate — one place, one rule.
+# Multi-value cell splitters. Two variants because MicrobeDecoder's
+# column-family conventions are not uniform:
 #
-# Known v1 limitation: a chemical name containing a literal comma (e.g.
-# ``2,3-butanediol``) will over-split into ``2`` and ``3-butanediol``. The
-# same limitation exists in madin_etal's multi-value handling; MicrobeDecoder
-# rows use simple end-product names in practice ("acetate", "lactate",
-# "butanol"). A follow-up can promote this to a smarter parser once a
-# curated exceptions list exists.
+# ``_MULTIVALUE_SPLIT`` (comma OR semicolon) is used for the metabolism
+# and BacDive-snapshot columns whose Bergey / VPI / Literature end-products
+# use comma-separated values ("acetate, lactate, ethanol") and occasionally
+# semicolons in the raw source text.
+#
+# ``_MULTIVALUE_SPLIT_COMMA_ONLY`` is used for the identity-crosswalk
+# columns (``NCBI_Taxonomy_ID``, ``GTDB_ID``, ``BacDive_ID``,
+# ``GOLD_Organism_ID``, ``IMG_Genome_ID``). Only ``IMG_Genome_ID`` actually
+# multi-values in practice — it packs multiple genome IDs per row
+# comma-separated. The other four columns are single-value but sometimes
+# contain internal semicolons that are part of the identifier itself
+# (``GTDB_ID`` uses semicolons as rank separators, e.g.
+# ``d__Bacteria;g__Bacillus;s__Bacillus subtilis``); a semicolon split
+# would shred those into three orphan CURIEs (issue #655 regression net).
+#
+# Known limitation shared with ``madin_etal``: a chemical name containing a
+# literal comma (e.g. ``2,3-butanediol``) still over-splits on the primary
+# splitter. MicrobeDecoder rows use simple end-product names in practice
+# ("acetate", "lactate", "butanol"); a follow-up can promote this to a
+# smarter parser once a curated exceptions list exists.
 _MULTIVALUE_SPLIT = re.compile(r"\s*[,;]\s*")
+_MULTIVALUE_SPLIT_COMMA_ONLY = re.compile(r"\s*,\s*")
 
 
 def split_multivalue(cell: object) -> List[str]:
-    """Split a multi-value cell into a list of trimmed non-empty tokens."""
+    """Split a multi-value cell on comma OR semicolon; return trimmed tokens."""
+    return _split(cell, _MULTIVALUE_SPLIT)
+
+
+def split_multivalue_comma_only(cell: object) -> List[str]:
+    """
+    Split a multi-value cell on comma ONLY (preserves in-value semicolons).
+
+    Use for identity-crosswalk cells (``IMG_Genome_ID`` and friends) where
+    a raw semicolon is part of the identifier (``GTDB_ID`` rank separator)
+    rather than a value separator.
+    """
+    return _split(cell, _MULTIVALUE_SPLIT_COMMA_ONLY)
+
+
+def _split(cell: object, pattern: "re.Pattern") -> List[str]:
+    """Shared helper for :func:`split_multivalue` and its comma-only variant."""
     if cell is None:
         return []
     text = str(cell).strip()
     if not text or text.lower() in _EMPTY_MARKERS:
         return []
-    return [tok for tok in (t.strip() for t in _MULTIVALUE_SPLIT.split(text)) if tok]
+    return [tok for tok in (t.strip() for t in pattern.split(text)) if tok]
 
 
 # Values MicrobeDecoder uses to indicate "no data" for a cell. Detected

--- a/tests/resources/microbedecoder/database.csv
+++ b/tests/resources/microbedecoder/database.csv
@@ -5,4 +5,5 @@ LPSN_ID,LPSN_status,LPSN_Species,LPSN_Strain,NCBI_Taxonomy_ID,GTDB_ID,BacDive_ID
 404,correct name,Methanocaldococcus jannaschii,DSM 2661,243232,d__Archaea;g__Methanocaldococcus;s__Methanocaldococcus jannaschii,,,,,,,,,,,,,Methanogenesis,methane,,"H2, CO2",Hydrogenotrophic methanogen,PMID:9634230,Methanogenesis,anaerobe,,,,coccus
 505,synonym,Streptococcus faecalis,Streptococcus faecalis,,,BAC05,,,,,,,,,,,,,,,,,,,facultative anaerobe,positive,,no,coccus
 606,correct name,Lactobacillus acidophilus,DSM 20079,1579,,BAC06,,,Homofermentative,lactate,,glucose,Homofermentative lactic acid bacterium,,,,,,,,,,,Homofermentative,microaerophile,positive,no,no,rod
+707,correct name,Testicola multivalens,,9999,,,,"3300000001,3300000002",,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,aerobe,,,,

--- a/tests/test_microbedecoder_transform.py
+++ b/tests/test_microbedecoder_transform.py
@@ -95,6 +95,7 @@ def test_lpsn_subject_nodes_are_not_stubbed(microbedecoder_transform):
         f"{LPSN_PREFIX}404",
         f"{LPSN_PREFIX}505",
         f"{LPSN_PREFIX}606",
+        f"{LPSN_PREFIX}707",
     }, "every non-blank LPSN_ID row produces edges keyed on lpsn:<id>"
 
 
@@ -136,6 +137,39 @@ def test_crosswalk_edges_carry_microbedecoder_provenance(microbedecoder_transfor
     assert close_matches, "some crosswalk edges must exist"
     for e in close_matches:
         assert e["primary_knowledge_source"] == MICROBEDECODER_KNOWLEDGE_SOURCE
+
+
+def test_crosswalk_splits_multi_value_cells(microbedecoder_transform):
+    """
+    Multi-value crosswalk cells (comma-separated) must emit one edge per token.
+
+    Regression for issue #655: the source's ``IMG_Genome_ID`` column packs
+    multiple IMG genome IDs per row (e.g. ``3300000001,3300000002``).
+    Before the fix the raw cell was emitted as a single malformed CURIE
+    (``IMG:3300000001,3300000002``); ~2.6 K such edges landed in the
+    first live merge. The fix runs every crosswalk cell through
+    :func:`split_multivalue` so each token becomes its own
+    ``biolink:close_match`` edge.
+
+    Fixture row LPSN_ID=707 carries a two-value IMG cell that must split
+    into two edges pointing at ``IMG:3300000001`` and ``IMG:3300000002``.
+    """
+    microbedecoder_transform.run()
+    edges = _read_tsv(microbedecoder_transform.output_edge_file)
+    img_edges_for_707 = [
+        e
+        for e in edges
+        if e["subject"] == f"{LPSN_PREFIX}707"
+        and e["predicate"] == CLOSE_MATCH_PREDICATE
+        and e["object"].startswith("IMG:")
+    ]
+    objects = {e["object"] for e in img_edges_for_707}
+    assert objects == {"IMG:3300000001", "IMG:3300000002"}, (
+        f"multi-value IMG cell must split into two edges; got {objects}"
+    )
+    # Nothing malformed: no CURIE should contain an embedded comma.
+    for obj in objects:
+        assert "," not in obj, f"multi-value cell escaped the split: {obj!r}"
 
 
 def test_missing_crosswalk_cells_are_skipped(microbedecoder_transform):


### PR DESCRIPTION
## Summary

Closes #655.

`_emit_crosswalk_edges` was emitting each raw crosswalk cell as a single CURIE. For `IMG_Genome_ID` — which packs multiple genome IDs per row comma-separated — that landed ~2,600 malformed CURIEs like `IMG:2547132264,2784746776` in the first live merge. Every crosswalk column now runs through a splitter so each token becomes its own `biolink:close_match` edge.

## Details

- New `split_multivalue_comma_only` helper in `microbedecoder/utils.py`. Comma-only (not the metabolism emitter's comma-or-semicolon `split_multivalue`) because `GTDB_ID` uses `;` as an internal hierarchical rank separator (e.g. `d__Bacteria;g__Bacillus;s__Bacillus subtilis`); a semicolon split would shred a single GTDB CURIE into three orphan fragments.
- `_emit_crosswalk_edges` iterates each cell's tokens instead of using the raw cell.
- The other three crosswalk columns (NCBITaxon, BacDive, GOLD) are single-value in practice; comma-only is safe there too.

## Live smoke (real 27,010-row database.csv)

```
IMG close_match edges total: 18,374; with comma-in-CURIE: 0
GTDB objects total: 15,584; over-split fragments: 0
```

Previously: 15,101 IMG edges (of which ~2,600 contained an embedded comma). +3,273 net IMG edges — exactly the ~2,600 multi-value cells expanding to ~2 tokens each.

## Tests

- New `test_crosswalk_splits_multi_value_cells` (fixture row LPSN_ID=707 with `IMG_Genome_ID="3300000001,3300000002"`) asserts two edges emit and neither CURIE contains a comma.
- `test_crosswalk_edges_use_close_match` (fixture row LPSN_ID=101 with `GTDB_ID="d__Bacteria;g__Bacillus;s__Bacillus subtilis"`) continues to assert the full GTDB rank string survives — regression net for the comma-only splitter choice.
- Full suite: `789 passed, 4 warnings, 21 subtests passed in 246.48s`.
- Tox format / lint / docstr-coverage: green.

## Test plan

- [x] `poetry run pytest tests/test_microbedecoder_transform.py -v` — 22 pass
- [x] `poetry run pytest tests/ -x` — 789 pass
- [x] `poetry run tox -e format -e lint -e docstr-coverage` — green
- [x] Live smoke on real 27,010-row CSV — 0 malformed IMG CURIEs, GTDB rank strings intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)