### PR TITLE
fix(kg): repair three path-review defects in transform outputs

### DIFF
--- a/.claude/skills/add-transform/SKILL.md
+++ b/.claude/skills/add-transform/SKILL.md
@@ -166,7 +166,7 @@ For each cross-ref the source provides:
 |---|---|---|---|---|
 | `NCBI:12345` | `NCBITaxon:12345` | yes (ncbitaxon transform) | `biolink:close_match` | trivial |
 | `GTDB s__X` | `gtdb.species:X` | yes (gtdb transform) | `biolink:close_match` | strip s__ per repo convention (see [[feedback_gtdb_prefix]] if noted) |
-| `BacDive 12345` | `bacdive:12345` | yes (bacdive transform) | `biolink:close_match` | this is the merge glue |
+| `BacDive 12345` | `kgmicrobe.strain:bacdive_12345` | yes (bacdive transform) | `biolink:close_match` | this is the merge glue. **Not** `bacdive:12345` — no transform emits that as a node, so edges to it dangle and KGX turns them into empty `biolink:NamedThing` stubs |
 
 Cross-refs that point to entities NOT in KG-Microbe: emit the edge anyway if you're confident downstream analyses will use it. Note it in the design and stub-node it appropriately.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,17 @@ Copy `.env.example` to `.env` and configure:
 - `BACDIVE_USERNAME`: BacDive API email
 - `BACDIVE_PASSWORD`: BacDive API password
 
+Optional, for the mediadive transform:
+- `KG_MEDIADIVE_ALLOW_STALE_CACHE=true`: run mediadive even when the bulk
+  download in `data/raw/mediadive/` is absent or incomplete. Off by default:
+  without the bulk JSONs the transform falls back to the YAML medium cache
+  under `transform_utils/mediadive/tmp/medium_yaml` and to `requests_cache`,
+  neither of which has an expiry, so a run started before `kg download`
+  finishes exits 0 having built the graph from years-old recipes. Set this only
+  for deliberate offline / cache-only work. It must be a **shell** variable —
+  `load_dotenv()` is not guaranteed to have run on the transform path, so an
+  `.env` entry is not reliable here.
+
 Optional, for the ontology transforms:
 - `KG_SEMSQL_BUILD=off`: skip building the SemSQL lookup DBs. Any transform that
   looks something up in an ontology resolves its adapter through

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -260,8 +260,8 @@ class BacDiveTransform(Transform):
         self.assay_edges_generated: Optional[List] = None  # Generated assay→entity edge rows
 
         # LPSN name → record_no index, loaded from data/raw/lpsn_gss.csv when
-        # present. Used to emit bacdive:<id> → biolink:close_match →
-        # lpsn:<record_no> for every strain whose LPSN block names an
+        # present. Used to emit kgmicrobe.strain:bacdive_<id> →
+        # biolink:subclass_of → lpsn:<record_no> for every strain whose LPSN block names an
         # exactly-known LPSN species. Silent skip on missing CSV so a fresh
         # checkout that hasn't downloaded LPSN still runs the BacDive
         # transform cleanly.

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -86,8 +86,6 @@ from kg_microbe.transform_utils.constants import (
     HAS_PHENOTYPE,
     HAS_PHENOTYPE_PREDICATE,
     ID_COLUMN,
-    IN_TAXON_PREDICATE,
-    IN_TAXON_RELATION,
     INFERRED_SUBCLASS_RELATION,
     INTERACTS_WITH_RELATION,
     IS_GROWN_IN,
@@ -501,6 +499,20 @@ class BacDiveTransform(Transform):
             len(name_index),
         )
         return name_index
