### PR TITLE
perf(prego): pickle cache for Phase 6b synonym lookup (#672)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30458,3 +30458,4 @@ notebooks/.ipynb_checkpoints/
 # if the analysis is worth keeping; ignored as-is to avoid a permanent blob.
 notebooks/bacdive_reformat.ipynb
 data/raw/lpsn/*
+data/raw/prego/*_extracted/

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -28,6 +28,7 @@ threshold on confidence.
 from __future__ import annotations
 
 import csv
+import pickle
 import tarfile
 from collections import defaultdict
 from pathlib import Path
@@ -212,6 +213,12 @@ class PregoTransform(Transform):
 
     _DICTIONARY_ARCHIVE_NAME = "prego_dictionary.tar.gz"
     _DICTIONARY_FILES = ("prego_entities.tsv", "prego_names.tsv")
+    # Pickle cache of the compiled `_synonym_lookup` (issue #672). Invalidated
+    # on any mtime change of the dictionary tarball OR the mondo_nodes.tsv
+    # file (which drives the DOID→MONDO xref routing). Sits alongside the
+    # extracted payload so it lives with what it's derived from.
+    _DICTIONARY_CACHE_NAME = "prego_dictionary_synonyms_cache.pickle"
+    _DICTIONARY_CACHE_VERSION = 1  # bump if the cache payload shape changes
 
     def _load_dictionary(self, prego_raw_dir: Path, doid_to_mondo: dict) -> None:
         """
@@ -251,6 +258,18 @@ class PregoTransform(Transform):
 
         payload_dir = prego_raw_dir / "prego_dictionary_extracted"
         payload_dir.mkdir(parents=True, exist_ok=True)
+
+        # ------------------------------------------------------------------
+        # Cache fast path: skip the ~15 s dictionary parse if the compiled
+        # lookup is still fresh vs both the dictionary tarball AND the
+        # mondo_nodes.tsv that drives DOID→MONDO routing. Keeps developer
+        # iteration cheap; production runs pay the cost once, then hit the
+        # cache on every subsequent kg-release build.
+        # ------------------------------------------------------------------
+        cache_path = payload_dir / self._DICTIONARY_CACHE_NAME
+        cache_key = self._dictionary_cache_key(archive)
+        if self._load_synonym_lookup_from_cache(cache_path, cache_key):
+            return
         # Same size-check-then-reuse pattern as _process_archive.
         with tarfile.open(archive, mode="r:gz") as tf:
             for member in tf.getmembers():
@@ -313,11 +332,92 @@ class PregoTransform(Transform):
             key = name_stripped.casefold()
             bucket.setdefault(key, name_stripped)
             n_kept += 1
+        # Persist the compiled lookup for the next run's fast path (issue #672).
+        # Wait to write until AFTER the flatten below so what's persisted is
+        # what `_emit_node` consumes at runtime.
         # Flatten the {casefold_key: original_case} inner dicts to sets of the
         # preserved-case names — that's what _emit_node consumes.
         self._synonym_lookup = {curie: set(inner.values()) for curie, inner in self._synonym_lookup.items()}
         self._stats["dictionary_synonyms_indexed"] = n_kept
         print(f"[prego] dictionary loaded: {n_kept:,} synonym rows kept across {len(self._synonym_lookup):,} CURIEs")
+
+        # Persist the compiled lookup so the next run skips the ~15 s parse.
+        self._save_synonym_lookup_cache(cache_path, cache_key)
+
+    # ------------------------------------------------------------------ #
+    # Cache helpers for the compiled synonym lookup (issue #672).
+    # ------------------------------------------------------------------ #
+
+    def _dictionary_cache_key(self, archive: Path) -> tuple:
+        """
+        Return a cache key sensitive to changes in either source-of-truth file.
+
+        The compiled ``_synonym_lookup`` is a function of the dictionary
+        tarball AND the mondo_nodes.tsv (which drives DOID→MONDO routing).
+        Cache invalidation triggers on any mtime change of either.
+        Version tag lets a schema change force a rebuild across the board.
+        """
+        dict_mtime = archive.stat().st_mtime
+        mondo_mtime = self._mondo_nodes_file.stat().st_mtime if self._mondo_nodes_file.is_file() else 0
+        return (self._DICTIONARY_CACHE_VERSION, dict_mtime, mondo_mtime)
+
+    def _load_synonym_lookup_from_cache(self, cache_path: Path, expected_key: tuple) -> bool:
+        """
+        Try to hydrate :attr:`_synonym_lookup` from the pickle cache.
+
+        Returns True on a cache hit (caller then skips the dictionary parse).
+        Returns False if the cache is missing, stale, corrupt, or version-
+        mismatched — the transform then does a full parse and re-writes
+        the cache at the end.
+        """
+        if not cache_path.exists():
+            return False
+        try:
+            with cache_path.open("rb") as fh:
+                cached = pickle.load(fh)  # noqa: S301 (trusted local-only cache)
+        except (pickle.UnpicklingError, EOFError, ValueError, AttributeError) as exc:
+            print(f"[prego] cache {cache_path.name} unreadable ({type(exc).__name__}); rebuilding")
+            return False
+        if cached.get("cache_key") != expected_key:
+            print(f"[prego] cache {cache_path.name} stale (source files changed); rebuilding")
+            return False
+        self._synonym_lookup = cached["synonym_lookup"]
+        for stat_key in (
+            "dictionary_curies_indexed",
+            "dictionary_synonyms_indexed",
+            "dictionary_doid_routed_to_mondo",
+        ):
+            self._stats[stat_key] = cached.get(stat_key, 0)
+        print(
+            f"[prego] loaded {len(self._synonym_lookup):,} CURIE synonyms from cache "
+            f"{cache_path.name} (skipped ~15 s parse)"
+        )
+        return True
+
+    def _save_synonym_lookup_cache(self, cache_path: Path, cache_key: tuple) -> None:
+        """
+        Persist the compiled synonym lookup atomically.
+
+        Writes to a ``.tmp`` sibling first, then ``rename()`` — that way a
+        crashed write doesn't leave a truncated cache the next run trusts.
+        """
+        tmp_path = cache_path.with_suffix(cache_path.suffix + ".tmp")
+        payload = {
+            "cache_key": cache_key,
+            "synonym_lookup": self._synonym_lookup,
+            "dictionary_curies_indexed": self._stats["dictionary_curies_indexed"],
+            "dictionary_synonyms_indexed": self._stats["dictionary_synonyms_indexed"],
+            "dictionary_doid_routed_to_mondo": self._stats["dictionary_doid_routed_to_mondo"],
+        }
+        try:
+            with tmp_path.open("wb") as fh:
+                pickle.dump(payload, fh, protocol=pickle.HIGHEST_PROTOCOL)
+            tmp_path.replace(cache_path)
+            print(f"[prego] persisted synonym lookup to {cache_path.name}")
+        except OSError as exc:
+            print(f"[prego] WARNING: could not persist cache {cache_path.name}: {exc}")
+            if tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
 
     # ------------------------------------------------------------------ #
     # Per-archive processing.

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -414,9 +414,7 @@ def test_bto_node_gets_dictionary_synonym(prego_transform_with_dictionary: Prego
     assert "bacterial gut microbiome" in bto["synonym"]
 
 
-def test_bto_row_with_non_bto_id_drops_to_prefix_mismatch(
-    tmp_path: Path, prego_output_dir: Path
-):
+def test_bto_row_with_non_bto_id_drops_to_prefix_mismatch(tmp_path: Path, prego_output_dir: Path):
     """
     A `-2 → -25` row whose entity2_id doesn't start with `BTO:` drops explicitly.
 
@@ -448,6 +446,100 @@ def test_bto_row_with_non_bto_id_drops_to_prefix_mismatch(
     report = _read_tsv(transform.unmapped_report_file)
     reasons = {r["reason"] for r in report}
     assert "bto_id_prefix_mismatch" in reasons
+
+
+def test_dictionary_cache_saves_and_reuses(prego_input_dir_with_dictionary: Path, prego_output_dir: Path):
+    """
+    Second run of PregoTransform hits the pickle cache instead of re-parsing.
+
+    Issue #672: the compiled ``_synonym_lookup`` is persisted after the
+    first successful load and rehydrated on subsequent runs, cutting the
+    ~15 s dictionary parse to ~0.1 s. Test asserts:
+
+    1. First run creates the cache file.
+    2. Second run's ``_synonym_lookup`` matches the first (identical output).
+    """
+    # First run — populates the cache.
+    t1 = PregoTransform(input_dir=prego_input_dir_with_dictionary, output_dir=prego_output_dir)
+    t1.run()
+    cache_path = (
+        prego_input_dir_with_dictionary
+        / "prego"
+        / "prego_dictionary_extracted"
+        / "prego_dictionary_synonyms_cache.pickle"
+    )
+    assert cache_path.exists(), "first run should have persisted the cache"
+    first_lookup = dict(t1._synonym_lookup)  # snapshot
+
+    # Second run — must produce the same lookup.
+    t2 = PregoTransform(input_dir=prego_input_dir_with_dictionary, output_dir=prego_output_dir)
+    t2.run()
+    assert t2._synonym_lookup == first_lookup, "cache-hit lookup must match cold-load lookup"
+
+
+def test_dictionary_cache_invalidates_on_mondo_mtime_change(
+    prego_input_dir_with_dictionary: Path, prego_output_dir: Path
+):
+    """
+    Bumping the mondo_nodes.tsv mtime invalidates the cache and forces a rebuild.
+
+    Regression net for the DOID→MONDO cache-key sensitivity — if the
+    ontologies transform re-runs and publishes a fresh DOID→MONDO
+    mapping, PREGO must rebuild the lookup rather than serve stale
+    MONDO enrichments from a previous run's cache.
+    """
+    # Prime the cache.
+    t1 = PregoTransform(input_dir=prego_input_dir_with_dictionary, output_dir=prego_output_dir)
+    t1.run()
+    cache_path = (
+        prego_input_dir_with_dictionary
+        / "prego"
+        / "prego_dictionary_extracted"
+        / "prego_dictionary_synonyms_cache.pickle"
+    )
+    cache_mtime_before = cache_path.stat().st_mtime
+
+    # Bump the mondo file's mtime forward — cache key changes, so the
+    # next run must rebuild.
+    mondo_file = prego_output_dir / "ontologies" / "mondo_nodes.tsv"
+    import os
+
+    os.utime(mondo_file, (cache_mtime_before + 10, cache_mtime_before + 10))
+
+    t2 = PregoTransform(input_dir=prego_input_dir_with_dictionary, output_dir=prego_output_dir)
+    t2.run()
+    assert cache_path.stat().st_mtime > cache_mtime_before, "cache should have been rewritten"
+
+
+def test_dictionary_cache_recovers_from_corrupt_file(prego_input_dir_with_dictionary: Path, prego_output_dir: Path):
+    """
+    A garbled cache file is logged-and-ignored, not fatal.
+
+    Robustness: an OOM / disk-full / interrupted pickle write could
+    leave the cache file half-populated. The transform must fall back
+    to a full parse rather than raise UnpicklingError.
+    """
+    # Prime the cache.
+    t1 = PregoTransform(input_dir=prego_input_dir_with_dictionary, output_dir=prego_output_dir)
+    t1.run()
+    cache_path = (
+        prego_input_dir_with_dictionary
+        / "prego"
+        / "prego_dictionary_extracted"
+        / "prego_dictionary_synonyms_cache.pickle"
+    )
+    # Corrupt the cache.
+    cache_path.write_bytes(b"\x00\x01\x02 not a pickle")
+
+    # Next run must not raise, and must rebuild.
+    t2 = PregoTransform(input_dir=prego_input_dir_with_dictionary, output_dir=prego_output_dir)
+    t2.run()  # would raise on unhandled UnpicklingError
+    # The rebuild happened → cache is a valid pickle again.
+    import pickle
+
+    with cache_path.open("rb") as fh:
+        rebuilt = pickle.load(fh)
+    assert "synonym_lookup" in rebuilt
 
 
 def test_mondo_node_enriched_via_doid_reverse_lookup(


### PR DESCRIPTION
## Summary

Closes item 2 of #672. Persists the compiled \`_synonym_lookup\` to a pickle so subsequent PregoTransform runs skip the ~15 s dictionary parse.

## Live canary

269 MB isolates + 278 MB dictionary, MacBook Pro:

| Run | Wall clock | Delta |
|---|---|---|
| Cold (no cache) | 3m34s | baseline |
| Warm (cache hit) | 3m04s | **−30 s** |

Output identical byte-for-byte between runs.

## Cache lifecycle

- **Path:** \`data/raw/prego/prego_dictionary_extracted/prego_dictionary_synonyms_cache.pickle\` (sits with what it's derived from)
- **Invalidation key:** \`(schema-version, dictionary-tarball-mtime, mondo_nodes.tsv-mtime)\` — either source-of-truth file changing forces a rebuild
- **Atomic write:** temp file + \`rename()\` so a crashed write can't leave a truncated cache the next run trusts
- **Corrupt/stale recovery:** logs + rebuilds; never fatal

## Not addressed in this PR

Item 1 of #672 — the O(dictionary) peak memory profile (~350 MB). Requires a bigger two-pass refactor for a smaller marginal win (memory-only, no correctness impact). Filing as continued follow-up on #672.

## Tests

- \`test_dictionary_cache_saves_and_reuses\` — two runs produce identical \`_synonym_lookup\`
- \`test_dictionary_cache_invalidates_on_mondo_mtime_change\` — bumping the mondo file's mtime rewrites the cache
- \`test_dictionary_cache_recovers_from_corrupt_file\` — garbled bytes in the cache path don't raise UnpicklingError

Test suite: **35 pass** (was 32).

## Test plan

- [x] 35 PREGO tests pass
- [x] tox format / lint / docstr-coverage — all green
- [x] Live cold + warm end-to-end runs; output identical, warm 30 s faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)