### PR TITLE
feat(novel-transforms): add category + node/edge scale columns

### DIFF
--- a/.claude/skills/novel-transforms/SKILL.md
+++ b/.claude/skills/novel-transforms/SKILL.md
@@ -68,6 +68,17 @@ Each open issue is scored against three signal sets:
      accepted them (curator says "this is enhancement / infra / meta").
    Editing these is the primary curation lever.
 
+4. **Per-source metadata** in `SOURCE_METADATA` (also in `novel_transforms.py`):
+   dict keyed by issue number, each entry carrying:
+   - `nodes` — rough node-count magnitude as `10^N` (string; `"?"` for unknown)
+   - `edges` — rough edge-count magnitude, same convention
+   - `category` — kebab-case tag from `DATA_CATEGORIES` (phenotype, genome,
+     metabolism, identity, media, environmental, ecology, fitness, literature)
+
+   These cannot be derived from issue title/body — curator judgement, so add a
+   row when you triage a new issue. Missing rows render as `?` in the doc so
+   the gap is visible.
+
 Every included issue is bucketed into one of:
 
 - **Novel external source** — the default bucket. New database, new API, new

--- a/.claude/skills/novel-transforms/SKILL.md
+++ b/.claude/skills/novel-transforms/SKILL.md
@@ -72,12 +72,14 @@ Each open issue is scored against three signal sets:
    dict keyed by issue number, each entry carrying:
    - `nodes` — rough node-count magnitude as `10^N` (string; `"?"` for unknown)
    - `edges` — rough edge-count magnitude, same convention
-   - `category` — kebab-case tag from `DATA_CATEGORIES` (phenotype, genome,
-     metabolism, identity, media, environmental, ecology, fitness, literature)
+   - `category` — kebab-case key from `DATA_CATEGORIES` (see that dict for the
+     current vocabulary — it's the single source of truth for both the
+     runtime whitelist and the legend block in the doc)
 
    These cannot be derived from issue title/body — curator judgement, so add a
    row when you triage a new issue. Missing rows render as `?` in the doc so
-   the gap is visible.
+   the gap is visible. A category typo is caught at import time by
+   `_validate_source_metadata`, so a bad value cannot ship silently.
 
 Every included issue is bucketed into one of:
 