+
+    @staticmethod
+    def _strain_curie(bacdive_key: str) -> str:
+        """
+        Return the ``kgmicrobe.strain:bacdive_NNN`` CURIE for a BacDive record key.
+
+        Every edge touching a BacDive strain must build its subject here.
+        Composing a strain reference from ``BACDIVE_PREFIX`` alone yields
+        ``bacdive:NNN``, which this transform never emits as a node row.
+
+        :param bacdive_key: BacDive record ID as a string.
+        :return: The strain CURIE used for the corresponding node row.
+        """
+        return STRAIN_PREFIX + BACDIVE_PREFIX.replace(":", "_") + bacdive_key
 
     def _lookup_lpsn(self, lpsn_block: dict) -> Optional[str]:
         """
@@ -1985,7 +1997,7 @@ class BacDiveTransform(Transform):
                             strain_designation = name_tax_classification.get(STRAIN_DESIGNATION).strip()
 
                     # Construct strain ID using BacDive ID
-                    organism_id = STRAIN_PREFIX + BACDIVE_PREFIX.replace(":", "_") + key
+                    organism_id = self._strain_curie(key)
 
                     # Construct strain label
                     bacdive_key = BACDIVE_PREFIX.replace(":", "_") + key
@@ -2437,26 +2449,32 @@ class BacDiveTransform(Transform):
                     # LPSN GSS index loaded in __init__. No-op when the CSV
                     # isn't on disk, or when the LPSN block is absent /
                     # ambiguous. Emitted per strain so the merge step
-                    # naturally reconciles bacdive:<id> with the LPSN
-                    # transform's lpsn:<record_no> nodes when both sources
-                    # ingest the same taxonomy.
+                    # naturally reconciles kgmicrobe.strain:bacdive_<id> with
+                    # the LPSN transform's lpsn:<record_no> nodes when both
+                    # sources ingest the same taxonomy.
                     lpsn_record_no = self._lookup_lpsn(lpsn) if lpsn else None
                     if lpsn_record_no:
-                        # ``biolink:in_taxon`` (RO:0002162) is the correct
-                        # predicate for a specific strain being classified
-                        # within an LPSN taxonomic-name record — the strain
-                        # is an instance of that taxon, not identical to it
-                        # (which would be exact_match) and not a subclass
-                        # (which would be subclass_of).
+                        # Subject must be the strain node this transform
+                        # actually emits (``kgmicrobe.strain:bacdive_NNN``).
+                        # ``bacdive:NNN`` is never written as a node row, so
+                        # using it here left every one of these edges orphaned
+                        # and KGX synthesized a bare NamedThing stub per strain.
+                        strain_curie = self._strain_curie(key)
+                        # ``biolink:subclass_of`` matches how this transform
+                        # already relates the same strain nodes to their
+                        # NCBITaxon species. Both endpoints are typed
+                        # biolink:OrganismTaxon, i.e. class-like, so the
+                        # instance-of reading behind biolink:in_taxon
+                        # contradicts the node typing in use.
                         knowledge_level, agent_type = self._add_edge_metadata(
-                            IN_TAXON_PREDICATE, IN_TAXON_RELATION, f"lpsn:{lpsn_record_no}"
+                            SUBCLASS_PREDICATE, RDFS_SUBCLASS_OF, f"lpsn:{lpsn_record_no}"
                         )
                         edge_writer.writerow(
                             [
-                                BACDIVE_PREFIX + key,
-                                IN_TAXON_PREDICATE,
+                                strain_curie,
+                                SUBCLASS_PREDICATE,
                                 f"lpsn:{lpsn_record_no}",
-                                IN_TAXON_RELATION,
+                                RDFS_SUBCLASS_OF,
                                 self.knowledge_source,
                                 knowledge_level,
                                 agent_type,

--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -769,8 +769,37 @@ class MediaDiveTransform(Transform):
                     print(exc)
         return json_obj
 
+    def _assert_bulk_data_available(self):
+        """
+        Refuse to transform when the bulk MediaDive download is missing.
+
+        Without it the medium/solution lookups fall back to the YAML cache
+        under ``tmp/medium_yaml`` and to ``requests_cache``, neither of
+        which carries an expiry. Those caches hold responses from 2023 and
+        2025 that predate MediaDive restructuring solutions, so the run
+        succeeds with exit code 0 while emitting a graph built from years-old
+        recipes. Set ``KG_MEDIADIVE_ALLOW_STALE_CACHE=true`` to accept that
+        tradeoff deliberately (offline reruns, cache-only debugging).
+        """
+        if self.using_bulk_data:
+            return
+        if os.getenv("KG_MEDIADIVE_ALLOW_STALE_CACHE", "").strip().lower() in {"1", "true", "yes"}:
+            print(
+                "WARNING: MediaDive bulk data missing; proceeding on the undated YAML/HTTP "
+                "caches because KG_MEDIADIVE_ALLOW_STALE_CACHE is set. Output may reflect "
+                "long-superseded MediaDive recipes."
+            )
+            return
+        raise FileNotFoundError(
+            f"MediaDive bulk data not found in {self.bulk_data_dir}/. Refusing to transform: "
+            "the fallback YAML and HTTP caches have no expiry and can silently produce a graph "
+            "from years-old recipes. Run `poetry run kg download -t mediadive` and let it finish "
+            "first, or set KG_MEDIADIVE_ALLOW_STALE_CACHE=true to override."
+        )
+
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True):
         """Run the transformation."""
+        self._assert_bulk_data_available()
         # replace with downloaded data filename for this source
         input_file = os.path.join(self.input_base_dir, "mediadive.json")  # must exist already
         bacdive_input_file = BACDIVE_TMP_DIR / "bacdive.tsv"

--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -98,6 +98,7 @@ from kg_microbe.transform_utils.constants import (
     PROVIDED_BY_COLUMN,
     PUBCHEM_KEY,
     PUBCHEM_PREFIX,
+    RAW_DATA_DIR,
     RDFS_SUBCLASS_OF,
     RECIPE_KEY,
     ROLE_CATEGORY,
@@ -149,8 +150,14 @@ class MediaDiveTransform(Transform):
         self._load_chebi_roles()
         self._load_chebi_categories()
 
-        # Load bulk downloaded data if available
-        self.bulk_data_dir = Path("data/raw/mediadive")
+        # Load bulk downloaded data if available. Prefer the input dir this
+        # transform was actually given so `kg download -o DIR` + `kg transform
+        # -i DIR` finds the bulk files; fall back to the repo-anchored raw dir
+        # because Transform.DEFAULT_INPUT_DIR points at a path that does not
+        # exist. Neither branch is CWD-relative — resolving against the process
+        # CWD is what let a run silently fall through to the undated caches.
+        _input_bulk_dir = Path(self.input_base_dir) / "mediadive"
+        self.bulk_data_dir = _input_bulk_dir if _input_bulk_dir.is_dir() else RAW_DATA_DIR / "mediadive"
         self.media_detailed = {}
         self.media_strains = {}
         self.solutions_data = {}
@@ -769,7 +776,7 @@ class MediaDiveTransform(Transform):
                     print(exc)
         return json_obj
 
-    def _assert_bulk_data_available(self):
+    def _assert_bulk_data_available(self) -> None:
         """
         Refuse to transform when the bulk MediaDive download is missing.
 
