### PR TITLE
feat(merge): allow merging a subset of sources with `kg merge -s`

### DIFF
--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -70,16 +70,52 @@ def parse_load_config(yaml_file: str) -> Dict:
     return config
 
 
-def load_and_merge(yaml_file: str, processes: int = 1) -> nx.MultiDiGraph:
+def _assert_sources_exist(yaml_file: str, sources: List[str]) -> None:
+    """
+    Fail before parsing anything if a requested source is not in the config.
+
+    KGX indexes the config dict directly, so an unknown key surfaces as a
+    bare ``KeyError: 'foo'`` only after the run is underway. A merge is a
+    long, expensive operation; a typo should not be discovered an hour in.
+
+    :param yaml_file: Path to the KGX merge config.
+    :param sources: Source keys requested on the command line.
+    :raises KeyError: If any requested source is absent from the config.
+    """
+    with open(yaml_file, "r") as fh:
+        config = yaml.safe_load(fh)
+    available = set((config.get("merged_graph", {}) or {}).get("source", {}) or {})
+    unknown = [s for s in sources if s not in available]
+    if unknown:
+        raise KeyError(f"Source(s) {sorted(unknown)} not in {yaml_file}. Available: {sorted(available)}")
+
+
+def load_and_merge(
+    yaml_file: str,
+    processes: int = 1,
+    sources: Optional[List[str]] = None,
+) -> nx.MultiDiGraph:
     """
     Load and merge sources defined in the config YAML.
 
-    :param yaml_file: A string pointing to a KGX compatible config YAML.
-    :param processes: Number of processes to use.
-    :return: networkx.MultiDiGraph: The merged graph.
+    ``sources`` restricts the merge to a subset of the config's sources.
+    KGX holds every source's graph in the parent process at once —
+    ``kgx.cli.cli_utils.merge`` collects them all before calling
+    ``merge_all_graphs`` — so peak memory scales with the whole set, not
+    with the largest member. Merging in stages is the only way to keep a
+    very large source (PREGO: 44.7M edges) from coexisting with all the
+    others.
 
+    :param yaml_file: A string pointing to a KGX compatible config YAML.
+    :param processes: Number of processes to use. Each concurrent process
+        holds its own source graph, so raising this raises peak memory.
+    :param sources: Optional subset of source keys to merge. None merges all.
+    :return: networkx.MultiDiGraph: The merged graph.
+    :raises KeyError: If a requested source is absent from the config.
     """
-    merged_graph = merge(yaml_file, processes=processes)
+    if sources:
+        _assert_sources_exist(yaml_file, sources)
+    merged_graph = merge(yaml_file, source=list(sources) if sources else None, processes=processes)
     try:
         _cleanup_merged_outputs(yaml_file)
     except Exception as exc:  # noqa: BLE001

--- a/kg_microbe/run.py
+++ b/kg_microbe/run.py
@@ -97,15 +97,28 @@ def transform(*args, **kwargs) -> None:
 @main.command()
 @click.option("yaml", "-y", default="merge.yaml", type=click.Path(exists=True))
 @click.option("processes", "-p", default=1, type=int)
-def merge(yaml: str, processes: int) -> None:
+@click.option(
+    "sources",
+    "-s",
+    "--source",
+    multiple=True,
+    help="Merge only these sources from the config (repeatable). Omit to merge all.",
+)
+def merge(yaml: str, processes: int, sources: tuple) -> None:
     """
     Use KGX to load subgraphs to create a merged graph.
 
+    Restricting to a subset with ``-s`` allows a staged merge, which is the
+    only way to keep a very large source from being resident at the same
+    time as every other one — KGX collects all source graphs in the parent
+    before combining them.
+
     :param yaml: A string pointing to a KGX compatible config YAML.
     :param processes: Number of processes to use.
+    :param sources: Source keys to merge; empty means all.
     :return: None
     """
-    load_and_merge(yaml, processes)
+    load_and_merge(yaml, processes, list(sources) or None)
 
 
 @main.command(name="query-organism")

