### PR TITLE
feat(prego): PREGO transform Phase 6a — associations from 3 channels (#182)

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -32,6 +32,7 @@
 #    metatraits_gtdb  MetaTraits summaries + crosswalks keyed by GTDB taxonomy
 #    bactotraits      BactoTraits V2 (static Jun-2022 dataset)
 #    microbedecoder   MicrobeDecoder wide CSV (Hackmann & Zhang, Sci Adv 2023; CC BY 4.0)
+#    prego            PREGO taxon↔env/process associations (Zafeiropoulos et al 2022; CC-BY)
 #    schema      Reference specs (Biolink Model, KGX format) — not pipeline inputs
 #
 #  A new entry MUST have a tag: tests/test_download_tags.py fails otherwise, so
@@ -292,6 +293,31 @@
   url: https://github.com/thackmann/MicrobeDecoder/raw/main/Shiny/MicrobeDecoder/data/database/database.zip
   local_name: microbedecoder_database.zip
   tag: microbedecoder
+
+#
+# PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
+# Zafeiropoulos et al. 2022, Microorganisms 10(2):293
+# License: CC-BY
+# Content: three separate association archives from three evidence channels.
+# All three unpack to a single database_pairs.tsv (JensenLab tagger format,
+# 9 cols). Unlinked from the prego.hcmr.gr/Downloads UI page but documented
+# in the paper's Appendix D — see docs/PREGO_INGEST_PLAN.md for the trail.
+# The Mamba/nginx server on prego.hcmr.gr occasionally returns HTTP 500 on
+# HEAD requests but 200 on GET — verify kghub-downloader tolerates this
+# during first `kg download -t prego`.
+#
+-
+  url: https://prego.hcmr.gr/download/literature.tar.gz
+  local_name: prego/literature.tar.gz
+  tag: prego
+-
+  url: https://prego.hcmr.gr/download/environmental_samples.tar.gz
+  local_name: prego/environmental_samples.tar.gz
+  tag: prego
+-
+  url: https://prego.hcmr.gr/download/annotated_genomes_isolates.tar.gz
+  local_name: prego/annotated_genomes_isolates.tar.gz
+  tag: prego
 
 #
 # Disbiome

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -24,6 +24,7 @@ from kg_microbe.transform_utils.constants import (
     MICROBEDECODER,
     ONTOLOGIES,
     ONTOLOGIES_STUBS,
+    PREGO,
     RHEAMAPPINGS,
 )
 from kg_microbe.transform_utils.gtdb.gtdb import GTDBTransform
@@ -42,6 +43,7 @@ from kg_microbe.transform_utils.ontologies.ontologies_transform import (
 from kg_microbe.transform_utils.ontologies_stubs.ontologies_stubs_transform import (
     OntologiesStubsTransform,
 )
+from kg_microbe.transform_utils.prego.prego import PregoTransform
 from kg_microbe.transform_utils.rhea_mappings.rhea_mappings import RheaMappingsTransform
 
 DATA_SOURCES = {
@@ -72,6 +74,7 @@ DATA_SOURCES = {
     RHEAMAPPINGS: RheaMappingsTransform,
     BACTOTRAITS: BactoTraitsTransform,
     MICROBEDECODER: MicrobeDecoderTransform,
+    PREGO: PregoTransform,
     # UNIPROT_HUMAN: UniprotHumanTransform,
     # CTD: CTDTransform,
     # DISBIOME: DisbiomeTransform,

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -23,6 +23,7 @@ GTDB = "gtdb"
 METATRAITS = "metatraits"
 METATRAITS_GTDB = "metatraits_gtdb"
 MICROBEDECODER = "microbedecoder"
+PREGO = "prego"
 
 TRANSFORM_UTILS_DIR = Path(__file__).parent
 BACDIVE_DIR = TRANSFORM_UTILS_DIR / BACDIVE
@@ -35,6 +36,7 @@ MEDIADIVE_MEDIUM_STRAIN_YAML_DIR = MEDIADIVE_TMP_DIR / "medium_strain_yaml"
 MADIN_ETAL_DIR = TRANSFORM_UTILS_DIR / MADIN_ETAL
 METATRAITS_DIR = TRANSFORM_UTILS_DIR / METATRAITS
 MICROBEDECODER_DIR = TRANSFORM_UTILS_DIR / MICROBEDECODER
+PREGO_DIR = TRANSFORM_UTILS_DIR / PREGO
 # Canonical curation hub for hand-curated label -> ontology mappings used by
 # metatraits + metatraits_gtdb. Moved from per-transform location
 # (transform_utils/metatraits/mappings/) to repo-root mappings/canonical/ in
@@ -58,6 +60,7 @@ KEGG_DIR = TRANSFORM_UTILS_DIR / KEGG
 KEGG_RAW_DIR = RAW_DATA_DIR / KEGG
 MICROBEDECODER_RAW_DIR = RAW_DATA_DIR / MICROBEDECODER
 MICROBEDECODER_MANUAL_ANNOTATION_FILE = MICROBEDECODER_DIR / "microbedecoder_manual_annotation.tsv"
+PREGO_RAW_DIR = RAW_DATA_DIR / PREGO
 UNIPROT_TREMBL_DIR = TRANSFORM_UTILS_DIR / "uniprot_trembl"
 UNIPROT_TREMBL_TMP_DIR = UNIPROT_TREMBL_DIR / "tmp"
 ONTOLOGIES_DIR = TRANSFORM_UTILS_DIR / ONTOLOGIES
@@ -240,6 +243,13 @@ BERGEY_KNOWLEDGE_SOURCE = "infores:bergey-manual"  # Bergey's Manual of Systemat
 VPI_KNOWLEDGE_SOURCE = "infores:vpi-anaerobe-manual"  # VPI Anaerobe Laboratory Manual
 LITERATURE_KNOWLEDGE_SOURCE = "infores:microbedecoder-literature"  # per-strain lit-curated
 FAPROTAX_KNOWLEDGE_SOURCE = "infores:faprotax"  # FAPROTAX functional labels
+PREGO_KNOWLEDGE_SOURCE = "infores:prego"  # PREGO taxon↔environment/process associations
+# PREGO edge attributes carried through as additional columns on emitted edges.
+# score, channel, direct_flag, evidence_url per JensenLab tagger convention.
+PREGO_SCORE_COLUMN = "prego_score"
+PREGO_CHANNEL_COLUMN = "prego_channel"
+PREGO_DIRECT_FLAG_COLUMN = "prego_direct_flag"
+PREGO_EVIDENCE_URL_COLUMN = "prego_evidence_url"
 
 MEDIADIVE_MEDIUM_TYPE_COMPLEX_ID = MEDIADIVE_MEDIUM_TYPE_PREFIX + "complex"
 MEDIADIVE_MEDIUM_TYPE_COMPLEX_LABEL = "Complex Medium"

--- a/kg_microbe/transform_utils/prego/__init__.py
+++ b/kg_microbe/transform_utils/prego/__init__.py
@@ -1,0 +1,1 @@
+"""PREGO transform package — taxon↔environment/process associations from text-mining."""

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -137,11 +137,13 @@ class PregoTransform(Transform):
         """
         Read every PREGO archive and emit nodes + edges + unmapped-associations report.
 
-        ``data_file`` is accepted for base-class compatibility but ignored —
-        PREGO ingests every ``*.tar.gz`` in its raw directory (typically the
-        three channels: literature / environmental_samples /
-        annotated_genomes_isolates). ``show_status`` toggles the tqdm progress
-        bar; false is used by the pytest suite to keep captured output clean.
+        ``data_file`` is accepted for base-class compatibility but ignored.
+        PREGO ingests every ``*.tar.gz`` in its raw directory — the full
+        three-channel set (literature / environmental_samples /
+        annotated_genomes_isolates) is the intended production input, but any
+        subset works (e.g. the isolates-only canary). ``show_status`` toggles
+        the tqdm progress bar; false is used by the pytest suite to keep
+        captured output clean.
         """
         del data_file  # multi-archive ingest; scanned from raw dir
 
@@ -184,27 +186,50 @@ class PregoTransform(Transform):
     # ------------------------------------------------------------------ #
 
     def _process_archive(self, archive_path, doid_to_mondo, node_writer, edge_writer, show_status: bool = True):
-        """Extract ``database_pairs.tsv`` from one archive and stream it row-by-row."""
-        # PREGO archives are single-file tar.gz payloads (verified 2026-08-04 canary).
-        # Extract the payload into the archive's own directory next to the tarball
-        # so the same file can be reused across re-runs without paying decompression
-        # cost twice.
+        """
+        Extract ``database_pairs.tsv`` from one archive and stream it row-by-row.
+
+        Cache-then-reuse: extract once into a sibling ``_extracted`` dir so
+        re-runs don't pay the ~30 s decompression cost twice. Guard against
+        interrupted-extraction: if the cached payload's size doesn't match the
+        tar member's declared size, re-extract rather than trusting a possibly
+        truncated file (the alternative would silently emit fewer edges on a
+        retry after Ctrl-C / disk-full / OOM).
+        """
         payload_dir = archive_path.parent / archive_path.stem.replace(".tar", "_extracted")
         payload_dir.mkdir(parents=True, exist_ok=True)
         payload_file = payload_dir / "database_pairs.tsv"
-        if not payload_file.exists():
-            print(f"[prego] extracting {archive_path.name} → {payload_file.name}...")
-            with tarfile.open(archive_path, mode="r:gz") as tf:
-                for member in tf.getmembers():
-                    if not member.name.endswith("database_pairs.tsv"):
-                        continue
-                    with tf.extractfile(member) as src, payload_file.open("wb") as dst:
-                        while True:
-                            chunk = src.read(1024 * 1024)
-                            if not chunk:
-                                break
-                            dst.write(chunk)
-                    break
+
+        # Read the member's declared size up front so we can compare against
+        # any cached file and decide whether re-extraction is needed.
+        with tarfile.open(archive_path, mode="r:gz") as tf:
+            member = next(
+                (m for m in tf.getmembers() if m.name.endswith("database_pairs.tsv")),
+                None,
+            )
+            if member is None:
+                raise SystemExit(
+                    f"[prego] {archive_path.name}: no database_pairs.tsv member found in tarball."
+                )
+            expected_size = member.size
+            need_extract = (
+                not payload_file.exists() or payload_file.stat().st_size != expected_size
+            )
+            if need_extract:
+                if payload_file.exists():
+                    print(
+                        f"[prego] cached {payload_file.name} size "
+                        f"({payload_file.stat().st_size:,}) != tar member "
+                        f"({expected_size:,}); re-extracting"
+                    )
+                else:
+                    print(f"[prego] extracting {archive_path.name} → {payload_file.name}...")
+                with tf.extractfile(member) as src, payload_file.open("wb") as dst:
+                    while True:
+                        chunk = src.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        dst.write(chunk)
 
         print(f"[prego] processing {payload_file.name} ({payload_file.stat().st_size / 1024**3:.1f} GB)")
         row_iter = iter_database_pairs(payload_file)
@@ -230,6 +255,12 @@ class PregoTransform(Transform):
             entity2_id = row[3]
             source = row[4]
             channel = row[5]
+            # Defensive: an empty entity_id would produce a malformed
+            # CURIE like `NCBITaxon:` on emit. Not seen in the canary,
+            # but a two-line check is cheap insurance.
+            if not entity1_id or not entity2_id:
+                self._record_drop("empty_id", entity1_type, entity1_id, entity2_type, entity2_id)
+                return
             score = row[6]
             direct_flag = row[7]
             evidence_url = row[8]

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -1,0 +1,389 @@
+"""
+PREGO transform — ingest taxon↔environment/process associations.
+
+Reads the three ``database_pairs.tsv`` archives from
+https://prego.hcmr.gr/download/ (documented in the paper's Appendix D — see
+`docs/PREGO_INGEST_PLAN.md` for the full acquisition trail and schema
+discovery) and emits KGX-format node + edge TSVs plus an
+``unmapped_associations.tsv`` curation report for rows that were
+intentionally skipped.
+
+Phase 6a scope (this module): the associations themselves. Phase 6b
+(dictionary synonym enrichment from ``prego_dictionary.tar.gz``) is a
+follow-up per the plan's own ship-6a-first guidance.
+
+Emitted edge shapes (canonical directions matching KGM convention — see
+`utils.classify_row`):
+
+- ``NCBITaxon:X → biolink:capable_of → GO:Y``  (all 3 GO namespaces)
+- ``ENVO:Y → biolink:location_of → NCBITaxon:X``  (matches bacdive)
+- ``NCBITaxon:X → biolink:associated_with → MONDO:Y``  (DOID routed via xref)
+
+Each edge carries per-row PREGO metadata (``score``, ``channel``,
+``direct_flag``, ``evidence_url``) as extra columns beyond the KGX
+minimum, so downstream consumers can filter by evidence type or
+threshold on confidence.
+"""
+
+from __future__ import annotations
+
+import csv
+import tarfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional, Union
+
+from tqdm import tqdm
+
+from kg_microbe.transform_utils.constants import (
+    CAPABLE_OF_PREDICATE,
+    CATEGORY_COLUMN,
+    ID_COLUMN,
+    OBJECT_COLUMN,
+    PREDICATE_COLUMN,
+    PREGO,
+    PREGO_CHANNEL_COLUMN,
+    PREGO_DIRECT_FLAG_COLUMN,
+    PREGO_EVIDENCE_URL_COLUMN,
+    PREGO_KNOWLEDGE_SOURCE,
+    PREGO_SCORE_COLUMN,
+    PRIMARY_KNOWLEDGE_SOURCE_COLUMN,
+    PROVIDED_BY_COLUMN,
+    RELATION_COLUMN,
+    SUBJECT_COLUMN,
+)
+from kg_microbe.transform_utils.prego.utils import (
+    KEEP_ENVO_TO_TAXON,
+    KEEP_TAXON_TO_DOID,
+    KEEP_TAXON_TO_GO,
+    classify_row,
+    go_category_for_type,
+    iter_database_pairs,
+    load_doid_to_mondo,
+)
+from kg_microbe.transform_utils.transform import Transform
+
+# ---------------------------------------------------------------------------
+# Edge predicates and relations. PREGO uses only biolink predicates; the
+# RELATION_COLUMN carries an RO term where an obvious one applies, else empty.
+# ---------------------------------------------------------------------------
+_LOCATION_OF_PREDICATE = "biolink:location_of"
+_ASSOCIATED_WITH_PREDICATE = "biolink:associated_with"
+_RELATION_LOCATION_OF = "RO:0001015"  # source → location_of → organism
+_RELATION_CAPABLE_OF = "RO:0002215"  # organism → capable_of → process
+_RELATION_ASSOCIATED_WITH = "RO:0002610"  # correlated with
+
+# ---------------------------------------------------------------------------
+# Node categories for stub emission. The `ontologies` transform is
+# authoritative for these CURIEs; PREGO's stubs let its own edges resolve
+# in its own nodes.tsv, and merge-time dedup upgrades the category if a
+# richer row exists.
+# ---------------------------------------------------------------------------
+_NCBITAXON_CATEGORY = "biolink:OrganismTaxon"
+_ENVO_CATEGORY = "biolink:OntologyClass"  # heterogeneous in ENVO; safe default
+_MONDO_CATEGORY = "biolink:Disease"
+
+# ---------------------------------------------------------------------------
+# Extra edge columns beyond the KGX minimum. Kept as a small tuple so the
+# header is single-sourced.
+# ---------------------------------------------------------------------------
+_PREGO_EDGE_EXTRA_COLUMNS = (
+    PREGO_SCORE_COLUMN,
+    PREGO_CHANNEL_COLUMN,
+    PREGO_DIRECT_FLAG_COLUMN,
+    PREGO_EVIDENCE_URL_COLUMN,
+)
+
+
+class PregoTransform(Transform):
+
+    """Ingest PREGO taxon↔environment/process associations."""
+
+    def __init__(
+        self,
+        input_dir: Optional[Path] = None,
+        output_dir: Optional[Path] = None,
+    ):
+        """Instantiate; register the source name + extend the edge header with PREGO metadata."""
+        super().__init__(PREGO, input_dir, output_dir)
+        # Extend edge header with PREGO's per-row metadata columns. Node
+        # header is unchanged (id / category / name / description / xref /
+        # provided_by / synonym / deprecated / same_as).
+        self.edge_header = list(self.edge_header) + list(_PREGO_EDGE_EXTRA_COLUMNS)
+        # Where mondo xrefs live in the ontologies output.
+        self._mondo_nodes_file = self.output_base_dir / "ontologies" / "mondo_nodes.tsv"
+        # Curation report path — one row per (drop_reason, source_id) pair
+        # with an occurrence count, so a curator can prioritise fix targets.
+        self.unmapped_report_file = self.output_dir / "unmapped_associations.tsv"
+        # Per-run counters.
+        self._stats = {
+            "rows_read": 0,
+            "rows_malformed": 0,
+            "edges_emitted": 0,
+            "edges_by_shape": defaultdict(int),
+            "rows_dropped": 0,
+            "rows_dropped_by_reason": defaultdict(int),
+            "doid_no_mondo_xref": 0,
+            "unique_nodes_emitted": 0,
+        }
+        # Node de-dup set — a CURIE seen twice only emits one node row.
+        self._emitted_nodes: set = set()
+        # Detailed drop report keyed by (reason, exemplar_id) so the report
+        # can point curators at the specific IDs that got dropped, capped
+        # per-reason to avoid unbounded memory on 10^8-row runs.
+        self._drop_examples: dict = defaultdict(lambda: defaultdict(int))
+
+    def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True):
+        """
+        Read every PREGO archive and emit nodes + edges + unmapped-associations report.
+
+        ``data_file`` is accepted for base-class compatibility but ignored —
+        PREGO ingests every ``*.tar.gz`` in its raw directory (typically the
+        three channels: literature / environmental_samples /
+        annotated_genomes_isolates). ``show_status`` toggles the tqdm progress
+        bar; false is used by the pytest suite to keep captured output clean.
+        """
+        del data_file  # multi-archive ingest; scanned from raw dir
+
+        prego_raw_dir = self.input_base_dir / PREGO
+        if not prego_raw_dir.is_dir():
+            raise SystemExit(f"[prego] {prego_raw_dir} not found. Run `poetry run kg download -t prego` first.")
+
+        archives = sorted(prego_raw_dir.glob("*.tar.gz"))
+        if not archives:
+            raise SystemExit(
+                f"[prego] no *.tar.gz archives in {prego_raw_dir}. Run `poetry run kg download -t prego` first."
+            )
+
+        doid_to_mondo = load_doid_to_mondo(self._mondo_nodes_file)
+        if not doid_to_mondo:
+            print(
+                f"[prego] WARNING: no DOID→MONDO xrefs loaded from {self._mondo_nodes_file}; "
+                "every DOID row will drop to the unmapped report. Re-run the ontologies "
+                "transform if you want disease edges."
+            )
+
+        Path.mkdir(self.output_dir, exist_ok=True, parents=True)
+        with (
+            self.output_node_file.open("w", newline="") as node_fh,
+            self.output_edge_file.open("w", newline="") as edge_fh,
+        ):
+            node_writer = csv.writer(node_fh, delimiter="\t")
+            edge_writer = csv.writer(edge_fh, delimiter="\t")
+            node_writer.writerow(self.node_header)
+            edge_writer.writerow(self.edge_header)
+
+            for archive_path in archives:
+                self._process_archive(archive_path, doid_to_mondo, node_writer, edge_writer, show_status=show_status)
+
+        self._write_unmapped_report()
+        self._print_summary()
+
+    # ------------------------------------------------------------------ #
+    # Per-archive processing.
+    # ------------------------------------------------------------------ #
+
+    def _process_archive(self, archive_path, doid_to_mondo, node_writer, edge_writer, show_status: bool = True):
+        """Extract ``database_pairs.tsv`` from one archive and stream it row-by-row."""
+        # PREGO archives are single-file tar.gz payloads (verified 2026-08-04 canary).
+        # Extract the payload into the archive's own directory next to the tarball
+        # so the same file can be reused across re-runs without paying decompression
+        # cost twice.
+        payload_dir = archive_path.parent / archive_path.stem.replace(".tar", "_extracted")
+        payload_dir.mkdir(parents=True, exist_ok=True)
+        payload_file = payload_dir / "database_pairs.tsv"
+        if not payload_file.exists():
+            print(f"[prego] extracting {archive_path.name} → {payload_file.name}...")
+            with tarfile.open(archive_path, mode="r:gz") as tf:
+                for member in tf.getmembers():
+                    if not member.name.endswith("database_pairs.tsv"):
+                        continue
+                    with tf.extractfile(member) as src, payload_file.open("wb") as dst:
+                        while True:
+                            chunk = src.read(1024 * 1024)
+                            if not chunk:
+                                break
+                            dst.write(chunk)
+                    break
+
+        print(f"[prego] processing {payload_file.name} ({payload_file.stat().st_size / 1024**3:.1f} GB)")
+        row_iter = iter_database_pairs(payload_file)
+        if show_status:
+            row_iter = tqdm(row_iter, desc=archive_path.name, unit="rows")
+        for row, err in row_iter:
+            self._stats["rows_read"] += 1
+            if err is not None:
+                self._stats["rows_malformed"] += 1
+                continue
+            self._process_row(row, doid_to_mondo, node_writer, edge_writer)
+
+    # ------------------------------------------------------------------ #
+    # Per-row processing.
+    # ------------------------------------------------------------------ #
+
+    def _process_row(self, row, doid_to_mondo, node_writer, edge_writer):
+        """Route one raw row through the canonical-direction filter + edge emission."""
+        try:
+            entity1_type = int(row[0])
+            entity1_id = row[1]
+            entity2_type = int(row[2])
+            entity2_id = row[3]
+            source = row[4]
+            channel = row[5]
+            score = row[6]
+            direct_flag = row[7]
+            evidence_url = row[8]
+        except (ValueError, IndexError):
+            self._stats["rows_malformed"] += 1
+            return
+
+        del source  # column carried in edge_attribute space for now; unused
+
+        outcome = classify_row(entity1_type, entity2_type)
+        if outcome not in (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID):
+            self._record_drop(outcome, entity1_type, entity1_id, entity2_type, entity2_id)
+            return
+
+        if outcome == KEEP_TAXON_TO_GO:
+            subject = f"NCBITaxon:{entity1_id}"
+            obj = entity2_id  # already "GO:xxxxxxx"
+            predicate = CAPABLE_OF_PREDICATE
+            relation = _RELATION_CAPABLE_OF
+            self._emit_node(node_writer, subject, _NCBITAXON_CATEGORY)
+            self._emit_node(node_writer, obj, go_category_for_type(entity2_type))
+
+        elif outcome == KEEP_ENVO_TO_TAXON:
+            subject = entity1_id  # already "ENVO:xxxxxxx"
+            obj = f"NCBITaxon:{entity2_id}"
+            predicate = _LOCATION_OF_PREDICATE
+            relation = _RELATION_LOCATION_OF
+            self._emit_node(node_writer, subject, _ENVO_CATEGORY)
+            self._emit_node(node_writer, obj, _NCBITAXON_CATEGORY)
+
+        else:  # KEEP_TAXON_TO_DOID
+            mondo = doid_to_mondo.get(entity2_id)
+            if mondo is None:
+                self._stats["doid_no_mondo_xref"] += 1
+                self._record_drop("doid_no_mondo_xref", entity1_type, entity1_id, entity2_type, entity2_id)
+                return
+            subject = f"NCBITaxon:{entity1_id}"
+            obj = mondo
+            predicate = _ASSOCIATED_WITH_PREDICATE
+            relation = _RELATION_ASSOCIATED_WITH
+            self._emit_node(node_writer, subject, _NCBITAXON_CATEGORY)
+            self._emit_node(node_writer, obj, _MONDO_CATEGORY)
+
+        edge_writer.writerow(
+            self._make_edge_row(
+                subject=subject,
+                predicate=predicate,
+                obj=obj,
+                relation=relation,
+                score=score,
+                channel=channel,
+                direct_flag=direct_flag,
+                evidence_url=evidence_url,
+            )
+        )
+        self._stats["edges_emitted"] += 1
+        self._stats["edges_by_shape"][outcome] += 1
+
+    # ------------------------------------------------------------------ #
+    # Writers.
+    # ------------------------------------------------------------------ #
+
+    def _emit_node(self, node_writer, node_id: str, category: str) -> None:
+        """Emit a stub node row if not already emitted (dedup by id)."""
+        if node_id in self._emitted_nodes:
+            return
+        self._emitted_nodes.add(node_id)
+        self._stats["unique_nodes_emitted"] += 1
+        row = {col: "" for col in self.node_header}
+        row[ID_COLUMN] = node_id
+        row[CATEGORY_COLUMN] = category
+        row[PROVIDED_BY_COLUMN] = PREGO_KNOWLEDGE_SOURCE
+        node_writer.writerow([row[c] for c in self.node_header])
+
+    def _make_edge_row(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        relation: str,
+        score: str,
+        channel: str,
+        direct_flag: str,
+        evidence_url: str,
+    ) -> list:
+        """Produce one edge row matching ``self.edge_header``."""
+        row = {col: "" for col in self.edge_header}
+        row[SUBJECT_COLUMN] = subject
+        row[PREDICATE_COLUMN] = predicate
+        row[OBJECT_COLUMN] = obj
+        row[RELATION_COLUMN] = relation
+        row[PRIMARY_KNOWLEDGE_SOURCE_COLUMN] = PREGO_KNOWLEDGE_SOURCE
+        row[PREGO_SCORE_COLUMN] = score
+        row[PREGO_CHANNEL_COLUMN] = channel
+        row[PREGO_DIRECT_FLAG_COLUMN] = direct_flag
+        row[PREGO_EVIDENCE_URL_COLUMN] = evidence_url
+        return [row[c] for c in self.edge_header]
+
+    # ------------------------------------------------------------------ #
+    # Drop tracking + report.
+    # ------------------------------------------------------------------ #
+
+    _MAX_EXAMPLES_PER_REASON = 500
+
+    def _record_drop(self, reason, e1_type, e1_id, e2_type, e2_id) -> None:
+        """
+        Increment drop counters and record an exemplar row per (reason, key).
+
+        Key is `(entity1_type, entity1_id, entity2_type, entity2_id)` compressed
+        to a short string. Per-reason exemplar count is capped so a
+        10^8-row run doesn't accumulate an unbounded dict.
+        """
+        self._stats["rows_dropped"] += 1
+        self._stats["rows_dropped_by_reason"][reason] += 1
+        bucket = self._drop_examples[reason]
+        if len(bucket) >= self._MAX_EXAMPLES_PER_REASON:
+            return
+        key = f"{e1_type}:{e1_id}->{e2_type}:{e2_id}"
+        bucket[key] += 1
+
+    def _write_unmapped_report(self) -> None:
+        """
+        Emit ``unmapped_associations.tsv`` — the per-run curation report.
+
+        One row per (reason, exemplar_key) with an occurrence count, sorted
+        by (reason, -count) so curators can scan the largest drop buckets
+        first.
+        """
+        with self.unmapped_report_file.open("w", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            writer.writerow(["reason", "exemplar_row", "occurrences", "reason_total"])
+            for reason in sorted(self._drop_examples):
+                total = self._stats["rows_dropped_by_reason"][reason]
+                sorted_examples = sorted(self._drop_examples[reason].items(), key=lambda kv: (-kv[1], kv[0]))
+                for key, count in sorted_examples:
+                    writer.writerow([reason, key, count, total])
+
+    # ------------------------------------------------------------------ #
+    # Summary.
+    # ------------------------------------------------------------------ #
+
+    def _print_summary(self) -> None:
+        """One-line summary a run script or CI log can grep for."""
+        by_shape = dict(self._stats["edges_by_shape"])
+        by_reason = dict(self._stats["rows_dropped_by_reason"])
+        print(
+            f"[prego] rows_read={self._stats['rows_read']:,} "
+            f"malformed={self._stats['rows_malformed']:,} "
+            f"edges_emitted={self._stats['edges_emitted']:,} "
+            f"nodes_emitted={self._stats['unique_nodes_emitted']:,} "
+            f"dropped={self._stats['rows_dropped']:,} "
+            f"doid_no_mondo={self._stats['doid_no_mondo_xref']:,}"
+        )
+        if by_shape:
+            print(f"[prego] edges_by_shape={by_shape}")
+        if by_reason:
+            print(f"[prego] rows_dropped_by_reason={by_reason}")

--- a/kg_microbe/transform_utils/prego/utils.py
+++ b/kg_microbe/transform_utils/prego/utils.py
@@ -1,0 +1,185 @@
+"""
+Helpers for the PREGO transform.
+
+Keeps ``prego.py`` focused on row → edge emission. Everything here is a pure
+function that :func:`prego.PregoTransform._process_row` can call without
+touching the transform's own state.
+
+The JensenLab tagger convention is documented in
+``docs/PREGO_INGEST_PLAN.md`` §Phase 3. The nine-column ``database_pairs.tsv``
+schema and the integer entity-type codes live in the constants below; the
+canonical-direction filter (:func:`classify_row`) implements the dedup step
+described in the plan's §Phase 6a (every unique association appears twice in
+the raw archives as ``(X, Y)`` AND as ``(Y, X)`` — the filter keeps one
+canonical direction per row shape and drops the inverse in O(1) memory).
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Iterator, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# JensenLab tagger entity type codes. Positive integers are NCBI taxonomy IDs
+# for species-specific proteins; negative integers are the standardized
+# vocabularies. Only the ones PREGO uses in practice are listed.
+# ---------------------------------------------------------------------------
+PREGO_TYPE_NCBITAXON = -2
+PREGO_TYPE_GO_BP = -21  # biological_process
+PREGO_TYPE_GO_CC = -22  # cellular_component
+PREGO_TYPE_GO_MF = -23  # molecular_function
+PREGO_TYPE_BTO = -25  # BTO tissues
+PREGO_TYPE_DOID = -26  # DOID diseases
+PREGO_TYPE_ENVO = -27  # ENVO environments
+
+# All three GO namespaces route to the same biolink predicate.
+_GO_TYPES = frozenset({PREGO_TYPE_GO_BP, PREGO_TYPE_GO_CC, PREGO_TYPE_GO_MF})
+
+# Nine-column schema of ``database_pairs.tsv`` (canary-verified 2026-08-04).
+DATABASE_PAIRS_COLUMNS: Tuple[str, ...] = (
+    "entity1_type",
+    "entity1_id",
+    "entity2_type",
+    "entity2_id",
+    "source",
+    "channel",
+    "score",
+    "direct_flag",
+    "evidence_url",
+)
+DATABASE_PAIRS_NCOL = len(DATABASE_PAIRS_COLUMNS)
+
+
+# ---------------------------------------------------------------------------
+# Row classification.
+# ---------------------------------------------------------------------------
+
+# Sentinel outcomes for :func:`classify_row`. Kept as short strings so the
+# unmapped-associations report reads clearly for a curator scanning it.
+KEEP_TAXON_TO_GO = "taxon_to_go"
+KEEP_ENVO_TO_TAXON = "envo_to_taxon"
+KEEP_TAXON_TO_DOID = "taxon_to_doid"
+DROP_INVERSE_TAXON_TO_GO = "inverse_go_to_taxon"
+DROP_INVERSE_ENVO_TO_TAXON = "inverse_taxon_to_envo"
+DROP_BTO_DEFERRED_V2 = "bto_deferred_v2"
+DROP_TAXON_TAXON_HOST = "taxon_taxon_host"
+DROP_UNKNOWN_SHAPE = "unknown_shape"
+
+
+def classify_row(entity1_type: int, entity2_type: int) -> str:
+    """
+    Return a short outcome tag for one raw PREGO row.
+
+    Callers use the tag either to route the row to :func:`build_edge` (any
+    ``KEEP_*`` tag) or to increment the unmapped-associations report bucket
+    (any ``DROP_*`` tag). See the module docstring for the canonical-direction
+    dedup rationale.
+    """
+    if entity1_type == PREGO_TYPE_NCBITAXON and entity2_type in _GO_TYPES:
+        return KEEP_TAXON_TO_GO
+    if entity1_type == PREGO_TYPE_ENVO and entity2_type == PREGO_TYPE_NCBITAXON:
+        return KEEP_ENVO_TO_TAXON
+    if entity1_type == PREGO_TYPE_NCBITAXON and entity2_type == PREGO_TYPE_DOID:
+        return KEEP_TAXON_TO_DOID
+    # Inverses of the three canonical directions — drop, don't re-emit.
+    if entity1_type in _GO_TYPES and entity2_type == PREGO_TYPE_NCBITAXON:
+        return DROP_INVERSE_TAXON_TO_GO
+    if entity1_type == PREGO_TYPE_NCBITAXON and entity2_type == PREGO_TYPE_ENVO:
+        return DROP_INVERSE_ENVO_TO_TAXON
+    # BTO deferred per v1 scope (see docs/PREGO_INGEST_PLAN.md §Explicitly out-of-scope).
+    if entity2_type == PREGO_TYPE_BTO or entity1_type == PREGO_TYPE_BTO:
+        return DROP_BTO_DEFERRED_V2
+    # Taxon-taxon host / co-occurrence rows (e.g. → NCBITaxon:9606 human).
+    if entity1_type == PREGO_TYPE_NCBITAXON and entity2_type == PREGO_TYPE_NCBITAXON:
+        return DROP_TAXON_TAXON_HOST
+    return DROP_UNKNOWN_SHAPE
+
+
+# ---------------------------------------------------------------------------
+# Node category resolution for stub emission. The `ontologies` transform is
+# the authoritative source of names + categories for these CURIEs; PREGO's
+# stubs only exist so its own edges have endpoints in its own nodes.tsv, and
+# the merge step dedups on id and prefers the ontologies row's richer info.
+# ---------------------------------------------------------------------------
+
+_GO_CATEGORY_BY_TYPE: Dict[int, str] = {
+    PREGO_TYPE_GO_BP: "biolink:BiologicalProcess",
+    PREGO_TYPE_GO_CC: "biolink:CellularComponent",
+    PREGO_TYPE_GO_MF: "biolink:MolecularActivity",
+}
+
+
+def go_category_for_type(entity_type: int) -> str:
+    """Return the biolink category matching a GO tagger type integer."""
+    return _GO_CATEGORY_BY_TYPE.get(entity_type, "biolink:OntologyClass")
+
+
+# ---------------------------------------------------------------------------
+# DOID → MONDO xref lookup.
+# ---------------------------------------------------------------------------
+
+
+def load_doid_to_mondo(mondo_nodes_file: Path) -> Dict[str, str]:
+    """
+    Build a ``{DOID:xxx: MONDO:yyy}`` lookup from the ontologies output.
+
+    Reads ``data/transformed/ontologies/mondo_nodes.tsv``, which carries a
+    pipe-delimited ``xref`` column containing DOID / MESH / NCIT / ... aliases
+    per MONDO term. The lookup is small enough (a few tens of thousands of
+    DOID entries) to sit in memory for the full PREGO run.
+
+    Returns an empty dict if the file does not exist — the transform will
+    then log-and-skip every DOID row rather than crash, which is the correct
+    behavior when the ontologies transform hasn't been re-run.
+    """
+    lookup: Dict[str, str] = {}
+    if not mondo_nodes_file.is_file():
+        return lookup
+    with mondo_nodes_file.open("r", newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        for row in reader:
+            mondo_id = row.get("id", "")
+            if not mondo_id.startswith("MONDO:"):
+                continue
+            xrefs = (row.get("xref") or "").split("|")
+            for xref in xrefs:
+                if xref.startswith("DOID:"):
+                    # Prefer first-seen mapping; MONDO xrefs are curated one-to-one
+                    # for DOID so collisions are rare, but if one occurs the first
+                    # row wins (deterministic per file order).
+                    lookup.setdefault(xref, mondo_id)
+    return lookup
+
+
+# ---------------------------------------------------------------------------
+# Raw-row iterator.
+# ---------------------------------------------------------------------------
+
+
+def iter_database_pairs(path: Path) -> Iterator[Tuple[list, Optional[str]]]:
+    """
+    Yield ``(row, error)`` pairs from a ``database_pairs.tsv``.
+
+    ``row`` is the raw split list of exactly nine strings when the row is
+    well-formed and ``error`` is ``None``. When a row is malformed, ``row``
+    is the raw list (may be any length) and ``error`` is a short reason
+    string. Callers should count malformed rows and continue rather than
+    raise — real files carry ~10^8 rows, and one bad line shouldn't sink
+    the whole transform.
+
+    Encoded as a plain generator over line-oriented reads; the caller is
+    responsible for opening a stream-friendly file handle (raw TSV, or
+    ``tarfile.extractfile()`` output). No CSV quoting is expected — PREGO
+    files are pure tab-delimited, no embedded quotes.
+    """
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.rstrip("\n\r")
+            if not line:
+                continue
+            row = line.split("\t")
+            if len(row) != DATABASE_PAIRS_NCOL:
+                yield row, f"malformed line {lineno}: got {len(row)} cols, want {DATABASE_PAIRS_NCOL}"
+                continue
+            yield row, None

--- a/merge.yaml
+++ b/merge.yaml
@@ -215,6 +215,17 @@ merged_graph:
         filename:
           - data/transformed/microbedecoder/nodes.tsv
           - data/transformed/microbedecoder/edges.tsv
+    # PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
+    # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
+    # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO
+    # associated_with (via DOID→MONDO xref). See docs/PREGO_INGEST_PLAN.md.
+    prego:
+      name: "PREGO"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/prego/nodes.tsv
+          - data/transformed/prego/edges.tsv
     # kegg:
     #   name: "kegg"
     #   input:

--- a/tests/resources/prego/database_pairs.tsv
+++ b/tests/resources/prego/database_pairs.tsv
@@ -1,0 +1,11 @@
+-2	100	-23	GO:0000034	JGI IMG	Isolates	4	TRUE	https://img.jgi.doe.gov/example1
+-2	100	-21	GO:0006355	JGI IMG	Isolates	3	TRUE	https://img.jgi.doe.gov/example2
+-2	100	-22	GO:0005634	JGI IMG	Isolates	3	TRUE	https://img.jgi.doe.gov/example3
+-23	GO:0000034	-2	100	JGI IMG	Isolates	4	TRUE	https://img.jgi.doe.gov/example4
+-27	ENVO:00000011	-2	693444	JGI IMG	Isolates	3	TRUE	https://img.jgi.doe.gov/example5
+-2	693444	-27	ENVO:00000011	JGI IMG	Isolates	3	TRUE	https://img.jgi.doe.gov/example6
+-2	562	-26	DOID:8	BioProject	PMID:12345678	3	TRUE	
+-2	562	-26	DOID:99999999	BioProject	PMID:12345679	3	TRUE	
+-2	562	-25	BTO:0000763	BioProject	PMID:12345680	3	TRUE	
+-2	1000570	-2	9606	JGI IMG	Human	4	TRUE	
+badrow_with_only_three_columns	x	y

--- a/tests/resources/prego/mondo_nodes_fixture.tsv
+++ b/tests/resources/prego/mondo_nodes_fixture.tsv
@@ -1,0 +1,3 @@
+id	category	name	description	xref	provided_by	synonym	deprecated	same_as
+MONDO:0007256	biolink:Disease	acquired immunodeficiency syndrome		DOID:8|MESH:D000163	infores:mondo
+MONDO:0000000	biolink:Disease	unknown other		DOID:11111111|MESH:D999999	infores:mondo

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -32,6 +32,7 @@ KNOWN_TAGS = {
     "metatraits_gtdb",
     "bactotraits",
     "microbedecoder",
+    "prego",
     "schema",
 }
 

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -1,0 +1,249 @@
+"""Tests for the PREGO transform."""
+
+import csv
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from kg_microbe.transform_utils.constants import (
+    CAPABLE_OF_PREDICATE,
+    PREGO_KNOWLEDGE_SOURCE,
+)
+from kg_microbe.transform_utils.prego.prego import PregoTransform
+from kg_microbe.transform_utils.prego.utils import (
+    DROP_BTO_DEFERRED_V2,
+    DROP_INVERSE_ENVO_TO_TAXON,
+    DROP_INVERSE_TAXON_TO_GO,
+    DROP_TAXON_TAXON_HOST,
+    KEEP_TAXON_TO_GO,
+    classify_row,
+    load_doid_to_mondo,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "resources" / "prego"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def prego_input_dir(tmp_path: Path) -> Path:
+    """
+    Build the PREGO raw input layout the transform expects.
+
+    Wraps ``tests/resources/prego/database_pairs.tsv`` in a
+    ``literature.tar.gz``-shaped tarball under
+    ``<tmp>/raw/prego/literature.tar.gz``, matching the real archive
+    layout (single-file payload named ``database_pairs.tsv``).
+    """
+    raw_dir = tmp_path / "raw"
+    prego_raw = raw_dir / "prego"
+    prego_raw.mkdir(parents=True)
+    archive = prego_raw / "literature.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(FIXTURE_DIR / "database_pairs.tsv", arcname="database_pairs.tsv")
+    return raw_dir
+
+
+@pytest.fixture()
+def prego_output_dir(tmp_path: Path) -> Path:
+    """
+    Build the PREGO output layout the transform expects.
+
+    Seeds ``<tmp>/transformed/ontologies/mondo_nodes.tsv`` from the
+    fixture so ``load_doid_to_mondo`` finds real DOID→MONDO xrefs.
+    """
+    out = tmp_path / "transformed"
+    ontologies_dir = out / "ontologies"
+    ontologies_dir.mkdir(parents=True)
+    shutil.copy(FIXTURE_DIR / "mondo_nodes_fixture.tsv", ontologies_dir / "mondo_nodes.tsv")
+    return out
+
+
+@pytest.fixture()
+def prego_transform(prego_input_dir: Path, prego_output_dir: Path) -> PregoTransform:
+    """Return a ``PregoTransform`` wired to the fixture input + output dirs."""
+    return PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+
+
+def _read_tsv(path: Path) -> list:
+    """Read a TSV into a list of dicts (header row → per-row dicts)."""
+    with open(path, newline="") as fh:
+        return list(csv.DictReader(fh, delimiter="\t"))
+
+
+# ---------------------------------------------------------------------------
+# classify_row (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_row_taxon_to_go_all_namespaces():
+    """All 3 GO namespaces (-21 BP, -22 CC, -23 MF) route to KEEP_TAXON_TO_GO."""
+    for go_type in (-21, -22, -23):
+        assert classify_row(-2, go_type) == KEEP_TAXON_TO_GO
+
+
+def test_classify_row_inverse_dropped():
+    """Inverse directions of the canonical shapes drop to their explicit reason."""
+    assert classify_row(-23, -2) == DROP_INVERSE_TAXON_TO_GO
+    assert classify_row(-2, -27) == DROP_INVERSE_ENVO_TO_TAXON
+
+
+def test_classify_row_bto_deferred():
+    """BTO on either side maps to the v1 deferred bucket."""
+    assert classify_row(-2, -25) == DROP_BTO_DEFERRED_V2
+    assert classify_row(-25, -2) == DROP_BTO_DEFERRED_V2
+
+
+def test_classify_row_taxon_taxon_dropped():
+    """Taxon-taxon host / co-occurrence rows go to their own drop reason."""
+    assert classify_row(-2, -2) == DROP_TAXON_TAXON_HOST
+
+
+# ---------------------------------------------------------------------------
+# load_doid_to_mondo
+# ---------------------------------------------------------------------------
+
+
+def test_load_doid_to_mondo_reads_fixture(prego_output_dir: Path):
+    """Reading the fixture mondo file yields a valid DOID→MONDO map."""
+    mondo_file = prego_output_dir / "ontologies" / "mondo_nodes.tsv"
+    lookup = load_doid_to_mondo(mondo_file)
+    assert lookup["DOID:8"] == "MONDO:0007256"
+    assert lookup["DOID:11111111"] == "MONDO:0000000"
+    assert "DOID:99999999" not in lookup
+
+
+def test_load_doid_to_mondo_missing_file_returns_empty(tmp_path: Path):
+    """A missing mondo file returns an empty dict rather than raising."""
+    assert load_doid_to_mondo(tmp_path / "does_not_exist.tsv") == {}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end transform run
+# ---------------------------------------------------------------------------
+
+
+def test_run_emits_nodes_and_edges(prego_transform: PregoTransform):
+    """A fixture-driven run produces well-formed nodes.tsv + edges.tsv."""
+    prego_transform.run()
+    assert prego_transform.output_node_file.exists()
+    assert prego_transform.output_edge_file.exists()
+    nodes = _read_tsv(prego_transform.output_node_file)
+    edges = _read_tsv(prego_transform.output_edge_file)
+    assert len(nodes) >= 5, "expected ≥5 unique nodes from the fixture"
+    assert len(edges) >= 5, "expected ≥5 emitted edges from the fixture"
+
+
+def test_taxon_to_go_edges_use_capable_of(prego_transform: PregoTransform):
+    """NCBITaxon→GO edges use biolink:capable_of, all 3 GO namespaces."""
+    prego_transform.run()
+    edges = _read_tsv(prego_transform.output_edge_file)
+    tax_go = [e for e in edges if e["subject"] == "NCBITaxon:100" and e["object"].startswith("GO:")]
+    assert len(tax_go) == 3, f"expected 3 canonical NCBITaxon:100→GO edges (BP/CC/MF), got {len(tax_go)}"
+    assert all(e["predicate"] == CAPABLE_OF_PREDICATE for e in tax_go)
+
+
+def test_envo_to_taxon_edges_use_location_of_matching_bacdive(
+    prego_transform: PregoTransform,
+):
+    """ENVO→NCBITaxon edges use biolink:location_of, matching bacdive convention."""
+    prego_transform.run()
+    edges = _read_tsv(prego_transform.output_edge_file)
+    envo_edges = [e for e in edges if e["subject"].startswith("ENVO:")]
+    assert len(envo_edges) == 1, f"expected 1 canonical ENVO→NCBITaxon edge, got {len(envo_edges)}"
+    assert envo_edges[0]["predicate"] == "biolink:location_of"
+    assert envo_edges[0]["object"] == "NCBITaxon:693444"
+
+
+def test_doid_with_mondo_xref_emits_mondo_edge(prego_transform: PregoTransform):
+    """A DOID row with a valid MONDO xref emits NCBITaxon → MONDO associated_with."""
+    prego_transform.run()
+    edges = _read_tsv(prego_transform.output_edge_file)
+    disease = [e for e in edges if e["object"].startswith("MONDO:")]
+    assert len(disease) == 1
+    assert disease[0] == {
+        **disease[0],
+        "subject": "NCBITaxon:562",
+        "predicate": "biolink:associated_with",
+        "object": "MONDO:0007256",  # from fixture DOID:8 xref
+    } | {"subject": "NCBITaxon:562", "predicate": "biolink:associated_with", "object": "MONDO:0007256"}
+
+
+def test_doid_without_mondo_xref_lands_in_unmapped_report(prego_transform: PregoTransform):
+    """A DOID row with no MONDO xref is dropped and recorded in the report."""
+    prego_transform.run()
+    report = _read_tsv(prego_transform.unmapped_report_file)
+    doid_drops = [r for r in report if r["reason"] == "doid_no_mondo_xref"]
+    assert len(doid_drops) == 1, f"expected 1 no-xref drop, got {len(doid_drops)}: {report}"
+    assert "DOID:99999999" in doid_drops[0]["exemplar_row"]
+
+
+def test_inverse_direction_rows_are_dropped(prego_transform: PregoTransform):
+    """GO→NCBITaxon and NCBITaxon→ENVO inverse rows are dropped, not re-emitted."""
+    prego_transform.run()
+    edges = _read_tsv(prego_transform.output_edge_file)
+    # No edges should have GO as subject (only as object in taxon→GO).
+    assert not any(e["subject"].startswith("GO:") for e in edges)
+    # No edges should have ENVO as object (only as subject in ENVO→taxon).
+    assert not any(e["object"].startswith("ENVO:") for e in edges)
+
+
+def test_taxon_taxon_and_bto_rows_are_dropped(prego_transform: PregoTransform):
+    """Both fixture drop cases land in the unmapped report."""
+    prego_transform.run()
+    report = _read_tsv(prego_transform.unmapped_report_file)
+    reasons = {r["reason"] for r in report}
+    assert DROP_TAXON_TAXON_HOST in reasons
+    assert DROP_BTO_DEFERRED_V2 in reasons
+
+
+def test_edges_carry_prego_metadata(prego_transform: PregoTransform):
+    """Every emitted edge has score, channel, direct_flag, primary_knowledge_source populated."""
+    prego_transform.run()
+    edges = _read_tsv(prego_transform.output_edge_file)
+    for e in edges:
+        assert e["primary_knowledge_source"] == PREGO_KNOWLEDGE_SOURCE
+        assert e["prego_score"], f"score missing on edge {e}"
+        assert e["prego_channel"], f"channel missing on edge {e}"
+        assert e["prego_direct_flag"], f"direct_flag missing on edge {e}"
+
+
+def test_nodes_are_deduplicated(prego_transform: PregoTransform):
+    """A CURIE that appears on multiple edges emits only one node row."""
+    prego_transform.run()
+    nodes = _read_tsv(prego_transform.output_node_file)
+    ids = [n["id"] for n in nodes]
+    assert len(ids) == len(set(ids)), f"duplicate node ids: {ids}"
+    # NCBITaxon:100 appears on 3 canonical GO edges — should still be one node.
+    assert ids.count("NCBITaxon:100") == 1
+
+
+def test_malformed_rows_are_counted_not_raised(prego_transform: PregoTransform):
+    """The fixture's 3-column garbage line is counted, not fatal."""
+    prego_transform.run()  # must not raise
+    assert prego_transform._stats["rows_malformed"] >= 1
+
+
+def test_missing_raw_dir_raises(tmp_path: Path):
+    """If input_base_dir/prego/ doesn't exist, run() raises SystemExit with a clear message."""
+    out = tmp_path / "out"
+    (out / "ontologies").mkdir(parents=True)
+    transform = PregoTransform(input_dir=tmp_path / "raw", output_dir=out)
+    with pytest.raises(SystemExit, match="not found"):
+        transform.run()
+
+
+def test_missing_archives_raises(tmp_path: Path):
+    """If prego/ exists but has no *.tar.gz, run() raises SystemExit."""
+    raw = tmp_path / "raw" / "prego"
+    raw.mkdir(parents=True)
+    out = tmp_path / "out"
+    (out / "ontologies").mkdir(parents=True)
+    transform = PregoTransform(input_dir=tmp_path / "raw", output_dir=out)
+    with pytest.raises(SystemExit, match="no .* archives"):
+        transform.run()

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -229,6 +229,35 @@ def test_malformed_rows_are_counted_not_raised(prego_transform: PregoTransform):
     assert prego_transform._stats["rows_malformed"] >= 1
 
 
+def test_empty_entity_id_row_is_dropped(tmp_path: Path, prego_output_dir: Path):
+    """
+    A row with an empty entity_id lands in the unmapped report as `empty_id`.
+
+    Regression net for the CURIE-shape defense added in the review-fix
+    commit (issue #668 finding 2) — an empty local part would otherwise
+    emit a malformed CURIE like `NCBITaxon:`.
+    """
+    raw_dir = tmp_path / "raw"
+    prego_raw = raw_dir / "prego"
+    prego_raw.mkdir(parents=True)
+    tsv_path = prego_raw / "one_row.tsv"
+    # Well-formed 9 cols but entity1_id is empty.
+    tsv_path.write_text("-2\t\t-23\tGO:0000034\tJGI IMG\tIsolates\t4\tTRUE\t\n")
+    archive = prego_raw / "onerow.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(tsv_path, arcname="database_pairs.tsv")
+    tsv_path.unlink()
+
+    transform = PregoTransform(input_dir=raw_dir, output_dir=prego_output_dir)
+    transform.run()
+
+    edges = _read_tsv(transform.output_edge_file)
+    assert edges == [], f"empty-id row should NOT emit an edge; got {edges}"
+    report = _read_tsv(transform.unmapped_report_file)
+    empty_id_rows = [r for r in report if r["reason"] == "empty_id"]
+    assert len(empty_id_rows) == 1, f"expected 1 empty_id drop, got {report}"
+
+
 def test_missing_raw_dir_raises(tmp_path: Path):
     """If input_base_dir/prego/ doesn't exist, run() raises SystemExit with a clear message."""
     out = tmp_path / "out"


### PR DESCRIPTION
## Summary

Ingests taxon↔environment/process associations from the PREGO knowledgebase (Zafeiropoulos et al. 2022, Microorganisms 10:293). Implements Phase 6a of \`docs/PREGO_INGEST_PLAN.md\`. Closes #182.

## Live canary (isolates channel, 269 MB → 8.1 GB → 42 M rows)

\`\`\`
[prego] rows_read=42,038,686 malformed=0 edges_emitted=21,012,068 nodes_emitted=39,766 dropped=21,026,618 doid_no_mondo=1
[prego] edges_by_shape={'taxon_to_go': 20969148, 'taxon_to_doid': 5171, 'envo_to_taxon': 37749}
[prego] rows_dropped_by_reason={'inverse_taxon_to_envo': 59199, 'bto_deferred_v2': 6725, 'taxon_taxon_host': 3992, 'doid_no_mondo_xref': 1, 'inverse_go_to_taxon': 20956701}

real 3m19.519s
\`\`\`

## Edge shapes emitted (canonical directions matching bacdive convention)

| Row shape | Emitted edge | Predicate |
|---|---|---|
| NCBITaxon ↔ GO (BP/CC/MF) | \`NCBITaxon:X → GO:Y\` | \`biolink:capable_of\` |
| NCBITaxon ↔ ENVO | \`ENVO:Y → NCBITaxon:X\` | \`biolink:location_of\` |
| NCBITaxon ↔ DOID | \`NCBITaxon:X → MONDO:Y\` (via DOID xref) | \`biolink:associated_with\` |

Every edge carries 4 additional columns: \`prego_score\`, \`prego_channel\`, \`prego_direct_flag\`, \`prego_evidence_url\` — so consumers can filter by evidence type.

## What's dropped (and where it lands)

\`data/transformed/prego/unmapped_associations.tsv\` — one row per \`(reason, exemplar_key)\` with occurrence count, per-reason exemplar cap:

- \`inverse_go_to_taxon\` — inverse of a canonical taxon→GO edge (deduped)
- \`inverse_taxon_to_envo\` — inverse of a canonical ENVO→taxon edge (deduped)
- \`bto_deferred_v2\` — BTO tissue rows (out of scope for v1 per plan)
- \`taxon_taxon_host\` — host / co-occurrence rows (out of scope per plan)
- \`doid_no_mondo_xref\` — DOID CURIEs with no MONDO equivalent
- \`unknown_shape\` — any pair we don't route (< 0.01% in the canary)

## kg-model-review

\`\`\`
[KGX     ] Required columns present (39,766 rows sampled)
[KGX     ] No duplicate IDs in sample
[Biolink ] All categories recognized
[Prefix  ] All id prefixes registered
[KGX     ] Required columns present (100,000 rows sampled)
[Biolink ] All predicates recognized
[METPO   ] All 405 CURIEs validated
[Prefix  ] All edge prefixes registered
[DomainRange] Domain/range OK across 99,971 constrained edges

Total ERRORs: 0 · Total WARNINGs: 0 · ✅ All checks passed
\`\`\`

## Scope explicitly deferred

- **Phase 6b** (dictionary synonym enrichment from \`prego_dictionary.tar.gz\`) — follow-up PR per the plan's ship-6a-first guidance
- **literature.tar.gz + environmental_samples.tar.gz canaries** — code handles them uniformly; someone with disk headroom (~30 GB extracted) runs them and confirms

## Test plan

- [x] 18 new unit tests in \`tests/test_prego_transform.py\` — all pass
- [x] Full suite: **808 pass** (was 789 pre-PR)
- [x] tox format / lint / docstr-coverage — all green
- [x] Live end-to-end run on the 269 MB isolates archive — 42 M rows processed in 3m19s, 0 errors, all Phase 7 gates satisfied
- [x] kg-model-review — 0 ERRORs, 0 WARNINGs on the transform output

🤖 Generated with [Claude Code](https://claude.com/claude-code)