@@ -794,7 +801,8 @@ class MediaDiveTransform(Transform):
             f"MediaDive bulk data not found in {self.bulk_data_dir}/. Refusing to transform: "
             "the fallback YAML and HTTP caches have no expiry and can silently produce a graph "
             "from years-old recipes. Run `poetry run kg download -t mediadive` and let it finish "
-            "first, or set KG_MEDIADIVE_ALLOW_STALE_CACHE=true to override."
+            "first, or export KG_MEDIADIVE_ALLOW_STALE_CACHE=true to override. It must be a shell "
+            "variable: load_dotenv() is not called on the transform path, so .env is not read."
         )
 
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True):

--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -150,14 +150,7 @@ class MediaDiveTransform(Transform):
         self._load_chebi_roles()
         self._load_chebi_categories()
 
-        # Load bulk downloaded data if available. Prefer the input dir this
-        # transform was actually given so `kg download -o DIR` + `kg transform
-        # -i DIR` finds the bulk files; fall back to the repo-anchored raw dir
-        # because Transform.DEFAULT_INPUT_DIR points at a path that does not
-        # exist. Neither branch is CWD-relative — resolving against the process
-        # CWD is what let a run silently fall through to the undated caches.
-        _input_bulk_dir = Path(self.input_base_dir) / "mediadive"
-        self.bulk_data_dir = _input_bulk_dir if _input_bulk_dir.is_dir() else RAW_DATA_DIR / "mediadive"
+        self.bulk_data_dir = self._resolve_bulk_data_dir(self.input_base_dir)
         self.media_detailed = {}
         self.media_strains = {}
         self.solutions_data = {}
@@ -775,6 +768,27 @@ class MediaDiveTransform(Transform):
                 except yaml.YAMLError as exc:
                     print(exc)
         return json_obj
+
+    @classmethod
+    def _resolve_bulk_data_dir(cls, input_base_dir) -> Path:
+        """
+        Return the directory the bulk MediaDive JSONs should be read from.
+
+        An explicit input dir is honoured exactly: `kg transform -i
+        /scratch/raw` that is missing its bulk files must fail naming
+        /scratch, never silently read the repo's copy instead — that would
+        reintroduce the same class of silent-wrong-data failure
+        :meth:`_assert_bulk_data_available` exists to prevent. Only the
+        class default falls back to the repo-anchored raw dir, because
+        ``Transform.DEFAULT_INPUT_DIR`` points at a directory that does not
+        exist.
+
+        :param input_base_dir: The input dir this transform was constructed with.
+        :return: Directory expected to contain the four bulk JSON files.
+        """
+        if Path(input_base_dir) == Path(cls.DEFAULT_INPUT_DIR):
+            return RAW_DATA_DIR / "mediadive"
+        return Path(input_base_dir) / "mediadive"
 
     def _assert_bulk_data_available(self) -> None:
         """

--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -331,7 +331,7 @@ class MicrobeDecoderTransform(Transform):
         The other four crosswalk columns (NCBI, BacDive, GOLD) are
         single-value in practice; comma-only is safe there too.
         """
-        for column, prefix, _formatter in CROSSWALK_COLUMNS:
+        for column, prefix, source_prefix in CROSSWALK_COLUMNS:
             raw = row.get(column)
             if is_empty_cell(raw):
                 continue
@@ -339,9 +339,14 @@ class MicrobeDecoderTransform(Transform):
                 # Strip a stray leading prefix if the source already CURIE'd
                 # it (``NCBI_Taxonomy_ID`` occasionally arrives as
                 # ``"NCBITaxon:562"`` rather than a bare integer — normalise