--- a/.claude/skills/novel-transforms/novel_transforms.py
+++ b/.claude/skills/novel-transforms/novel_transforms.py
@@ -96,21 +96,21 @@ MANUAL_EXCLUDE: Set[int] = {
 # Missing entries render as ``?`` in the doc so a curator can see the gap.
 # ---------------------------------------------------------------------------
 
-# Kebab-case category taxonomy. Keep this list tight — every entry needs a
-# clear one-line meaning so unrelated sources don't collide under the same
-# tag. Add a new category by extending both the tuple and the doc that
-# render_markdown prints so downstream readers understand it.
-DATA_CATEGORIES: Tuple[str, ...] = (
-    "phenotype",  # organism trait observations (growth, morphology, metabolism)
-    "genome",  # gene / protein content, functional annotation
-    "metabolism",  # pathways, reactions, end-products
-    "identity",  # crosswalks, naming registries
-    "media",  # growth-media composition
-    "environmental",  # habitat, biogeography, distribution
-    "ecology",  # inter-organism / host-microbe / microbe-drug interactions
-    "fitness",  # gene-essentiality, knockout experiments
-    "literature",  # publication associations
-)
+# Kebab-case category taxonomy. Single source of truth: this dict feeds both
+# the runtime whitelist (used to validate SOURCE_METADATA at import) AND the
+# legend block in the generated doc. Adding a category is one edit here —
+# no drift possible.
+DATA_CATEGORIES: Dict[str, str] = {
+    "phenotype": "organism trait observations (growth, morphology, metabolism)",
+    "genome": "gene / protein content, functional annotation",
+    "metabolism": "pathways / reactions / end-products",
+    "identity": "crosswalks, naming registries",
+    "media": "growth-media composition",
+    "environmental": "habitat / biogeography / distribution",
+    "ecology": "inter-organism / host-microbe / microbe-drug interactions",
+    "fitness": "gene-essentiality / knockout experiments",
+    "literature": "publication associations",
+}
 
 SOURCE_METADATA: Dict[int, Dict[str, str]] = {
     # Novel bucket
@@ -150,6 +150,32 @@ SOURCE_METADATA: Dict[int, Dict[str, str]] = {
     321: {"nodes": "10^3", "edges": "10^3", "category": "identity"},  # periodic table of bacteria
     569: {"nodes": "10^5", "edges": "10^6", "category": "environmental"},  # nmdc.cn
 }
+
+
+def _validate_source_metadata() -> None:
+    """
+    Fail fast on curator typos in :data:`SOURCE_METADATA`.
+
+    Runs at import time. Catches category typos (e.g. ``"phentoype"``) that
+    would otherwise ship a mystery tag to readers of the generated doc; the
+    error message names both the offending issue and the valid vocabulary so
+    the fix is one edit.
+    """
+    valid = set(DATA_CATEGORIES)
+    bad = [
+        (num, meta["category"])
+        for num, meta in SOURCE_METADATA.items()
+        if "category" in meta and meta["category"] not in valid
+    ]
+    if bad:
+        detail = ", ".join(f"#{num}='{cat}'" for num, cat in bad)
+        raise SystemExit(
+            f"[novel-transforms] SOURCE_METADATA carries category values not in "
+            f"DATA_CATEGORIES: {detail}. Valid: {sorted(valid)}."
+        )
+
+
+_validate_source_metadata()
 
 # ---------------------------------------------------------------------------
 # Inclusion signals (regex). Case-insensitive.
@@ -440,20 +466,10 @@ def render_markdown(kept: List[Issue], dropped: List[Issue], verbose: bool) -> s
         "see `.claude/skills/novel-transforms/SKILL.md` for the full contract.\n\n"
     )
 
-    # Category legend — kept short; every entry in DATA_CATEGORIES should have
-    # a one-line meaning here so a reader can decode the table without opening
-    # the script.
+    # Category legend generated from DATA_CATEGORIES — no drift possible.
+    legend_entries = " · ".join(f"`{name}` = {desc}" for name, desc in DATA_CATEGORIES.items())
     category_legend = (
-        "**Category legend:** "
-        "`phenotype` = organism trait observations · "
-        "`genome` = gene/protein content, functional annotation · "
-        "`metabolism` = pathways / reactions / end-products · "
-        "`identity` = crosswalks, naming registries · "
-        "`media` = growth-media composition · "
-        "`environmental` = habitat / biogeography / distribution · "
-        "`ecology` = inter-organism / host-microbe / microbe-drug interactions · "
-        "`fitness` = gene-essentiality / knockout experiments · "
-        "`literature` = publication associations.\n\n"
+        f"**Category legend:** {legend_entries}.\n\n"
         "**Scale columns** (`~Nodes` / `~Edges`) are curator estimates in "
         "powers of ten — magnitude, not exact count. `?` means the entry "
         "hasn't been sized yet; add a row to `SOURCE_METADATA` in "

--- a/.claude/skills/novel-transforms/novel_transforms.py
+++ b/.claude/skills/novel-transforms/novel_transforms.py
@@ -88,6 +88,70 @@ MANUAL_EXCLUDE: Set[int] = {
 }
 
 # ---------------------------------------------------------------------------
+# Per-source metadata. Cannot be reliably derived from title/body — this is
+# curator judgement. Fields:
+#   nodes    : rough node-count magnitude as ``10^N`` (string; use "?" if unknown)
+#   edges    : rough edge-count magnitude, same convention
+#   category : short kebab-case data-shape label from ``DATA_CATEGORIES`` below
+# Missing entries render as ``?`` in the doc so a curator can see the gap.
+# ---------------------------------------------------------------------------
+
+# Kebab-case category taxonomy. Keep this list tight — every entry needs a
+# clear one-line meaning so unrelated sources don't collide under the same
+# tag. Add a new category by extending both the tuple and the doc that
+# render_markdown prints so downstream readers understand it.
+DATA_CATEGORIES: Tuple[str, ...] = (
+    "phenotype",  # organism trait observations (growth, morphology, metabolism)
+    "genome",  # gene / protein content, functional annotation
+    "metabolism",  # pathways, reactions, end-products
+    "identity",  # crosswalks, naming registries
+    "media",  # growth-media composition
+    "environmental",  # habitat, biogeography, distribution
+    "ecology",  # inter-organism / host-microbe / microbe-drug interactions
+    "fitness",  # gene-essentiality, knockout experiments
+    "literature",  # publication associations
+)
+
+SOURCE_METADATA: Dict[int, Dict[str, str]] = {
+    # Novel bucket
+    9: {"nodes": "10^4", "edges": "10^6", "category": "fitness"},  # LBL knockouts
+    27: {"nodes": "10^3", "edges": "10^4", "category": "phenotype"},  # Weissman
+    33: {"nodes": "10^4", "edges": "10^5", "category": "ecology"},  # gutMEGA
+    34: {"nodes": "10^6", "edges": "10^7", "category": "environmental"},  # biogeography
+    36: {"nodes": "10^3", "edges": "10^4", "category": "ecology"},  # Web of Microbes
+    37: {"nodes": "10^2", "edges": "10^3", "category": "environmental"},  # skin pathobionts
+    38: {"nodes": "10^3", "edges": "10^4", "category": "environmental"},  # Microbe Directory
+    39: {"nodes": "10^5", "edges": "10^6", "category": "environmental"},  # PREGO (dup of #182)
+    41: {"nodes": "10^5", "edges": "10^6", "category": "metabolism"},  # METABOLIC
+    42: {"nodes": "10^5", "edges": "10^5", "category": "genome"},  # FusionDB
+    44: {"nodes": "10^6", "edges": "10^8", "category": "genome"},  # ProGenomes3
+    58: {"nodes": "10^4", "edges": "10^5", "category": "environmental"},  # dbBact
+    61: {"nodes": "10^3", "edges": "10^6", "category": "phenotype"},  # protraits
+    66: {"nodes": "10^4", "edges": "10^5", "category": "identity"},  # ATCC strains
+    132: {"nodes": "10^4", "edges": "10^4", "category": "identity"},  # Names4Life
+    140: {"nodes": "10^4", "edges": "10^5", "category": "ecology"},  # BugSigDB
+    141: {"nodes": "10^3", "edges": "10^4", "category": "phenotype"},  # bugbase
+    154: {"nodes": "10^3", "edges": "10^4", "category": "genome"},  # ATCC genomes
+    159: {"nodes": "10^2", "edges": "10^3", "category": "phenotype"},  # thermobase
+    177: {"nodes": "10^5", "edges": "10^6", "category": "environmental"},  # microbeatlas
+    182: {"nodes": "10^5", "edges": "10^6", "category": "environmental"},  # PREGO
+    304: {"nodes": "10^5", "edges": "10^5", "category": "identity"},  # GOLD
+    320: {"nodes": "10^3", "edges": "10^4", "category": "media"},  # togomedium
+    329: {"nodes": "10^2", "edges": "10^3", "category": "media"},  # CRBIP
+    369: {"nodes": "10^2", "edges": "10^3", "category": "media"},  # gut microbe media
+    419: {"nodes": "10^3", "edges": "10^4", "category": "media"},  # MediaDB
+    478: {"nodes": "10^3", "edges": "10^4", "category": "phenotype"},  # LASER (antibiotic resistance)
+    537: {"nodes": "10^4", "edges": "10^5", "category": "phenotype"},  # bac2feature
+    # Salvage bucket
+    518: {"nodes": "10^8", "edges": "10^9", "category": "genome"},  # UniRef90
+    519: {"nodes": "10^4", "edges": "10^5", "category": "identity"},  # HGNC
+    520: {"nodes": "10^4", "edges": "10^5", "category": "phenotype"},  # IJSEM
+    # Exploratory bucket
+    321: {"nodes": "10^3", "edges": "10^3", "category": "identity"},  # periodic table of bacteria
+    569: {"nodes": "10^5", "edges": "10^6", "category": "environmental"},  # nmdc.cn
+}
+
+# ---------------------------------------------------------------------------
 # Inclusion signals (regex). Case-insensitive.
 # ---------------------------------------------------------------------------
 
@@ -308,21 +372,46 @@ def _guess_source_name(iss: Issue) -> str:
     return stripped.split(" from ")[0].split(" for ")[0].strip() or title
 
 
+def _fmt_scale(power_str: str) -> str:
+    """Render ``10^N`` as ``10ⁿ`` using Unicode superscripts for compactness."""
+    if not power_str or power_str == "?":
+        return "?"
+    if not power_str.startswith("10^"):
+        return power_str
+    superscripts = str.maketrans("0123456789", "⁰¹²³⁴⁵⁶⁷⁸⁹")
+    return "10" + power_str[3:].translate(superscripts)
+
+
 def _render_bucket(bucket_name: str, issues: List[Issue]) -> str:
-    """Render one bucket's table (or a 'none' placeholder)."""
+    """
+    Render one bucket's table (or a 'none' placeholder).
+
+    Columns: #, Source, Category, ~Nodes, ~Edges, Title, Link. Category and
+    scale come from :data:`SOURCE_METADATA`; missing entries render as ``?``
+    so a curator sees the gap.
+    """
     if not issues:
         return "_None open._\n"
-    lines = ["| # | Source | One-line | Link |", "|---|---|---|---|"]
+    lines = [
+        "| # | Source | Category | ~Nodes | ~Edges | One-line | Link |",
+        "|---|---|---|---:|---:|---|---|",
+    ]
     for iss in issues:
         source = _guess_source_name(iss)
         summary = iss.title.strip().replace("|", "\\|")
-        # Trim summary to a reasonable column width.
-        if len(summary) > 90:
-            summary = summary[:87] + "…"
+        if len(summary) > 80:
+            summary = summary[:77] + "…"
         salvage_note = ""
         if iss.bucket == "salvage" and iss.salvage_pr is not None:
             salvage_note = f" _(salvage from PR #{iss.salvage_pr})_"
-        lines.append(f"| #{iss.number} | **{source}** | {summary}{salvage_note} | [link]({iss.url}) |")
+        meta = SOURCE_METADATA.get(iss.number, {})
+        category = meta.get("category", "?")
+        nodes = _fmt_scale(meta.get("nodes", "?"))
+        edges = _fmt_scale(meta.get("edges", "?"))
+        lines.append(
+            f"| #{iss.number} | **{source}** | {category} | {nodes} | {edges} | "
+            f"{summary}{salvage_note} | [link]({iss.url}) |"
+        )
     return "\n".join(lines) + "\n"
 
 
@@ -351,11 +440,32 @@ def render_markdown(kept: List[Issue], dropped: List[Issue], verbose: bool) -> s
         "see `.claude/skills/novel-transforms/SKILL.md` for the full contract.\n\n"
     )
 
+    # Category legend — kept short; every entry in DATA_CATEGORIES should have
+    # a one-line meaning here so a reader can decode the table without opening
+    # the script.
+    category_legend = (
+        "**Category legend:** "
+        "`phenotype` = organism trait observations · "
+        "`genome` = gene/protein content, functional annotation · "
+        "`metabolism` = pathways / reactions / end-products · "
+        "`identity` = crosswalks, naming registries · "
+        "`media` = growth-media composition · "
+        "`environmental` = habitat / biogeography / distribution · "
+        "`ecology` = inter-organism / host-microbe / microbe-drug interactions · "
+        "`fitness` = gene-essentiality / knockout experiments · "
+        "`literature` = publication associations.\n\n"
+        "**Scale columns** (`~Nodes` / `~Edges`) are curator estimates in "
+        "powers of ten — magnitude, not exact count. `?` means the entry "
+        "hasn't been sized yet; add a row to `SOURCE_METADATA` in "
+        "`novel_transforms.py` to fill it in.\n\n"
+    )
+
     sections = [
+        category_legend,
         "## Novel external sources\n\n"
         "New databases, APIs, or datasets that KG-Microbe does not cover yet. "
         "The default bucket — each entry corresponds to a transform directory "
-        "that does not exist today.\n\n" + _render_bucket("novel", novel) + "\n"
+        "that does not exist today.\n\n" + _render_bucket("novel", novel) + "\n",
     ]
 
     if salvage:
@@ -411,6 +521,7 @@ def render_json(kept: List[Issue], dropped: List[Issue]) -> str:
     """Machine-readable dump for other skills / pipelines."""
 
     def _asdict(iss: Issue) -> Dict:
+        meta = SOURCE_METADATA.get(iss.number, {})
         return {
             "number": iss.number,
             "title": iss.title,
@@ -418,6 +529,9 @@ def render_json(kept: List[Issue], dropped: List[Issue]) -> str:
             "bucket": iss.bucket,
             "salvage_pr": iss.salvage_pr,
             "source_name": _guess_source_name(iss),
+            "category": meta.get("category"),
+            "nodes_magnitude": meta.get("nodes"),
+            "edges_magnitude": meta.get("edges"),
         }
 
     payload = {

--- a/docs/NOVEL_TRANSFORMS.md
+++ b/docs/NOVEL_TRANSFORMS.md
@@ -8,7 +8,7 @@ Open GitHub issues on `Knowledge-Graph-Hub/kg-microbe` that ask for the ingest o
 
 How to update this file: run `poetry run python .claude/skills/novel-transforms/novel_transforms.py`. The skill queries the live tracker, classifies each open issue, and rewrites this doc. Tuning is done by editing the `MANUAL_INCLUDE` / `MANUAL_EXCLUDE` sets at the top of that script; see `.claude/skills/novel-transforms/SKILL.md` for the full contract.
 
-**Category legend:** `phenotype` = organism trait observations · `genome` = gene/protein content, functional annotation · `metabolism` = pathways / reactions / end-products · `identity` = crosswalks, naming registries · `media` = growth-media composition · `environmental` = habitat / biogeography / distribution · `ecology` = inter-organism / host-microbe / microbe-drug interactions · `fitness` = gene-essentiality / knockout experiments · `literature` = publication associations.
+**Category legend:** `phenotype` = organism trait observations (growth, morphology, metabolism) · `genome` = gene / protein content, functional annotation · `metabolism` = pathways / reactions / end-products · `identity` = crosswalks, naming registries · `media` = growth-media composition · `environmental` = habitat / biogeography / distribution · `ecology` = inter-organism / host-microbe / microbe-drug interactions · `fitness` = gene-essentiality / knockout experiments · `literature` = publication associations.
 
 **Scale columns** (`~Nodes` / `~Edges`) are curator estimates in powers of ten — magnitude, not exact count. `?` means the entry hasn't been sized yet; add a row to `SOURCE_METADATA` in `novel_transforms.py` to fill it in.
 

--- a/docs/NOVEL_TRANSFORMS.md
+++ b/docs/NOVEL_TRANSFORMS.md
@@ -8,61 +8,66 @@ Open GitHub issues on `Knowledge-Graph-Hub/kg-microbe` that ask for the ingest o
 
 How to update this file: run `poetry run python .claude/skills/novel-transforms/novel_transforms.py`. The skill queries the live tracker, classifies each open issue, and rewrites this doc. Tuning is done by editing the `MANUAL_INCLUDE` / `MANUAL_EXCLUDE` sets at the top of that script; see `.claude/skills/novel-transforms/SKILL.md` for the full contract.
 
+**Category legend:** `phenotype` = organism trait observations · `genome` = gene/protein content, functional annotation · `metabolism` = pathways / reactions / end-products · `identity` = crosswalks, naming registries · `media` = growth-media composition · `environmental` = habitat / biogeography / distribution · `ecology` = inter-organism / host-microbe / microbe-drug interactions · `fitness` = gene-essentiality / knockout experiments · `literature` = publication associations.
+
+**Scale columns** (`~Nodes` / `~Edges`) are curator estimates in powers of ten — magnitude, not exact count. `?` means the entry hasn't been sized yet; add a row to `SOURCE_METADATA` in `novel_transforms.py` to fill it in.
+
+
 ## Novel external sources
 
 New databases, APIs, or datasets that KG-Microbe does not cover yet. The default bucket — each entry corresponds to a transform directory that does not exist today.
 
-| # | Source | One-line | Link |
-|---|---|---|---|
-| #9 | **gene knockout** | ingest gene knockout data from LBL microbial fitness experiments | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/9) |
-| #27 | **Weissman** | Ingest Weissman et al human microbiome taxa microbial trait data | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/27) |
-| #33 | **gutMEGA** | Ingest gutMEGA | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/33) |
-| #34 | **global microbial gene biogeography** | Ingest global microbial gene biogeography | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/34) |
-| #36 | **Web of Microbes** | ingest Web of Microbes environment-metabolite change-microbe associations | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/36) |
-| #37 | **pathobionts** | Ingest distribution of pathobionts across 12 skin sites | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/37) |
-| #38 | **Microbe Directory** | Ingest The Microbe Directory | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/38) |
-| #39 | **PREGO** | Inspect data and sources for PREGO | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/39) |
-| #41 | **METABOLIC genomic** | ingest METABOLIC genomic source data and trait predictions | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/41) |
-| #42 | **FusionDB** | Ingest FusionDB | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/42) |
-| #44 | **ProGenomes3** | Ingest ProGenomes3 | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/44) |
-| #58 | **dbBact** | ingest dbBact data | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/58) |
-| #61 | **protraits** | ingest protraits | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/61) |
-| #66 | **ATCC** | strains and annotations from ATCC | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/66) |
-| #132 | **Names4Life** | ingest Names4Life | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/132) |
-| #140 | **BugSigDB** | ingest BugSigDB | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/140) |
-| #141 | **bugbase** | ingest bugbase phenotypes and predictions | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/141) |
-| #154 | **ATCC** | ingest some ATCC genome entry fields | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/154) |
-| #159 | **thermobase** | thermobase | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/159) |
-| #177 | **microbeatlas** | ingest microbeatlas environments | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/177) |
-| #182 | **PREGO** | ingest PREGO knowledgebase | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/182) |
-| #304 | **GOLD ingest** | GOLD ingest -- starting with growth information | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/304) |
-| #320 | **togomedium** | togomedium ingest exploration | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/320) |
-| #329 | **CRBIP** | ingest CRBIP media | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/329) |
-| #369 | **gut microbe media** | ingest gut microbe media table | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/369) |
-| #419 | **MediaDB** | MediaDB media, organisms and growth rates | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/419) |
-| #478 | **LASER** | ingest LASER db | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/478) |
-| #537 | **bac2feature** | ingest bac2feature data from Microbiome Datahub | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/537) |
+| # | Source | Category | ~Nodes | ~Edges | One-line | Link |
+|---|---|---|---:|---:|---|---|
+| #9 | **gene knockout** | fitness | 10⁴ | 10⁶ | ingest gene knockout data from LBL microbial fitness experiments | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/9) |
+| #27 | **Weissman** | phenotype | 10³ | 10⁴ | Ingest Weissman et al human microbiome taxa microbial trait data | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/27) |
+| #33 | **gutMEGA** | ecology | 10⁴ | 10⁵ | Ingest gutMEGA | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/33) |
+| #34 | **global microbial gene biogeography** | environmental | 10⁶ | 10⁷ | Ingest global microbial gene biogeography | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/34) |
+| #36 | **Web of Microbes** | ecology | 10³ | 10⁴ | ingest Web of Microbes environment-metabolite change-microbe associations | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/36) |
+| #37 | **pathobionts** | environmental | 10² | 10³ | Ingest distribution of pathobionts across 12 skin sites | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/37) |
+| #38 | **Microbe Directory** | environmental | 10³ | 10⁴ | Ingest The Microbe Directory | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/38) |
+| #39 | **PREGO** | environmental | 10⁵ | 10⁶ | Inspect data and sources for PREGO | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/39) |
+| #41 | **METABOLIC genomic** | metabolism | 10⁵ | 10⁶ | ingest METABOLIC genomic source data and trait predictions | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/41) |
+| #42 | **FusionDB** | genome | 10⁵ | 10⁵ | Ingest FusionDB | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/42) |
+| #44 | **ProGenomes3** | genome | 10⁶ | 10⁸ | Ingest ProGenomes3 | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/44) |
+| #58 | **dbBact** | environmental | 10⁴ | 10⁵ | ingest dbBact data | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/58) |
+| #61 | **protraits** | phenotype | 10³ | 10⁶ | ingest protraits | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/61) |
+| #66 | **ATCC** | identity | 10⁴ | 10⁵ | strains and annotations from ATCC | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/66) |
+| #132 | **Names4Life** | identity | 10⁴ | 10⁴ | ingest Names4Life | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/132) |
+| #140 | **BugSigDB** | ecology | 10⁴ | 10⁵ | ingest BugSigDB | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/140) |
+| #141 | **bugbase** | phenotype | 10³ | 10⁴ | ingest bugbase phenotypes and predictions | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/141) |
+| #154 | **ATCC** | genome | 10³ | 10⁴ | ingest some ATCC genome entry fields | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/154) |
+| #159 | **thermobase** | phenotype | 10² | 10³ | thermobase | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/159) |
+| #177 | **microbeatlas** | environmental | 10⁵ | 10⁶ | ingest microbeatlas environments | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/177) |
+| #182 | **PREGO** | environmental | 10⁵ | 10⁶ | ingest PREGO knowledgebase | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/182) |
+| #304 | **GOLD ingest** | identity | 10⁵ | 10⁵ | GOLD ingest -- starting with growth information | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/304) |
+| #320 | **togomedium** | media | 10³ | 10⁴ | togomedium ingest exploration | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/320) |
+| #329 | **CRBIP** | media | 10² | 10³ | ingest CRBIP media | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/329) |
+| #369 | **gut microbe media** | media | 10² | 10³ | ingest gut microbe media table | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/369) |
+| #419 | **MediaDB** | media | 10³ | 10⁴ | MediaDB media, organisms and growth rates | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/419) |
+| #478 | **LASER** | phenotype | 10³ | 10⁴ | ingest LASER db | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/478) |
+| #537 | **bac2feature** | phenotype | 10⁴ | 10⁵ | ingest bac2feature data from Microbiome Datahub | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/537) |
 
 
 ## Salvage from stale PRs
 
 Issues whose title marks them as recoveries of work-in-progress PRs that never merged. Same output as the Novel bucket — a new transform — but with a starting point in git history.
 
-| # | Source | One-line | Link |
-|---|---|---|---|
-| #518 | **UniRef** | Add UniRef90 transform (salvaged from stale PR #170) _(salvage from PR #170)_ | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/518) |
-| #519 | **HGNC** | Fix HGNC gene ingestion to include all UniProt mappings (salvaged from stale PR #290) _(salvage from PR #290)_ | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/519) |
-| #520 | **IJSEM** | Add IJSEM phenotypic data source (salvaged from stale PR #250, connects to OntoGPT work) _(salvage from PR #250)_ | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/520) |
+| # | Source | Category | ~Nodes | ~Edges | One-line | Link |
+|---|---|---|---:|---:|---|---|
+| #518 | **UniRef** | genome | 10⁸ | 10⁹ | Add UniRef90 transform (salvaged from stale PR #170) _(salvage from PR #170)_ | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/518) |
+| #519 | **HGNC** | identity | 10⁴ | 10⁵ | Fix HGNC gene ingestion to include all UniProt mappings (salvaged from stale … _(salvage from PR #290)_ | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/519) |
+| #520 | **IJSEM** | phenotype | 10⁴ | 10⁵ | Add IJSEM phenotypic data source (salvaged from stale PR #250, connects to On… _(salvage from PR #250)_ | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/520) |
 
 
 ## Exploratory
 
 Research-first: someone flagged an external resource worth understanding before deciding whether to ingest.
 
-| # | Source | One-line | Link |
-|---|---|---|---|
-| #321 | **periodic table of bacteria** | explore 'periodic table of bacteria' ingest | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/321) |
-| #569 | **nmdc.cn** | explore nmdc.cn data | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/569) |
+| # | Source | Category | ~Nodes | ~Edges | One-line | Link |
+|---|---|---|---:|---:|---|---|
+| #321 | **periodic table of bacteria** | identity | 10³ | 10³ | explore 'periodic table of bacteria' ingest | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/321) |
+| #569 | **nmdc.cn** | environmental | 10⁵ | 10⁶ | explore nmdc.cn data | [link](https://github.com/Knowledge-Graph-Hub/kg-microbe/issues/569) |
 
 
 ## Not in this list


### PR DESCRIPTION
## Summary

Two new columns per source in the generated doc:

- **Category** — kebab-case shape tag (`phenotype`, `genome`, `metabolism`, `identity`, `media`, `environmental`, `ecology`, `fitness`, `literature`)
- **~Nodes / ~Edges** — order-of-magnitude estimates as powers of ten (rendered `10²` … `10⁹`). Enough to tell "one afternoon" from "reshape the merge pipeline" at a glance.

Both live in a new `SOURCE_METADATA` dict keyed by issue number. Uncurated entries render as `?` so the gap is visible.

## Rendered

Sample rows from the current backlog (right-aligned scale columns):

| # | Source | Category | ~Nodes | ~Edges |
|---|---|---|---:|---:|
| #44 | **ProGenomes3** | genome | 10⁶ | 10⁸ |
| #159 | **thermobase** | phenotype | 10² | 10³ |
| #518 | **UniRef** | genome | 10⁸ | 10⁹ |

## Curation

All 33 current issues pre-populated. New issues added to the tracker will show `?` until a curator adds a row to `SOURCE_METADATA` — the doc surfaces the gap on next regeneration.

`DATA_CATEGORIES` is a whitelist; if you need a new category, extend both the tuple and the legend block that `render_markdown` emits so readers can decode it without opening the script.

## Test plan

- [x] `poetry run tox -e lint` — green
- [x] Regenerated doc looks correct (unicode superscripts render, scale columns right-align, legend block precedes tables)
- [x] JSON output (`--json`) round-trips through `json.load` and now carries `category`, `nodes_magnitude`, `edges_magnitude` per entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)