--- a/tests/test_merge_source_subset.py
+++ b/tests/test_merge_source_subset.py
@@ -1,0 +1,104 @@
+"""
+Tests for merging a subset of the sources in a KGX config.
+
+KGX holds every source's graph in the parent process simultaneously:
+``kgx.cli.cli_utils.merge`` does ``stores = [r.get() for r in results]``
+before calling ``merge_all_graphs``. Peak memory therefore scales with the
+whole source set, not with its largest member. A full kg-microbe merge
+reached 48 GB resident on a 64 GB machine, dominated by PREGO's 44.7M
+edges (~76% of all input by size).
+
+Selecting a subset lets the merge run in stages so the big source is never
+resident alongside the other nineteen. These tests pin the plumbing —
+that the selection actually reaches KGX and that a bad key fails fast —
+rather than running a real merge, which needs the full data tree.
+"""
+
+from unittest import mock
+
+import pytest
+import yaml as yaml_lib
+
+from kg_microbe.merge_utils.merge_kg import load_and_merge
+
+_CONFIG = {
+    "configuration": {"output_directory": "data/merged"},
+    "merged_graph": {
+        "name": "test graph",
+        "source": {
+            "alpha": {"input": {"format": "tsv", "filename": ["a_nodes.tsv", "a_edges.tsv"]}},
+            "beta": {"input": {"format": "tsv", "filename": ["b_nodes.tsv", "b_edges.tsv"]}},
+            "gamma": {"input": {"format": "tsv", "filename": ["c_nodes.tsv", "c_edges.tsv"]}},
+        },
+        "destination": {"merged-kg-tsv": {"format": "tsv", "filename": "merged-kg"}},
+    },
+}
+
+
+@pytest.fixture()
+def config_path(tmp_path):
+    """Write a minimal three-source KGX merge config and return its path."""
+    path = tmp_path / "merge.test.yaml"
+    path.write_text(yaml_lib.safe_dump(_CONFIG))
+    return str(path)
+
+
+def _merged_sources(mock_merge):
+    """Return the ``source`` argument KGX was actually called with."""
+    return mock_merge.call_args.kwargs.get("source")
+
+
+@mock.patch("kg_microbe.merge_utils.merge_kg._cleanup_merged_outputs")
+@mock.patch("kg_microbe.merge_utils.merge_kg.merge")
+def test_subset_is_passed_through_to_kgx(mock_merge, _cleanup, config_path):
+    """The selected subset must reach KGX, not just be accepted by the CLI."""
+    load_and_merge(config_path, sources=["alpha", "gamma"])
+    assert _merged_sources(mock_merge) == ["alpha", "gamma"]
+
+
+@mock.patch("kg_microbe.merge_utils.merge_kg._cleanup_merged_outputs")
+@mock.patch("kg_microbe.merge_utils.merge_kg.merge")
+def test_no_subset_merges_everything(mock_merge, _cleanup, config_path):
+    """Omitting the subset must merge all sources, i.e. pass source=None."""
+    load_and_merge(config_path)
+    assert _merged_sources(mock_merge) is None
+
+
+@mock.patch("kg_microbe.merge_utils.merge_kg._cleanup_merged_outputs")
+@mock.patch("kg_microbe.merge_utils.merge_kg.merge")
+def test_empty_subset_is_treated_as_all(mock_merge, _cleanup, config_path):
+    """An empty tuple from click must not mean 'merge nothing'."""
+    load_and_merge(config_path, sources=[])
+    assert _merged_sources(mock_merge) is None
+
+
+@mock.patch("kg_microbe.merge_utils.merge_kg._cleanup_merged_outputs")
+@mock.patch("kg_microbe.merge_utils.merge_kg.merge")
+def test_unknown_source_fails_before_kgx_runs(mock_merge, _cleanup, config_path):
+    """
+    A typo must abort before any parsing starts.
+
+    KGX indexes the config dict directly, so an unknown key would otherwise
+    surface as a bare ``KeyError`` only once the merge is underway — an
+    expensive place to discover a misspelling.
+    """
+    with pytest.raises(KeyError) as excinfo:
+        load_and_merge(config_path, sources=["alpha", "prego"])
+    message = str(excinfo.value)
+    assert "prego" in message
+    # The error has to name the valid options, or the user is left guessing.
+    assert "alpha" in message and "beta" in message
+    mock_merge.assert_not_called()
+
+
+@mock.patch("kg_microbe.merge_utils.merge_kg._cleanup_merged_outputs")
+@mock.patch("kg_microbe.merge_utils.merge_kg.merge")
+def test_processes_still_defaults_to_one(mock_merge, _cleanup, config_path):
+    """
+    Each concurrent process holds its own source graph.
+
+    Raising the default would multiply peak memory on the exact workload
+    this subset option exists to make survivable.
+    """
+    load_and_merge(config_path)
+    assert mock_merge.call_args.kwargs.get("processes") == 1