-                # so downstream nodes merge cleanly).
-                if local_id.upper().startswith(prefix.upper()):
-                    local_id = local_id.split(":", 1)[1]
+                # so downstream nodes merge cleanly). Both the emitted prefix
+                # and the source's own prefix are stripped, because they
+                # differ for BacDive; slice by length rather than splitting on
+                # ":" so a prefix ending in "_" strips fully.
+                for candidate in (prefix, source_prefix):
+                    if candidate and local_id.upper().startswith(candidate.upper()):
+                        local_id = local_id[len(candidate) :]
+                        break
                 object_curie = f"{prefix}{local_id}"
                 edge_writer.writerow(
                     self._make_edge_row(

--- a/kg_microbe/transform_utils/microbedecoder/utils.py
+++ b/kg_microbe/transform_utils/microbedecoder/utils.py
@@ -25,13 +25,18 @@ LPSN_STATUS_COLUMN = "LPSN_status"
 
 # Identity crosswalk MicrobeDecoder pre-joins per row. Emit each as a
 # `biolink:close_match` edge from `lpsn:<LPSN_ID>` to the target CURIE.
-# `(column, prefix, formatter)`: formatter takes the raw cell value and
-# returns the local ID part (or None to skip). None formatter means the raw
-# value is already the local ID.
+# `(column, emitted_prefix, source_prefix)`: `source_prefix` is the CURIE
+# prefix the raw cell may already carry when it differs from the emitted
+# one; None means the source uses the emitted prefix (or a bare local ID).
+#
+# BacDive emits `kgmicrobe.strain:bacdive_<id>` because that is the CURIE the
+# bacdive transform actually mints for a strain (99,392 node rows). The bare
+# `bacdive:<id>` form this used to emit is not a node anywhere in the graph,
+# so all ~19 K of these edges dangled and KGX turned them into empty stubs.
 CROSSWALK_COLUMNS: Tuple[Tuple[str, str, Optional[str]], ...] = (
     ("NCBI_Taxonomy_ID", "NCBITaxon:", None),
     ("GTDB_ID", "GTDB:", None),
-    ("BacDive_ID", "bacdive:", None),
+    ("BacDive_ID", "kgmicrobe.strain:bacdive_", "bacdive:"),
     ("GOLD_Organism_ID", "GOLD:", None),
     ("IMG_Genome_ID", "IMG:", None),
 )

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -858,14 +858,16 @@ class OntologiesTransform(Transform):
                         line = _replace_special_prefixes(line)
                         line = replace_category_ontology(line, id_index, category_index)
                         new_nf_lines.append(line + "\n")
-                # Update prefixes in edges file
+                # Update prefixes in edges file. The incoming header must be
+                # dropped by position: a canonical header is written below, and
+                # an edges header starts with "subject" (not "id"), so matching
+                # on a column name leaves the original as a duplicate data row.
                 new_ef_lines = []
-                for line in ef:
-                    if line.startswith("id"):
+                for edge_line_index, line in enumerate(ef):
+                    if edge_line_index == 0:
                         continue
-                    else:
-                        line = _replace_special_prefixes(line)
-                        new_ef_lines.append(line)
+                    line = _replace_special_prefixes(line)
+                    new_ef_lines.append(line)
             if name == "ec":
                 # Remove UniProt and TrEMBL nodes since accounted for elsewhere
                 protein_prefixes = [UNIPROT_PREFIX, TREMBL_PREFIX]

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -864,7 +864,10 @@ class OntologiesTransform(Transform):
                 # on a column name leaves the original as a duplicate data row.
                 new_ef_lines = []
                 for edge_line_index, line in enumerate(ef):
-                    if edge_line_index == 0:
+                    # Guarded on the column name too, so a headerless input
+                    # loses no edge — it would just re-duplicate the header,
+                    # which the tests catch, rather than silently drop a row.
+                    if edge_line_index == 0 and line.split("\t")[0] == SUBJECT_COLUMN:
                         continue
                     line = _replace_special_prefixes(line)
                     new_ef_lines.append(line)

--- a/tests/resources/microbedecoder/database.csv
+++ b/tests/resources/microbedecoder/database.csv
@@ -3,7 +3,7 @@ LPSN_ID,LPSN_status,LPSN_Species,LPSN_Strain,NCBI_Taxonomy_ID,GTDB_ID,BacDive_ID
 202,correct name,Escherichia coli,Escherichia coli K-12,562,d__Bacteria;g__Escherichia;s__Escherichia coli,BAC02,Gs0000202,,Mixed-acid fermentation,"acetate, lactate, ethanol, formate, succinate",hydrogen,"glucose, xylose",Mixed-acid fermentation produces multiple organic acids,Glucose is main fermentable substrate,,,,,,,,,,Fermentation,facultative anaerobe,negative,yes,no,rod
 303,correct name,Clostridium acetobutylicum,ATCC 824,1488,,BAC03,Gs0000303,,,,,,,,ABE fermentation,"acetone, butanol, ethanol",acetate,,,,,,,Fermentation,anaerobe,positive,no,yes,rod
 404,correct name,Methanocaldococcus jannaschii,DSM 2661,243232,d__Archaea;g__Methanocaldococcus;s__Methanocaldococcus jannaschii,,,,,,,,,,,,,Methanogenesis,methane,,"H2, CO2",Hydrogenotrophic methanogen,PMID:9634230,Methanogenesis,anaerobe,,,,coccus
-505,synonym,Streptococcus faecalis,Streptococcus faecalis,,,BAC05,,,,,,,,,,,,,,,,,,,facultative anaerobe,positive,,no,coccus
+505,synonym,Streptococcus faecalis,Streptococcus faecalis,,,bacdive:BAC05,,,,,,,,,,,,,,,,,,,facultative anaerobe,positive,,no,coccus
 606,correct name,Lactobacillus acidophilus,DSM 20079,1579,,BAC06,,,Homofermentative,lactate,,glucose,Homofermentative lactic acid bacterium,,,,,,,,,,,Homofermentative,microaerophile,positive,no,no,rod
 707,correct name,Testicola multivalens,,9999,,,,"3300000001,3300000002",,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,aerobe,,,,

--- a/tests/test_bacdive_lpsn_crossref.py
+++ b/tests/test_bacdive_lpsn_crossref.py
@@ -11,6 +11,7 @@ class that owns a heavy constructor.
 """
 
 import csv
+import inspect
 from pathlib import Path
 
 from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
@@ -187,6 +188,38 @@ def test_ambiguous_species_emits_no_edge(tmp_path):
     x = _bare_transform(csv_path)
     assert x._lookup_lpsn({"species": "Escherichia coli"}) is None
     assert x._lpsn_stats["ambiguous"] == 1
+
+
+def test_strain_curie_matches_the_emitted_node_prefix():
+    """
+    The LPSN edge subject must be the strain CURIE this transform emits as a node.
+
+    The edge previously used ``bacdive:NNN``, which is never written as a
+    node row, so all ~62 K of these edges were orphaned and KGX
+    synthesized a bare ``biolink:NamedThing`` stub for each one in the
+    merged KG.
+    """
+    assert BacDiveTransform._strain_curie("7249") == "kgmicrobe.strain:bacdive_7249"
+    # The bare source prefix is precisely the form that produced the orphans.
+    assert not BacDiveTransform._strain_curie("7249").startswith("bacdive:")
+
+
+def test_lpsn_edge_uses_subclass_of_not_in_taxon():
+    """
+    Strain → LPSN record is emitted as ``biolink:subclass_of``/``rdfs:subClassOf``.
+
+    Both endpoints are typed ``biolink:OrganismTaxon``, and this transform
+    already relates the same strain nodes to their NCBITaxon species with
+    ``subclass_of``. ``biolink:in_taxon`` asserts instance-of, which
+    contradicts that class-like typing and made this edge the only
+    strain→taxon link in the transform using a different predicate.
+    """
+    source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
+    lpsn_edge_block = source.split("lpsn_record_no = self._lookup_lpsn")[1].split("synonyms =")[0]
+    assert "SUBCLASS_PREDICATE" in lpsn_edge_block
+    assert "RDFS_SUBCLASS_OF" in lpsn_edge_block
+    assert "IN_TAXON_PREDICATE" not in lpsn_edge_block
+    assert "BACDIVE_PREFIX + key" not in lpsn_edge_block
 
 
 def test_blank_lpsn_block_returns_none(tmp_path):

--- a/tests/test_bacdive_lpsn_crossref.py
+++ b/tests/test_bacdive_lpsn_crossref.py
@@ -219,7 +219,14 @@ def test_lpsn_edge_uses_subclass_of_not_in_taxon():
     assert "SUBCLASS_PREDICATE" in lpsn_edge_block
     assert "RDFS_SUBCLASS_OF" in lpsn_edge_block
     assert "IN_TAXON_PREDICATE" not in lpsn_edge_block
-    assert "BACDIVE_PREFIX + key" not in lpsn_edge_block
+    # Pin the subject positively on the helper, and ban the raw source prefix
+    # outright. Asserting only that one literal spelling of the old
+    # concatenation is absent passes for every other spelling of it —
+    # including the in-scope `bacdive_key`, which lacks the strain prefix.
+    assert "strain_curie = self._strain_curie(key)" in lpsn_edge_block
+    assert "strain_curie," in lpsn_edge_block
+    assert "BACDIVE_PREFIX" not in lpsn_edge_block
+    assert "bacdive_key" not in lpsn_edge_block
 
 
 def test_blank_lpsn_block_returns_none(tmp_path):

--- a/tests/test_mediadive_stale_cache_guard.py
+++ b/tests/test_mediadive_stale_cache_guard.py
@@ -1,0 +1,71 @@
+"""
+Regression tests for the MediaDive stale-cache guard.
+
+``data/transformed/mediadive/edges.tsv`` was once produced by a transform
+launched while ``kg download`` was still fetching ``data/raw/mediadive/``.
+With the bulk JSONs absent, medium lookups fell back to the YAML cache under
+``tmp/medium_yaml`` (files dated 2023) and compound lookups to
+``requests_cache``, which is installed with no expiry. The run exited 0 and
+emitted a graph built from superseded recipes: MediaDive has since inserted
+wrapper solutions, so e.g. ``solution:1878`` linked straight to ``1885``
+instead of to the wrapper ``6570`` that now holds it, and ``1885`` was
+labelled "Solution F" rather than "Ferrous chloride solution (5.2%)".
+
+The guard turns that silent degradation into a refusal at ``run()`` — the
+point where the stale artifact would be written — while leaving construction
+cheap so unrelated tests can still instantiate the transform.
+"""
+
+import pytest
+
+from kg_microbe.transform_utils.mediadive.mediadive import MediaDiveTransform
+
+
+def _bare_transform(tmp_path, using_bulk_data: bool) -> MediaDiveTransform:
+    """
+    Return a MediaDiveTransform with only the fields the guard reads.
+
+    ``__init__`` is skipped: it installs the HTTP cache and loads the ChEBI
+    category table, neither of which the guard touches.
+    """
+    transform = MediaDiveTransform.__new__(MediaDiveTransform)
+    transform.using_bulk_data = using_bulk_data
+    transform.bulk_data_dir = tmp_path / "mediadive"
+    return transform
+
+
+def test_missing_bulk_data_refuses_to_run(tmp_path, monkeypatch):
+    """Absent bulk data must raise rather than fall through to the undated caches."""
+    monkeypatch.delenv("KG_MEDIADIVE_ALLOW_STALE_CACHE", raising=False)
+    transform = _bare_transform(tmp_path, using_bulk_data=False)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        transform._assert_bulk_data_available()
+    message = str(excinfo.value)
+    # The message has to name the remedy; this failure is most likely to be hit
+    # by someone who started the transform before the download finished.
+    assert "kg download" in message
+    assert "KG_MEDIADIVE_ALLOW_STALE_CACHE" in message
+
+
+def test_bulk_data_present_is_a_no_op(tmp_path, monkeypatch):
+    """The normal path must not raise."""
+    monkeypatch.delenv("KG_MEDIADIVE_ALLOW_STALE_CACHE", raising=False)
+    transform = _bare_transform(tmp_path, using_bulk_data=True)
+    transform._assert_bulk_data_available()
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes"])
+def test_explicit_opt_out_allows_cache_only_run(tmp_path, monkeypatch, capsys, value):
+    """An explicit opt-out proceeds, but must say so on stdout."""
+    monkeypatch.setenv("KG_MEDIADIVE_ALLOW_STALE_CACHE", value)
+    transform = _bare_transform(tmp_path, using_bulk_data=False)
+    transform._assert_bulk_data_available()
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_unrelated_env_value_still_refuses(tmp_path, monkeypatch):
+    """Only the documented truthy values count as an opt-out."""
+    monkeypatch.setenv("KG_MEDIADIVE_ALLOW_STALE_CACHE", "maybe")
+    transform = _bare_transform(tmp_path, using_bulk_data=False)
+    with pytest.raises(FileNotFoundError):
+        transform._assert_bulk_data_available()

--- a/tests/test_mediadive_stale_cache_guard.py
+++ b/tests/test_mediadive_stale_cache_guard.py
@@ -69,3 +69,22 @@ def test_unrelated_env_value_still_refuses(tmp_path, monkeypatch):
     transform = _bare_transform(tmp_path, using_bulk_data=False)
     with pytest.raises(FileNotFoundError):
         transform._assert_bulk_data_available()
+
+
+def test_run_invokes_the_guard(tmp_path, monkeypatch):
+    """
+    ``run()`` must call the guard, not merely define it.
+
+    Asserting only on ``_assert_bulk_data_available`` in isolation leaves
+    the wiring untested — deleting the call from ``run()`` would keep every
+    other test in this file green while restoring the silent-stale-output
+    behaviour this guard exists to prevent. The guard also has to fire
+    before ``run()`` touches any input path, so this must raise
+    ``FileNotFoundError`` from the guard rather than from a missing
+    ``mediadive.json``.
+    """
+    monkeypatch.delenv("KG_MEDIADIVE_ALLOW_STALE_CACHE", raising=False)
+    transform = _bare_transform(tmp_path, using_bulk_data=False)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        transform.run()
+    assert "KG_MEDIADIVE_ALLOW_STALE_CACHE" in str(excinfo.value)

--- a/tests/test_mediadive_stale_cache_guard.py
+++ b/tests/test_mediadive_stale_cache_guard.py
@@ -16,6 +16,8 @@ point where the stale artifact would be written — while leaving construction
 cheap so unrelated tests can still instantiate the transform.
 """
 
+from pathlib import Path
+
 import pytest
 
 from kg_microbe.transform_utils.mediadive.mediadive import MediaDiveTransform
@@ -69,6 +71,31 @@ def test_unrelated_env_value_still_refuses(tmp_path, monkeypatch):
     transform = _bare_transform(tmp_path, using_bulk_data=False)
     with pytest.raises(FileNotFoundError):
         transform._assert_bulk_data_available()
+
+
+def test_explicit_input_dir_is_not_silently_overridden():
+    """
+    An explicit ``-i DIR`` must resolve bulk data under DIR, never the repo copy.
+
+    Falling back to the repo-anchored raw dir whenever the given directory
+    lacks the bulk files would reintroduce exactly the failure this guard
+    exists to prevent: the user believes they ran against their own
+    directory and silently gets someone else's data. Only the class
+    default falls back, because it points at a directory that does not
+    exist.
+    """
+    from kg_microbe.transform_utils.constants import RAW_DATA_DIR
+
+    scratch = Path("/scratch/raw-does-not-exist")
+    resolved = MediaDiveTransform._resolve_bulk_data_dir(scratch)
+    assert resolved == scratch / "mediadive"
+    assert RAW_DATA_DIR not in resolved.parents
+
+    # The class default points at a directory that does not exist, so it
+    # is the one case that must fall back to the repo-anchored raw dir.
+    default_resolved = MediaDiveTransform._resolve_bulk_data_dir(MediaDiveTransform.DEFAULT_INPUT_DIR)
+    assert default_resolved == RAW_DATA_DIR / "mediadive"
+    assert not Path(MediaDiveTransform.DEFAULT_INPUT_DIR).is_dir()
 
 
 def test_run_invokes_the_guard(tmp_path, monkeypatch):

--- a/tests/test_microbedecoder_transform.py
+++ b/tests/test_microbedecoder_transform.py
@@ -124,9 +124,52 @@ def test_crosswalk_edges_use_close_match(microbedecoder_transform):
     objects = {e["object"] for e in e_101}
     assert "NCBITaxon:1423" in objects
     assert "GTDB:d__Bacteria;g__Bacillus;s__Bacillus subtilis" in objects
-    assert "bacdive:BAC01" in objects
+    assert "kgmicrobe.strain:bacdive_BAC01" in objects
     assert "GOLD:Gs0000101" in objects
     assert "IMG:3300000001" in objects
+
+
+def test_bacdive_crosswalk_targets_the_strain_curie(microbedecoder_transform):
+    """
+    BacDive crosswalk objects must be the CURIE the bacdive transform mints.
+
+    This used to emit the bare ``bacdive:<id>`` form, which no transform
+    emits as a node row. All ~19 K of these edges dangled and KGX turned
+    them into empty ``biolink:NamedThing`` stubs in the merged KG, while
+    the real strain nodes sat under ``kgmicrobe.strain:bacdive_<id>``
+    (99,392 rows). Every source BacDive ID resolves under that prefix.
+    """
+    microbedecoder_transform.run()
+    edges = _read_tsv(microbedecoder_transform.output_edge_file)
+    close_matches = [e for e in edges if e["predicate"] == CLOSE_MATCH_PREDICATE]
+
+    bacdive_objects = {e["object"] for e in close_matches if "bacdive" in e["object"].lower()}
+    assert bacdive_objects, "fixture must produce BacDive crosswalk edges"
+    for obj in bacdive_objects:
+        assert obj.startswith("kgmicrobe.strain:bacdive_"), (
+            f"BacDive crosswalk target must use the strain CURIE; got {obj!r}"
+        )
+    # The bare source form must not survive anywhere.
+    assert not any(e["object"].startswith("bacdive:") for e in close_matches)
+
+
+def test_bacdive_crosswalk_normalizes_a_precuried_cell(microbedecoder_transform):
+    """
+    A cell already CURIE'd as ``bacdive:<id>`` must not be double-prefixed.
+
+    The prefix-stripping step keys off the *emitted* prefix, which for
+    BacDive no longer matches the prefix the source uses. Without also
+    stripping the source prefix, fixture row 505 (``bacdive:BAC05``) would
+    emit ``kgmicrobe.strain:bacdive_bacdive:BAC05``.
+    """
+    microbedecoder_transform.run()
+    edges = _read_tsv(microbedecoder_transform.output_edge_file)
+    objects = {
+        e["object"] for e in edges if e["subject"] == f"{LPSN_PREFIX}505" and e["predicate"] == CLOSE_MATCH_PREDICATE
+    }
+    assert "kgmicrobe.strain:bacdive_BAC05" in objects, f"pre-CURIE'd cell was not normalized; got {objects}"
+    for obj in objects:
+        assert obj.count(":") == 1, f"double-prefixed CURIE: {obj!r}"
 
 
 def test_crosswalk_edges_carry_microbedecoder_provenance(microbedecoder_transform):
@@ -190,7 +233,7 @@ def test_crosswalk_targets_are_not_stubbed(microbedecoder_transform):
     """
     microbedecoder_transform.run()
     nodes = _read_tsv(microbedecoder_transform.output_node_file)
-    for prefix in ("NCBITaxon:", "GTDB:", "bacdive:", "GOLD:", "IMG:", "CHEBI:"):
+    for prefix in ("NCBITaxon:", "GTDB:", "kgmicrobe.strain:", "GOLD:", "IMG:", "CHEBI:"):
         stubs = [n["id"] for n in nodes if n["id"].startswith(prefix)]
         assert stubs == [], (
             f"MicrobeDecoder must not emit stub nodes for cross-ref target "

--- a/tests/test_microbedecoder_transform.py
+++ b/tests/test_microbedecoder_transform.py
@@ -233,7 +233,10 @@ def test_crosswalk_targets_are_not_stubbed(microbedecoder_transform):
     """
     microbedecoder_transform.run()
     nodes = _read_tsv(microbedecoder_transform.output_node_file)
-    for prefix in ("NCBITaxon:", "GTDB:", "kgmicrobe.strain:", "GOLD:", "IMG:", "CHEBI:"):
+    # "bacdive:" stays in the list even though nothing emits it now — it is the
+    # prefix this transform used to target, and stubbing it would be a silent
+    # return of the dangling-edge bug.
+    for prefix in ("NCBITaxon:", "GTDB:", "kgmicrobe.strain:", "bacdive:", "GOLD:", "IMG:", "CHEBI:"):
         stubs = [n["id"] for n in nodes if n["id"].startswith(prefix)]
         assert stubs == [], (
             f"MicrobeDecoder must not emit stub nodes for cross-ref target "

--- a/tests/test_ontologies_ec_uri_compaction.py
+++ b/tests/test_ontologies_ec_uri_compaction.py
@@ -215,3 +215,29 @@ class TestEcPostProcessUriCompaction(TestCase):
                     "uniprot" in row["subject"].lower() or "uniprot" in row["object"].lower(),
                     f"UniProt edge survived: {row}",
                 )
+
+    def test_edge_header_is_written_exactly_once(self):
+        """
+        The ec branch must not leave the incoming header as a data row.
+
+        The branch rewrites ec_edges.tsv with a canonical header, and the
+        read loop that feeds it skipped headers by matching ``id`` — the
+        node header's first column. An edges header starts with
+        ``subject``, so it never matched and survived into the body. KGX
+        then read ``subject``/``object`` as endpoint CURIEs and
+        synthesized two bare ``biolink:NamedThing`` nodes in the merged
+        KG. DictReader-based assertions cannot see this, so compare raw
+        lines.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            _, edges_path = self._run_post_process(Path(tmp))
+            with open(edges_path) as fh:
+                lines = [line.rstrip("\n") for line in fh if line.strip()]
+            header = lines[0].split("\t")
+            self.assertEqual(header[:3], ["subject", "predicate", "object"])
+            duplicates = [i for i, line in enumerate(lines[1:], start=2) if line.split("\t")[:3] == header[:3]]
+            self.assertEqual(
+                duplicates,
+                [],
+                f"edges header repeated as a data row at line(s) {duplicates}",
+            )


### PR DESCRIPTION
Found by a `kg-path-review` sweep. All three are invisible to single-edge conformance checks (`kg-model-review` reports the merged KG as clean), because each is a *path* or *provenance* defect rather than a malformed row.

## 1. BacDive — 62k orphan strain→LPSN edges

The LPSN cross-ref edge used `bacdive:<id>` as its subject, but this transform only ever emits strain nodes as `kgmicrobe.strain:bacdive_<id>` (99,392 of them). Every one of the **62,096** edges was orphaned, and KGX synthesized **62,521 bare `biolink:NamedThing` stubs** (`provided_by=Graph`, no name) into the merged KG.

Both call sites now go through a shared `_strain_curie()` helper so the node-emitting path and the edge-emitting path cannot drift apart again.

**Predicate also changed: `biolink:in_taxon` → `biolink:subclass_of` / `rdfs:subClassOf`.** Rationale:
- Both endpoints are typed `biolink:OrganismTaxon`.
- This transform *already* relates the same strain nodes to their NCBITaxon species with `subclass_of` (99,381 edges), and the `lpsn` transform uses `subclass_of` for its own hierarchy (29,695 edges). `in_taxon` was the lone outlier for the same semantic relation.
- `in_taxon` asserts instance-of, which contradicts the class-like `OrganismTaxon` typing already in use; NCBITaxon likewise models strains as classes `subclass_of` their species.
- On Biolink purity: `organism taxon` descends from neither `thing with taxon` (in_taxon's domain) nor `ontology class` (subclass_of's domain) in 4.2.2, so both are formally out-of-domain. `subclass_of` folds into an existing, accepted violation shape instead of adding a second, rarer one.

## 2. Ontologies — EC edges header written twice

The `ec` branch drops the incoming header by matching `line.startswith("id")` — the **node** header's first column. An edges header starts with `subject`, so it never matched and survived as a data row beneath the freshly written canonical header. KGX then read `subject`/`object` as endpoint CURIEs and emitted two phantom `biolink:NamedThing` nodes into the merged KG (the non-CURIE node IDs flagged as an ERROR by `kg-model-review`). Header is now dropped by position.

Only `ec_edges.tsv` was affected; the other 13 ontology edge files were clean.

## 3. MediaDive — silent degradation to undated caches

With `data/raw/mediadive/` absent, the transform falls back to the YAML cache under `tmp/medium_yaml` and to `requests_cache` — **neither has an expiry**. A transform launched before `kg download` finishes exits 0 having built the graph from years-old recipes.

That is exactly what produced the shipped output: `data/transformed/mediadive/edges.tsv` is dated Jul 24 15:38 while `data/raw/mediadive/*.json` are Jul 25 00:14, and `tmp/medium_yaml/916.yaml` is dated **Oct 30 2023**. MediaDive has since inserted wrapper solutions, so the output links `solution:1878` straight to `1885` instead of to the wrapper `6570` that now holds it, and labels `1885` "Solution F" rather than "Ferrous chloride solution (5.2%)".

`run()` now refuses this case at the point the stale artifact would be written; `KG_MEDIADIVE_ALLOW_STALE_CACHE=true` opts back in for offline/cache-only work. Construction stays cheap so unrelated tests can still instantiate the transform.

**Important:** the MediaDive recipe divergence is *not* an emission-logic bug — the per-solution edge loop is correct. It is stale input. Re-running the transform against current raw data is what actually repairs that output; this guard only prevents recurrence.

## Testing

Regression tests added for all three, each verified red on the previous code and green on this one:
- `tests/test_ontologies_ec_uri_compaction.py` — raw-line header check (the existing `DictReader` assertions structurally could not see a duplicated header)
- `tests/test_bacdive_lpsn_crossref.py` — strain-CURIE prefix + predicate invariants
- `tests/test_mediadive_stale_cache_guard.py` — new file

`poetry run tox` green: **835 passed**.

## Follow-ups not in this PR

- The merged KG in `data/merged/` (Aug 3) still contains all of the above; it needs a re-merge from freshly re-run transforms.
- `mediadive.py:139` installs `requests_cache` with no expiry, and the YAML medium cache has no invalidation at all. The guard prevents the silent-fallback path but does not add cache expiry.
- `orphan-edges` scans a stray `data/transformed/microbedecoder_bak/` directory as if it were a transform, double-counting results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)