### PR TITLE
fix(novel-transforms): validate scale strings at import (#660)

### DIFF
--- a/.claude/skills/novel-transforms/SKILL.md
+++ b/.claude/skills/novel-transforms/SKILL.md
@@ -78,7 +78,8 @@ Each open issue is scored against three signal sets:
 
    These cannot be derived from issue title/body — curator judgement, so add a
    row when you triage a new issue. Missing rows render as `?` in the doc so
-   the gap is visible. A category typo is caught at import time by
+   the gap is visible. Both category typos and malformed scale strings (must
+   match `10^N` or `?`) are caught at import time by
    `_validate_source_metadata`, so a bad value cannot ship silently.
 
 Every included issue is bucketed into one of:

--- a/.claude/skills/novel-transforms/novel_transforms.py
+++ b/.claude/skills/novel-transforms/novel_transforms.py
@@ -152,26 +152,48 @@ SOURCE_METADATA: Dict[int, Dict[str, str]] = {
 }
 
 
+_VALID_SCALE_RE = re.compile(r"^(10\^\d+|\?)$")
+
+
 def _validate_source_metadata() -> None:
     """
     Fail fast on curator typos in :data:`SOURCE_METADATA`.
 
-    Runs at import time. Catches category typos (e.g. ``"phentoype"``) that
-    would otherwise ship a mystery tag to readers of the generated doc; the
-    error message names both the offending issue and the valid vocabulary so
-    the fix is one edit.
+    Runs at import time. Two independent checks, one shared error message:
+
+    - ``category`` values must be keys of :data:`DATA_CATEGORIES` (catches typos
+      like ``"phentoype"`` that would otherwise ship a mystery tag).
+    - ``nodes`` and ``edges`` values must match ``10^N`` or ``?`` (catches the
+      wrong-format cases from issue #660 — ``"5000"`` or ``"1e6"`` or
+      ``"10^abc"`` would render literal-garbage cells in the doc).
+
+    The error message names both the offending issue and the valid vocabulary,
+    so the fix is one edit.
     """
-    valid = set(DATA_CATEGORIES)
-    bad = [
+    valid_categories = set(DATA_CATEGORIES)
+    bad_categories = [
         (num, meta["category"])
         for num, meta in SOURCE_METADATA.items()
-        if "category" in meta and meta["category"] not in valid
+        if "category" in meta and meta["category"] not in valid_categories
     ]
-    if bad:
-        detail = ", ".join(f"#{num}='{cat}'" for num, cat in bad)
+    if bad_categories:
+        detail = ", ".join(f"#{num}='{cat}'" for num, cat in bad_categories)
         raise SystemExit(
             f"[novel-transforms] SOURCE_METADATA carries category values not in "
-            f"DATA_CATEGORIES: {detail}. Valid: {sorted(valid)}."
+            f"DATA_CATEGORIES: {detail}. Valid: {sorted(valid_categories)}."
+        )
+    bad_scales = [
+        (num, field, meta[field])
+        for num, meta in SOURCE_METADATA.items()
+        for field in ("nodes", "edges")
+        if field in meta and not _VALID_SCALE_RE.match(meta[field])
+    ]
+    if bad_scales:
+        detail = ", ".join(f"#{num}.{field}='{val}'" for num, field, val in bad_scales)
+        raise SystemExit(
+            f"[novel-transforms] SOURCE_METADATA has scale values that don't match "
+            f"'10^N' or '?': {detail}. Curator convention lives in the SOURCE_METADATA "
+            f"docstring at the top of novel_transforms.py."
         )
 
 


### PR DESCRIPTION
## Summary

Closes #660. Extends \`_validate_source_metadata\` in the novel-transforms skill with a regex check on \`nodes\` and \`edges\` fields, mirroring the existing category-taxonomy validator. Fires a clear \`SystemExit\` at import time if any value doesn't match \`10^N\` (integer exponent) or \`?\` (sentinel).

## What it catches

Three malformed forms flagged in #660:

- \`\"5000\"\` — numeric, not power-of-ten notation
- \`\"10^abc\"\` — non-digit exponent (previously translated only digits to superscripts, rendered literal \`\"10abc\"\`)
- \`\"1e6\"\` — scientific notation (previously passed through, breaking column alignment)

## Verification

\`\`\`
PASS: clean import
PASS: scale validator fires: '#999999.nodes=5000' typo caught
PASS: 10^abc caught
PASS: 1e6 caught
\`\`\`

## Same pattern as existing category validator

Both were introduced via review-fix cycles (categories in #659, scales in #660). The single \`_validate_source_metadata\` function is now the authoritative gate for both fields; SKILL.md updated to note both are runtime-checked.

## Test plan

- [x] Clean \`SOURCE_METADATA\` state imports without error
- [x] Injected typos on all three malformed forms fire SystemExit with the offending issue + field named
- [x] \`poetry run python .claude/skills/novel-transforms/novel_transforms.py\` regenerates the doc successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)