### PR DESCRIPTION
## Problem

A full `kg merge -y merge.yaml` reached **48 GB resident on a 64 GB machine**, drove free RAM to 59 MB, grew the swapfile from 14 GB to 18 GB, and died after ~40 minutes **without writing anything** — KGX only serializes at the end, so nothing partial survives.

Reading KGX 2.4.2's implementation shows why (`kgx/cli/cli_utils.py:640-661`):

```python
stores = [r.get() for r in results]                        # ALL 20 source graphs in the parent
merged_graph = merge_all_graphs([x.graph for x in stores])
```

Every source's graph is materialized and held simultaneously. Peak scales with the **whole set**, not the largest member — and there was no way to merge in stages.

PREGO dominates: **44,716,161 edges in a 7.38 GB `edges.tsv`**, ~76% of the 9.7 GB total input. Every other source combined is ~2.3 GB.

## What this adds

`kg merge -y merge.yaml -s bacdive -s mediadive` passes the subset through to KGX's existing `source=` parameter, enabling a staged merge so PREGO is never resident alongside the other nineteen sources.

An unknown key fails immediately and names the valid options:

```
$ poetry run kg merge -y merge.yaml -s notasource
KeyError: "Source(s) ['notasource'] not in merge.yaml. Available: ['bacdive', 'bactotraits', ...]"
```

KGX indexes the config dict directly, so a typo would otherwise surface as a bare `KeyError: 'foo'` only once an hour-long run was underway.

`processes` stays at **1** and is now documented as memory-scaling — each concurrent process holds its own source graph, so raising it works directly against the problem this option exists to solve. A test pins the default.

## Investigated and rejected — recorded so nobody re-derives them

| approach | verdict |
|---|---|
| `checkpoint: true` | **No.** `cli_utils.py:787-790` just calls `transformer.save()` per source. Adds I/O, frees nothing. |
| Streaming merge | **Not available.** `stream` exists only on `transform()`; `merge()` has no streaming path in 2.4.2. |
| `merge_all_graphs` tuning | **Already optimal.** It merges into the largest graph by design (`graph_merge.py:17-20`). |
| Filter PREGO by confidence | **Correction: not weak — but not expressible here.** `prego_score` runs 0 to **4.0074** (mean 2.92), not 0–1, so a ≥4.0 cutoff drops **44.66% (20.0M edges)**. It must be **per-channel** (53% of edges are continuously scored, ~46% carry a flat integer 3/4) and applied at transform time, since `merge.yaml` cannot express numeric comparisons. See #693. |
| Filter by `prego_direct_flag` | **No.** 100% `TRUE` — dead column. |
| Dedup PREGO | **No.** 40,604 distinct subjects × 32,440 distinct objects at 3.4% density; the edges are genuinely distinct. |

`edge_filters` *are* applied at read time (`tsv_source.py:275` → `check_edge_filter`), so filtered edges never enter the graph — that mechanism is real and useful. But `check_edge_filter` (`source/source.py:102-134`) does exact-string and list-membership matching only, **no numeric comparison**, so no score threshold is expressible in `merge.yaml`. Score-based reduction has to happen at transform time.

## Testing

Five tests pin the plumbing rather than the flag parsing — that the subset actually reaches KGX, that omitting it still merges everything, that click's empty tuple isn't misread as "merge nothing", that a bad key aborts before KGX runs, and that `processes` stays 1.

`poetry run tox` green: **844 passed**.

## Follow-ups

- The staged-merge workflow needs a stage-2 config (stage-1 output + PREGO as two sources). Not included here; this PR is the enabling change.
- For a real reduction rather than a workaround, PREGO would need either a categorical confidence band emitted by the transform (making `edge_filters` usable), or a curation decision about whether all 44.7M text-mined associations — ~1,101 per taxon — belong in the KG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
