### PR TITLE
feat(prego): per-resource confidence calibration + emit the resource column

### DIFF
--- a/TODO/2026-08-06_codex_review_prompt_pr697_prego_calibration.md
+++ b/TODO/2026-08-06_codex_review_prompt_pr697_prego_calibration.md
@@ -1,0 +1,218 @@
+# Codex review prompt — PREGO gold-standard analysis + threshold calibration (PR #697)
+
+Generated 2026-08-06 via `/codex-review-kg-microbe`. Hand the fenced block below to
+`Agent(subagent_type="codex:codex-rescue", prompt="<block>")` or paste into `codex exec`.
+
+Extends the standard six-dimension template with a **seventh dimension (statistical
+validity)**, because the substance of this branch is a measurement claim, not just
+code — and the two defects already found in it were both methodological rather than
+ordinary logic bugs.
+
+---
+
+```
+You are an experienced code reviewer performing a focused review of the PREGO
+confidence-calibration and gold-standard-analysis work in KG-Microbe
+(Knowledge-Graph-Hub/kg-microbe), branch `feat/prego-confidence-calibration`
+(PR #697, design issue #696).
+
+## Repo context
+
+KG-Microbe is a Python knowledge-graph construction pipeline with three stages —
+**Download → Transform → Merge** — emitting Biolink-modeled `nodes.tsv` +
+`edges.tsv` per source plus a merged KG.
+
+- CLI: `poetry run kg download | transform | merge` (`kg_microbe/run.py`, Click).
+- Transforms: `kg_microbe/transform_utils/<source>/<source>.py`, subclasses of
+  `Transform` in `transform_utils/transform.py`, registered in `DATA_SOURCES`.
+- Shared conventions: `transform_utils/constants.py` (column names, path
+  constants), `transform_utils/custom_curies.yaml`.
+- Merge uses the KGX library (`kg_microbe/merge_utils/merge_kg.py`).
+
+## What this branch does
+
+PREGO (Zafeiropoulos et al. 2022, Microorganisms 10:293) is a text-mined +
+database-derived taxon↔function/environment/disease resource. Its KG-Microbe
+ingest emits **44,716,161 edges in a 7.38 GB `edges.tsv`** — about 76% of all
+merge input by size, and the reason a full merge exhausts a 64 GB machine.
+
+The branch adds a tunable confidence threshold so the source can be reduced, plus
+the machinery to test whether that threshold actually selects better edges.
+
+Files changed (1,301 insertions):
+
+- `kg_microbe/transform_utils/prego/calibration.py` (new, 327 lines) —
+  per-resource percentile calibration. Continuous-channel rows are remapped
+  `star = 4 * F_r(score)` where `F_r` is the empirical CDF within resource `r`;
+  flat channels are rated by their own score. One knob, `tau in [0,4]`; keep
+  iff `star >= tau`. Cutoffs come from fixed-width binned histograms
+  (`BIN_WIDTH = 1e-4` over `[0, SCORE_MAX=4.01]`).
+- `kg_microbe/transform_utils/prego/quality.py` (new, 235 lines) — fold-enrichment
+  measurement against a gold standard: `fold = P(hit | window) / P(hit)`.
+- `kg_microbe/transform_utils/prego/prego.py` (+183) — two-pass wiring
+  (`_collect_calibration` then the emit pass), `PREGO_MIN_CONFIDENCE` env var,
+  `prego_source` column now emitted (previously `del source`), payload memoization,
+  calibration-table output.
+- `kg_microbe/transform_utils/constants.py` (+5) — `PREGO_SOURCE_COLUMN`.
+- Tests (+555 across three files).
+
+## Domain facts established empirically — treat as given, do not re-derive
+
+- `prego_score` runs **0 to 4.00735** (mean 2.92). The paper documents a cap of 4;
+  the shipped data exceeds it.
+- The score is **not one scale**. Per PREGO's authors (§2.3), the genome-derived
+  channels were "assigned arbitrarily a confidence level of four out of five" and
+  BioProject/PMID rows three of five. Only the Environmental Samples channel has a
+  computed, varying score. PREGO computes **no cross-channel combined score**.
+- Channel composition of emitted edges: continuous (`<N of M samples>`) **53.00%**;
+  flat (Isolates 28.66%, Genome annotation 9.17%, MAG 7.27%, SAG 1.79%,
+  PMID 0.05%) **47.00%**.
+- The continuous channel aggregates three resources with materially different
+  cutoffs at the same tau: MG-RAST metagenome **1.717**, MG-RAST amplicon **0.575**,
+  MGnify **0.848**. MG-RAST metagenome is 99.62% of the channel.
+- **MG-RAST amplicon holds 46.4% of its rows at the score cap**, so every tau above
+  ~2.5 retains that same 46.4%.
+- A real calibration pass sees 23,698,632 continuous rows vs 23,697,432 in the
+  emitted `edges.tsv` (0.005% apart).
+- Two gold standards were built and **they disagree on the direction of the
+  score/quality relationship**:
+  - UniProt (from `data/merged/20250222_function/`, joining
+    `protein -derives_from-> NCBITaxon` with `protein -participates_in|located_in-> GO`):
+    14,411,869 pairs, 4,209 GO terms, 41.5% of PREGO taxon→GO edges comparable.
+    Fold **rises**: 0.94x, 0.96x, 1.04x, 1.19x. Flat channels 2.19x.
+  - metatraits + metatraits_gtdb + madin_etal (trait-derived): 333,407 pairs,
+    78 GO terms, 1.0% comparable. Fold **falls**: 1.61x, 1.59x, 1.56x.
+    Flat channels 1.00x.
+- A GO term's edge count correlates with its mean score at Spearman **+0.26**,
+  driven by rare terms scoring low (0.67 mean in the lowest-ubiquity decile vs
+  ~2.0 above).
+
+## Review scope
+
+Focus on: **kg_microbe/transform_utils/prego/ and tests/test_prego_*.py**
+
+Read `calibration.py`, `quality.py`, and the changed regions of `prego.py` in full.
+Ignore `data/`, `.tox/`, `.venv/`, `__pycache__/`, and generated TSVs.
+
+## Review dimensions — required
+
+Evaluate against **all seven**. Not every file will have findings in every
+dimension; do not skip one.
+
+1. **Code logic** — control flow, off-by-one, wrong operator precedence,
+   mis-ordered arguments, values computed but never reaching a writer.
+   Specifically: is `ScoreHistogram.cutoff()` solving `4*F(s) >= tau` correctly at
+   the boundaries? Is `_bin_index` clamping correct for `score <= 0`, `score` at
+   exactly `SCORE_MAX`, and `score > SCORE_MAX`? Does `star_for_row` return the
+   right thing for each of {continuous with cutoff, continuous without cutoff,
+   recognised flat, unrecognised}?
+
+2. **Consistency** — does the calibration path duplicate logic that already exists
+   elsewhere in the repo? Is `_KEEP_OUTCOMES` genuinely the same predicate the emit
+   pass applies, or can the two diverge? Is `is_continuous_channel` (shape-matching
+   on `"N of M samples"`) duplicated anywhere? Does the env-var convention match
+   `METATRAITS_WORKERS` / `KG_MEDIADIVE_ALLOW_STALE_CACHE`?
+
+3. **Robustness** — malformed rows, missing columns, absent archives, a resource
+   present in pass 2 but absent from pass 1's cutoff table, empty histograms,
+   `float()` on user-supplied text, non-idempotency, `atomic_write` usage for the
+   calibration table.
+
+4. **Bugs** — provable on real inputs. Each MUST include file:line, ≤2-sentence
+   description, minimal repro, expected vs actual.
+
+5. **Bottlenecks** — the two-pass design reads the archives twice. Is
+   `_ensure_payload` memoization actually hit on both passes? Is `tarfile.getmembers()`
+   on an 8.7 GB gzipped tar avoided where possible? Any per-row work that belongs
+   outside the loop?
+
+6. **Scalability** — the emit path streams 44.7M rows and the calibration pass
+   another 44.7M. Flag anything O(N) in memory. `ScoreHistogram` uses a dict keyed
+   by bin index — bound its worst case. Does anything accumulate per-row state that
+   would break past 5M rows? Would this survive being run under the metatraits-style
+   multiprocessing pool?
+
+7. **Statistical validity** *(added for this branch — the substance here is a
+   measurement claim, and both defects found so far were methodological)*
+   - **Tie handling.** `enrichment_by_window` aggregates by exact score so window
+     boundaries fall only where the score changes. Verify that is airtight,
+     including float-equality keying of scores, and that no code path can
+     reintroduce index-based slicing. Prior bug: an analysis sorted
+     `(score, is_hit)` tuples, so the sort tiebreak pushed non-hits below the 4.0
+     block and hits above it, fabricating a 0.44x window adjacent to a 1.95x one.
+   - **Baseline definition.** `GoldStandard.baseline` uses
+     `|gold ∩ shared| / (|shared subjects| × |shared objects|)`. Is that the right
+     null? It assumes every subject×object cell is an equally likely draw, which
+     ignores that taxa differ enormously in annotation depth. Would a
+     degree-preserving null change the conclusions? State the direction of any bias.
+   - **Circularity.** The UniProt gold standard is genome-derived and PREGO's flat
+     channels are genome-derived (JGI IMG, Struo-GTDB). Is the 2.19x flat-channel
+     enrichment measuring quality or shared provenance? Is there any independent
+     gold standard in-repo that avoids this?
+   - **Multiple comparisons / effect size.** Fold enrichment spans ~1.0–1.2x across
+     the continuous channel. Given n≈8.6M, is that distinguishable from structured
+     noise? Are confidence intervals warranted before any of this is cited?
+   - **The percentile remap's meaning.** `star = 4*F_r(score)` equalises rank within
+     a resource. Is calling the output "confidence" defensible given no quality
+     anchor, and does the code or its docstrings overclaim anywhere?
+   - **Ubiquity confound.** Spearman +0.26 between GO-term degree and mean score.
+     Does that undermine the fold-enrichment result — i.e. could the enrichment
+     trend be explained entirely by term frequency rather than by the score?
+     Propose the specific stratified test that would settle it.
+
+## Output format — required
+
+For every finding:
+
+```
+### {severity} · {dimension} · {short-title}
+
+- **File:** `<path>:<line>`
+- **Category:** one of {logic | consistency | robustness | bug | bottleneck | scalability | statistical}
+- **Severity:** one of {CRITICAL | HIGH | MEDIUM | LOW}
+- **Confidence:** {HIGH | MEDIUM | LOW}
+- **Impact:** one sentence — who / what is affected on a real run.
+- **Fix sketch:** one or two sentences; if > 20 lines say `fix requires refactor; see notes`.
+- **Notes:** free text; minimal repro for bugs, cross-file refs for consistency,
+  and for statistical findings the specific test that would confirm or refute.
+```
+
+End with a **summary table** grouped by `(dimension, severity)` with counts, plus
+**top 5 to fix first** ranked by `severity × confidence × blast-radius`.
+
+Additionally, answer these three directly, as a short section before the table:
+
+1. Is the threshold safe to ship as a **size** lever (its stated purpose in #693),
+   independent of the unresolved quality question? Yes/no + why.
+2. Is any claim in the module docstrings or test docstrings **not supported** by the
+   evidence described above? Quote it.
+3. What is the single highest-value experiment that would resolve the
+   UniProt-vs-metatraits disagreement?
+
+## Explicit non-goals
+
+Do NOT:
+- Propose renames, formatter fixes, or docstring additions unless they block
+  correctness or fix an overclaim.
+- Rewrite files. Fix sketches only, never diffs.
+- Comment on ontology curation choices (which GO IDs are "right"), only on how the
+  code handles them.
+- Re-derive the empirical numbers above; they came from full passes over the real
+  archives. Do challenge the **method** by which they were obtained.
+- Flag dependency deprecation warnings KG-Microbe cannot fix.
+- Duplicate a finding across dimensions — pick the best fit.
+
+## Ground rules
+
+- All file paths are repo-relative.
+- Prefer high-confidence findings; mark speculative ones `Confidence: LOW` and say
+  what you would need to raise it.
+- For a systemic issue, describe it once with a representative site plus a
+  grep-friendly pattern rather than listing every occurrence.
+- Run today (date: 2026-08-06). Note any finding whose behavior depends on a data
+  snapshot that may have changed — in particular the PREGO archives, which
+  `lab42open-team/prego_daemons` recomputes periodically, and
+  `data/merged/20250222_function/`, which is a February 2025 build.
+- `poetry run tox` is currently green (888 passed). A finding that would break it
+  should say so.
+```

--- a/TODO/2026-08-06_codex_review_prompt_prego_assessment.md
+++ b/TODO/2026-08-06_codex_review_prompt_prego_assessment.md
@@ -1,0 +1,198 @@
+# Codex review prompt — PREGO validation assessment + recommendations
+
+Generated 2026-08-06. Hand the fenced block to
+`Agent(subagent_type="codex:codex-rescue", prompt="<block>")` or `codex exec`.
+
+Distinct from `2026-08-06_codex_review_prompt_pr697_prego_calibration.md`, which
+reviewed the *code*. This one reviews the **empirical assessment and the
+recommendations drawn from it** — whether the measurements support the
+conclusions, and whether the proposed actions follow.
+
+---
+
+```
+You are reviewing an empirical assessment and the recommendations drawn from it.
+This is NOT primarily a code review — it is a review of measurement design,
+inference, and whether proposed actions follow from evidence. Findings about
+statistical validity and unsupported inference outrank findings about style.
+
+## Repo context
+
+KG-Microbe (Knowledge-Graph-Hub/kg-microbe) is a Python knowledge-graph
+pipeline: Download -> Transform -> Merge, emitting Biolink-modeled nodes.tsv +
+edges.tsv per source plus a merged KG.
+
+PREGO (Zafeiropoulos et al. 2022, Microorganisms 10:293) is a text-mined +
+database-derived taxon<->function/environment/disease resource. Its ingest emits
+44,716,161 edges in a 7.38 GB edges.tsv — ~76% of all merge input by size, and
+the reason a full merge exhausts a 64 GB machine.
+
+## What to review
+
+Primary: `docs/PREGO_SCORE_VALIDATION.md` — the consolidated findings and
+recommendations.
+
+Supporting:
+- `scripts/prego_validation/` — the seven analysis scripts that produced every
+  number in that document, plus a README.
+- `kg_microbe/transform_utils/prego/quality.py` — the reusable measurement API
+  (GoldStandard, LabelledEvidence, enrichment_by_window, precision_by_window,
+  lift, is_monotone_increasing).
+- `kg_microbe/transform_utils/prego/calibration.py` and `prego.py` — the
+  threshold implementation the recommendations would configure.
+- `tests/test_prego_quality.py`, `tests/test_prego_calibration.py`.
+- `docs/PREGO_INGEST_PLAN.md` — the original ingest rationale, which states
+  PREGO's value proposition.
+
+You may run the fast scripts (`build_assay_gold.py`, `fold_enrichment_bto.py`,
+each seconds to ~2 min) and the test suite. Do NOT run `build_uniprot_gold.py`
+(~25 min, reads 28.6 GB) unless you need to check a specific claim. Do NOT edit,
+stage, commit, or push. Do NOT run any transform or merge that writes into
+`data/`.
+
+## The claims under review
+
+1. **Verdict:** the score discriminates on `biolink:location_of` edges
+   (ENVO->taxon, BTO->taxon; 452,051 edges) and not on `biolink:capable_of`
+   edges (taxon->GO; 44,258,939 edges).
+2. **Mechanism:** the score counts taxon-sample co-occurrence, which is direct
+   evidence for "found in location X" and only indirect for "can perform
+   function Y".
+3. **Threshold:** for location_of edges, precision peaks at score >= 3.0
+   (0.641, 18.79x) and falls above it, so thresholds above 3.0 are strictly
+   dominated.
+4. **Recommendation:** keep and threshold the location_of edges; keep the
+   flat/genome-derived GO channels unthresholded on provenance grounds; DROP
+   the continuous GO channel (~23.3M edges, ~52% of PREGO); keep MONDO flagged
+   unvalidated.
+5. **Claimed side effect:** dropping the continuous GO block takes edges.tsv
+   from 7.4 GB to ~3.5 GB and largely dissolves the 48 GB merge problem.
+
+## Review dimensions — required, in priority order
+
+### 1. Inferential validity (highest priority)
+
+- Does each conclusion follow from the measurement that supposedly supports it?
+  Flag any place a correlational result is stated causally, a single-benchmark
+  result is generalized, or absence of evidence is reported as evidence of
+  absence.
+- **The verdict rests on a predicate-level split inferred from three edge types
+  measured against different gold standards with wildly different coverage**
+  (41.5% / 2.64% / 3.08% / 0.1%). Is "location_of works, capable_of does not"
+  actually established, or is it confounded with which gold standard happened
+  to be available for which edge type? What would distinguish those?
+- Is the mechanism (claim 2) supported, or is it a post-hoc story that fits?
+  What would falsify it?
+- The document says three gold standards disagree on the continuous GO channel
+  (1.45x / 1.07x / 0.91x) "in a pattern matching each standard's provenance".
+  Is that pattern real, or is it small-n noise across differently-powered tests?
+
+### 2. Measurement design
+
+- **Baseline.** Fold enrichment uses a uniform subject x object null over the
+  shared entity space. It controls for neither taxon annotation depth nor term
+  ubiquity. The document claims the *within-term stratified ratios* address that
+  confound. Do they? A median split within term controls for term identity but
+  not for taxon degree — does that matter here, and in which direction?
+- **Tie handling.** Windows break only where the score changes. Verify that
+  holds in both `quality.enrichment_by_window` and every script. A prior version
+  sorted `(score, is_hit)` tuples and manufactured a 0.44x window next to a
+  1.95x one from sort order alone.
+- **Uncertainty.** No clustered intervals anywhere. Edges reuse taxa, terms and
+  resources. Which of the headline numbers would survive two-way clustered
+  bootstrap by taxon and term? Specifically: is the ENVO within-term result
+  (18 of 19 terms, pooled 1.57x) robust, and is the BTO one (7 of 9 terms,
+  n=1,102, 9 terms clearing the bar) strong enough to claim replication?
+- **Selection effects.** All gold standards can only reach where PREGO overlaps
+  existing sources — precisely where PREGO is least additive. The document
+  states this. Does it then draw conclusions that quietly depend on
+  extrapolating to the unmeasured 99%?
+- **Circularity.** UniProt is genome-derived and PREGO's flat channels are
+  genome-derived. The document says the assay standard (wet-lab, disjoint)
+  corroborates the flat-over-continuous ordering. Check that reasoning: are
+  BacDive assays genuinely disjoint from PREGO's genome channels, given both
+  ultimately concern cultured isolates?
+
+### 3. The recommendations
+
+- Does recommendation 4 follow from the evidence, or does it over-read it?
+  Dropping 23.3M edges is irreversible in effect; is "no positive evidence
+  under standards covering 0.1-41.5% of the edge type" sufficient grounds?
+- Is the flat/continuous channel split the right instrument, given the flat
+  channels' apparent reliability comes from a constant author-assigned score
+  and not from any measurement of the edges themselves?
+- Is claim 5 (the size arithmetic) correct? Verify against the actual channel
+  composition rather than accepting the stated ~52%.
+- Does the recommendation to threshold location_of edges at 3.0 account for the
+  fact that this keeps only 17% of them, and that unfiltered they are already
+  7.9x enriched? Is the marginal precision gain worth an 83% recall loss for KG
+  construction, where recall is often the point?
+- What is the strongest argument AGAINST each recommendation? State it even if
+  you ultimately agree.
+
+### 4. Reproducibility
+
+- Do the scripts actually produce the documented numbers? Run the fast ones and
+  compare. Report any discrepancy precisely.
+- Are the scripts' inputs pinned or snapshot-dependent in ways the document does
+  not disclose? PREGO archives are recomputed periodically by
+  `lab42open-team/prego_daemons`; `data/merged/20250222_function/` is a February
+  2025 build.
+- Could someone re-derive the verdict from what is committed, or is essential
+  state only in /tmp pickles?
+
+### 5. Code correctness (lower priority, but do not skip)
+
+Ordinary defects in `quality.py`, `calibration.py`, and the scripts: boundary
+conditions, silent failure paths, float-equality keying of scores, memory
+behaviour on realistic inputs.
+
+## Output format
+
+For every finding:
+
+```
+### {severity} · {dimension} · {short-title}
+
+- **File / section:** `<path>` or the document heading
+- **Category:** {inference | measurement | recommendation | reproducibility | code}
+- **Severity:** {CRITICAL | HIGH | MEDIUM | LOW}
+- **Confidence:** {HIGH | MEDIUM | LOW}
+- **Claim affected:** which numbered claim above, if any
+- **Why it does not hold / what is missing:** 2-4 sentences
+- **What would settle it:** the specific test, statistic, or data
+```
+
+Then a summary table by (dimension, severity), and answer these five directly:
+
+1. Is the headline verdict — location_of yes, capable_of no — **established**,
+   **plausible but unproven**, or **not supported**? Justify in three sentences.
+2. Which single number in the document is least trustworthy, and why?
+3. Should the continuous GO channel be dropped on this evidence? Yes/no/not yet,
+   with the condition that would change your answer.
+4. Is 3.0 the right threshold for location_of edges, given the recall cost?
+5. What is the cheapest measurement that would most reduce uncertainty about the
+   verdict?
+
+## Explicit non-goals
+
+- Do not propose renames, formatting, or docstring additions unless they fix an
+  overclaim.
+- Do not rewrite files; sketches only.
+- Do not re-derive the UniProt gold standard (25 min) unless a specific claim
+  demands it.
+- Do not comment on which GO or ENVO terms are biologically "right" — only on
+  how the analysis handles them.
+- Do not treat the author's own admissions of error (six are listed in the
+  document) as findings; assess whether the *corrections* are complete.
+
+## Ground rules
+
+- Repo-relative paths. Run date 2026-08-06.
+- Prefer high-confidence findings; mark speculative ones LOW and say what would
+  raise them.
+- If a systemic problem recurs, describe it once with a representative site.
+- `poetry run tox` is green (900 passed). Say so if a finding would break it.
+- The document explicitly invites challenge to its recommendations; being
+  contrarian where justified is the point of this review.
+```

--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -9,13 +9,16 @@ Companion to [`PREGO_INGEST_PLAN.md`](PREGO_INGEST_PLAN.md), which covers acquis
 
 ## Verdict
 
->  **Status after external review: PLAUSIBLE BUT UNPROVEN.** The predicate-level
->  split below is confounded with benchmark design — each predicate was measured
->  against a different gold standard, with coverage ranging 0.1% to 41.5%. Read
->  the [Confounds](#confounds-that-limit-the-verdict) section before citing any
->  of it.
+>  **Status: NOT ESTABLISHED.** Under matched taxa *and* matched label policy the
+>  predicate contrast largely dissolves — interaction +0.281, clustered 95% CI
+>  [−0.237, +0.624], 82.5% one-sided. Both predicates show weak positive
+>  discrimination (1.40 vs 1.12) and the difference between them is not
+>  distinguishable from zero. See
+>  [Matched-taxa interaction test](#matched-taxa-interaction-test). The
+>  per-benchmark contrast reported below was driven substantially by differences
+>  in gold standard and label policy, not by the predicate.
 
-**Working hypothesis: the score discriminates on `location_of` edges and not on `capable_of` edges.**
+**Original hypothesis (now unsupported): the score discriminates on `location_of` edges and not on `capable_of` edges.**
 
 | predicate | edge types | count | score works? | within-term ratio (tie-safe) |
 |---|---|---:|---|---|
@@ -43,25 +46,41 @@ clustered bootstrap over taxa and terms.
 **Interaction (location − capable): +0.479, two-way clustered 95% CI [−0.015, +1.128].**
 96.8% of resamples put `location_of` above `capable_of`.
 
-**Reading.** The point estimate is exactly what the verdict predicts — the score
-discriminates for location (1.50) and essentially not at all for function (1.02) — and
-it survives on matched taxa with term and degree controls, which is much stronger than
-the original per-benchmark comparison. The location figure also reproduces the
-independent tie-safe ENVO estimate (1.49). But the 95% interval **just barely includes
-zero**. One-sided the evidence is fairly strong (~0.03); two-sided at 95% it does not
-clear the bar.
+That still left one confound: the **label policies differ.** Location gold is
+positive-only — absence means unknown but is necessarily counted as a miss — while
+function gold carries explicit negatives and excludes unlabelled pairs. Matching taxa
+does not match that.
 
-**One confound survives even here:** the label policies still differ. Location gold is
-positive-only (absence = unknown) while function gold carries real negatives. Matching
-the taxa does not match that. Closing it needs either negatives for location or a
-positive-only recasting of the assay labels.
+#### Matching the label policy too (`--positive-only`)
 
-Verdict after this test: **strengthened, still not established at 95%.**
+Recasting function labels as positive-only, so both predicates use identical semantics:
+
+| predicate | terms | in-stratum n | high/low ratio |
+|---|---:|---:|---:|
+| `location_of` | 65 | 8,805 | **1.396** |
+| `capable_of` | 31 | 28,892 | **1.115** |
+
+**Interaction +0.281, two-way clustered 95% CI [−0.237, +0.624].** 82.5% of resamples
+positive — down from 96.8%.
+
+**Reading — this is the decisive run.** Once taxa *and* label policy are matched, the
+contrast largely dissolves. The interaction nearly halves, the interval widens well
+across zero, and one-sided support falls to ~0.18 (not significant). Note especially
+that `capable_of` rises from 1.023 to **1.115** under matched semantics: the "no
+discrimination at all for function" result was **partly an artifact of the label
+policy**, not a property of the predicate.
+
+What survives: **both** predicates show weak positive discrimination (1.40 and 1.12),
+and the difference between them is not distinguishable from zero on matched data.
+
+Verdict after this test: **not established.** The dramatic per-benchmark contrast
+reported below was driven substantially by gold-standard and label-policy differences
+rather than by the predicate.
 
 <a name="confounds-that-limit-the-verdict"></a>
 ### Confounds that limit the verdict
 
-1. **Predicate was inseparable from benchmark.** Partly addressed by the matched-taxa test above, which uses one resource and one taxon set for both predicates. What remains unmatched is the **label policy**: location gold is positive-only, function gold has negatives.
+1. **Predicate was inseparable from benchmark and label policy.** Addressed by the matched-taxa test above, which controls both. The contrast did not survive: interaction +0.281, CI [−0.237, +0.624].
 2. **BTO is not an independent replication of ENVO.** Both project the *same* BacDive isolation source. With tie-safe strata it is 6 of 8 terms (n=843 in-stratum), an unclustered one-sided sign test around p≈0.1 — a sensitivity check, not confirmation.
 3. **Within-term stratification controls term identity, not taxon degree.** In the BTO split the high-score half has mean BacDive gold degree 4.85 vs 3.56 and mean PREGO degree 23.10 vs 18.73; ENVO likewise 91.64 vs 70.67. Well-covered taxa remain an open path to apparent discrimination.
 4. **No clustered uncertainty anywhere.** Edges reuse taxa, terms and resources; all intervals quoted are iid and therefore optimistic.

--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -1,0 +1,195 @@
+# PREGO score validation — findings
+
+**Date:** 2026-08-06 · **Branch:** `feat/prego-confidence-calibration` · **PR:** #697
+**Issues:** #693 (merge RAM), #694 (`prego_channel`), #695 (edge metadata), #696 (calibration design), #698 (statistical review), #702 (validation coverage)
+
+Companion to [`PREGO_INGEST_PLAN.md`](PREGO_INGEST_PLAN.md), which covers acquisition and schema. This document covers **whether PREGO's `prego_score` means anything**, measured against four independent gold standards.
+
+---
+
+## Verdict
+
+**The score discriminates on `location_of` edges and not on `capable_of` edges.**
+
+| predicate | edge types | count | score works? | within-term ratio |
+|---|---|---:|---|---|
+| `biolink:location_of` | `ENVO→taxon`, `BTO→taxon` | 452,051 | **yes** | 1.57x (18/19 terms), 1.94x (7/9 terms) |
+| `biolink:capable_of` | `taxon→GO` | 44,258,939 | **no** | 0.84x — wrong direction, or flat |
+| `biolink:associated_with` | `taxon→MONDO` | 5,171 | untested | no in-graph reference exists |
+
+**Mechanism.** PREGO's environmental-samples score counts taxon–sample co-occurrence. That is *direct* evidence for "this organism is found in location X" and only *indirect* evidence for "this organism can perform function Y". The split is what the score is measuring, not a defect.
+
+---
+
+## Why this was needed
+
+`prego_score` is not one scale. Per PREGO's authors (Zafeiropoulos et al. 2022, §2.3, verified against PMC8879827):
+
+> "All associations extracted from these resources were assigned **arbitrarily a confidence level of four out of five**."
+
+Appendix C.1: *"The Genome Annotation and Isolates channel has **fixed values of scores** depending on the resource."* BioProject/PMID rows get 3/5. **PREGO computes no cross-channel combined score** — the shared (0,5] range is a display convention.
+
+Measured channel composition of emitted edges:
+
+| channel | share | scores |
+|---|---:|---|
+| `<N of M samples>` (Environmental Samples) | 53.00% | continuous, mean 1.96 |
+| Isolates | 28.66% | flat, all 4.0 |
+| Genome annotation | 9.17% | flat, all 4.0 |
+| Metagenome-Assembled Genome | 7.27% | flat, ~all 4.0 |
+| Single Amplified Genome | 1.79% | flat |
+| `PMID:*` | 0.05% | flat, all 3.0 |
+
+Range is 0 to **4.00735** (mean 2.92) — the shipped data exceeds the paper's documented cap of 4.
+
+---
+
+## Gold standards built
+
+All four are **in-graph**; none required external data.
+
+| # | standard | how built | scale | provenance |
+|---|---|---|---|---|
+| 1 | metatraits + metatraits_gtdb + madin_etal | direct `NCBITaxon→GO` edges | 333,407 pairs, 78 GO terms | trait curation |
+| 2 | UniProt proteomes | `protein -derives_from-> NCBITaxon` × `protein -participates_in\|located_in-> GO` from `data/merged/20250222_function/` | 14,411,869 pairs, 4,209 GO terms | genome annotation |
+| 3 | **BacDive assays** | `strain -METPO:2000302\|2000303-> assay -has_output-> GO`, strain lifted to taxon | 36,844 pos / 67,571 neg, 36 GO terms | **wet-lab phenotype, with negatives** |
+| 4 | BacDive isolation | `ENVO -location_of-> strain` and `UBERON\|CL -location_of-> strain` (BTO via `uberon_nodes.xref`) | 13,212 ENVO + 6,288 BTO pairs | isolation records |
+
+Standard 3 is the only one with **labelled negatives**, so it supports direct precision measurement with no null model.
+
+---
+
+## Results
+
+### `NCBITaxon -capable_of-> GO` — 44,258,939 edges (98.98%)
+
+| gold standard | coverage | continuous | flat | trend with score |
+|---|---|---|---|---|
+| metatraits | 78 GO, 1.0% | 1.45x | 1.00x | **falls** 1.61→1.59→1.56; 30 of 47 terms wrong way |
+| UniProt | 4,209 GO, **41.5%** | 1.07x | 2.19x | rises weakly 0.94→0.96→1.04→1.19 |
+| BacDive assays | 36 GO, 0.1% | precision **0.3215**, lift **0.91** | **0.4897**, lift **1.39** | **flat** 0.303/0.318/0.307/0.350/0.331 |
+
+Assay base rate: **0.3529** (measured).
+
+Two readings:
+
+- **The score does not work here.** No standard produces a usable monotone trend, and the assay test — the only one needing no null model — shows none.
+- **The flat/genome channels are enriched** under both non-trait standards (2.19x, 1.39x), including the provenance-disjoint one. Their reliability comes from **provenance, not score** (they carry a constant).
+
+The three standards disagree on the *continuous channel* (1.45x / 1.07x / 0.91x) in a pattern matching each standard's provenance. That disagreement is itself a finding: **no single gold standard is neutral here.**
+
+### `ENVO -location_of-> NCBITaxon` — 416,229 edges (0.93%)
+
+| window | score range | n | hit rate | fold |
+|---|---|---:|---:|---:|
+| 1 | 0.001–0.327 | 2,204 | 0.122 | 3.58x |
+| 2 | 0.327–0.862 | 2,202 | 0.103 | 3.01x |
+| 3 | 0.862–2.102 | 2,203 | 0.111 | 3.26x |
+| 4 | 2.103–3.951 | 2,202 | 0.429 | **12.58x** |
+| 5 | 3.951–4.007 | 2,197 | 0.581 | **17.03x** |
+
+**7.89x overall.** Stratified within ENVO term: **18 of 19** terms with ≥100 comparable edges have the higher-score half agreeing more; pooled 0.211 → 0.331 (**1.57x**).
+
+### `BTO -location_of-> NCBITaxon` — 35,822 edges (0.08%)
+
+| window | score range | n | hit rate | fold |
+|---|---|---:|---:|---:|
+| 1 | 0.010–0.489 | 222 | 0.099 | 1.66x |
+| 2 | 0.490–1.032 | 221 | 0.086 | 1.44x |
+| 3 | 1.036–3.000 | 427 | 0.351 | **5.89x** |
+| 4 | 4.000 (tied) | 232 | 0.272 | 4.55x |
+
+**3.86x overall.** Stratified: **7 of 9** BTO terms (≥30 edges) agree; pooled **1.94x**.
+
+### `NCBITaxon -associated_with-> MONDO` — 5,171 edges (0.01%)
+
+Untested. PREGO is the only source of MONDO edges in the graph. Emitting BacDive pathogenicity as `taxon→MONDO` would unlock it and has independent value.
+
+---
+
+## Threshold selection for `location_of` edges
+
+Measured on ENVO (the larger of the two):
+
+Baseline 0.03411, over the entity space shared between PREGO and the gold standard (the TISSUES protocol).
+
+| ≥ T | precision | fold | ENVO kept |
+|---:|---:|---:|---:|
+| 0.00 | 0.269 | 7.89x | 416,229 (100%) |
+| 0.50 | 0.324 | 9.51x | 301,988 (72.6%) |
+| 1.00 | 0.395 | 11.59x | 217,954 (52.4%) |
+| 1.50 | 0.450 | 13.19x | 153,873 (37.0%) |
+| 2.00 | 0.495 | 14.51x | 109,921 (26.4%) |
+| 2.50 | 0.583 | 17.10x | 81,827 (19.7%) |
+| **3.00** | **0.641** | **18.79x** | **70,558 (17.0%)** |
+| 3.50 | 0.570 | 16.71x | 54,615 (13.1%) |
+| 4.00 | 0.585 | 17.14x | 52,379 (12.6%) |
+
+**Precision peaks at 3.0 and then falls.** Thresholds above 3.0 lose recall *and* precision, so they are strictly dominated — the upper bound is not a judgement call.
+
+Below 3.0 the choice is precision vs recall. Two defensible settings: **3.0** (precision 0.64, keeps 17%) or **1.0** (precision 0.40, keeps 52%, still a 47% precision gain over unfiltered).
+
+Note the floor: **unfiltered ENVO edges are already 7.9x enriched.** The threshold improves a signal that is present without it.
+
+---
+
+## Recommendations (Claude's, for review)
+
+| edge type | count | recommendation | basis |
+|---|---:|---|---|
+| `ENVO -location_of->` | 416,229 | keep; threshold at 3.0 (or 1.0) | score validated, 18.8x at optimum |
+| `BTO -location_of->` | 35,822 | keep; same threshold | same predicate, 1.94x within-term |
+| `taxon -capable_of-> GO`, flat channels | ~20.9M | keep, **no** threshold | provenance: 1.39x disjoint, 2.19x UniProt |
+| `taxon -capable_of-> GO`, continuous | ~23.3M | **drop** | 0.91x — below chance under the only test with negatives |
+| `taxon -associated_with-> MONDO` | 5,171 | keep, flag unvalidated | no reference exists |
+
+Supporting arguments:
+
+1. **Filter GO edges by channel, not by score.** The evidence speaks to provenance, not to the score. A channel filter is expressible in `merge.yaml` via `edge_filters` today (exact-string matching), so it needs no numeric comparison.
+2. **Per-predicate thresholds, not one global knob.** A single `min_confidence` is a validated quality filter on `location_of` and an arbitrary cut on `capable_of` simultaneously.
+3. **Dropping the continuous GO block removes ~52% of PREGO** — the part with no supporting evidence under any standard — taking `edges.tsv` from 7.4 GB to roughly 3.5 GB and largely dissolving the 48 GB merge problem in #693 as a side effect, without inventing a confidence claim to justify it.
+
+---
+
+## Caveats
+
+- **Coverage is thin everywhere except UniProt.** Comparable fractions: 41.5% (UniProt/GO), 2.64% (ENVO), 3.08% (BTO), 0.1% (assays/GO).
+- **These tests can only reach where PREGO overlaps existing sources** — precisely where it is least additive. PREGO's stated value is ~2M taxa at species-and-above rank vs BacDive's ~250K strains. That unique contribution is **unmeasurable by construction**. "Unreliable" here means *no positive evidence*, not *shown wrong*.
+- **The fold-enrichment baseline is a uniform subject×object null** (#698 finding 1). It controls for neither taxon annotation depth nor term ubiquity. The **within-term stratified ratios** are what address the degree confound; the raw fold numbers do not.
+- **No clustered uncertainty** (#698 finding 3). Edges reuse taxa, terms and resources, so intervals are wider than iid. Quoted CIs are iid and therefore optimistic.
+- **Strain-level negatives do not cleanly refute species-level claims.** 12,916 (taxon, GO) pairs had one strain positive and another negative; those are excluded, but the granularity mismatch inflates apparent error in the assay test.
+- **Positive-only standards** (1, 2, 4) cannot measure false positives; only the assay standard can.
+- **Time sensitivity.** PREGO archives are recomputed periodically by `lab42open-team/prego_daemons`; `data/merged/20250222_function/` is a February 2025 build.
+
+---
+
+## Claims corrected during this work
+
+Recorded because each was stated confidently before being overturned:
+
+1. **"The score is anti-correlated with quality."** Held only against the trait-derived standard (78 GO terms, 1% coverage). Against UniProt (41.5%) it rises. Withdrawn.
+2. **"0.24% of PREGO's GO space."** Wrong — used PREGO's 32,440 distinct *objects*, which include ENVO and MONDO. The correct figure against 5,230 taxon→GO terms is 1.5%.
+3. **"BTO is untestable."** Wrong — 1,645 anatomy terms in `uberon_nodes.tsv` already carry BTO xrefs, the same reverse-lookup the transform uses for DOID→MONDO. No new mapping was needed.
+4. **A tie-splitting bug in the analysis** sorted `(score, is_hit)` tuples, so the sort tiebreak pushed non-hits below the 4.0 block and hits above it, fabricating a 0.44x window adjacent to a 1.95x one. Fixed in `enrichment_by_window`; two regression tests.
+5. **"The calibration and emit passes can never disagree."** False — the emit pass applies further checks. The 1,200-row delta reported as reassuring was a symptom of this (#699).
+6. **Inconsistent fold baselines between two of my own ENVO runs.** The window table used the shared entity space (baseline 0.03411) while the threshold table used the full gold space (0.02421), so the latter's fold column was inflated — 11.11x rather than 7.89x at T=0. Caught by smoke-testing the extracted scripts against the published figures. Both now use the shared space; precision and the location of the optimum were unaffected, only the multipliers.
+
+---
+
+## Reproducing
+
+Analysis scripts: [`scripts/prego_validation/`](../scripts/prego_validation/).
+
+```bash
+# 1. gold standards
+poetry run python scripts/prego_validation/build_uniprot_gold.py     # ~25 min, reads 28.6 GB
+poetry run python scripts/prego_validation/build_assay_gold.py       # seconds
+
+# 2. tests
+poetry run python scripts/prego_validation/fold_enrichment_go.py     # vs UniProt
+poetry run python scripts/prego_validation/precision_assay_go.py     # vs assays (labelled +/-)
+poetry run python scripts/prego_validation/fold_enrichment_envo.py   # vs BacDive isolation
+poetry run python scripts/prego_validation/fold_enrichment_bto.py    # vs BacDive host anatomy
+```
+
+Reusable API: `kg_microbe/transform_utils/prego/quality.py` — `GoldStandard`, `LabelledEvidence`, `enrichment_by_window`, `precision_by_window`, `lift`, `is_monotone_increasing`. Tests in `tests/test_prego_quality.py`.

--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -9,15 +9,29 @@ Companion to [`PREGO_INGEST_PLAN.md`](PREGO_INGEST_PLAN.md), which covers acquis
 
 ## Verdict
 
-**The score discriminates on `location_of` edges and not on `capable_of` edges.**
+>  **Status after external review: PLAUSIBLE BUT UNPROVEN.** The predicate-level
+>  split below is confounded with benchmark design — each predicate was measured
+>  against a different gold standard, with coverage ranging 0.1% to 41.5%. Read
+>  the [Confounds](#confounds-that-limit-the-verdict) section before citing any
+>  of it.
 
-| predicate | edge types | count | score works? | within-term ratio |
+**Working hypothesis: the score discriminates on `location_of` edges and not on `capable_of` edges.**
+
+| predicate | edge types | count | score works? | within-term ratio (tie-safe) |
 |---|---|---:|---|---|
-| `biolink:location_of` | `ENVO→taxon`, `BTO→taxon` | 452,051 | **yes** | 1.57x (18/19 terms), 1.94x (7/9 terms) |
-| `biolink:capable_of` | `taxon→GO` | 44,258,939 | **no** | 0.84x — wrong direction, or flat |
+| `biolink:location_of` | `ENVO→taxon`, `BTO→taxon` | 452,051 | apparently yes | 1.49x (18/20 terms), 1.69x (6/8 terms) |
+| `biolink:capable_of` | `taxon→GO` | 44,258,939 | no | 0.84x — wrong direction, or flat |
 | `biolink:associated_with` | `taxon→MONDO` | 5,171 | untested | no in-graph reference exists |
 
-**Mechanism.** PREGO's environmental-samples score counts taxon–sample co-occurrence. That is *direct* evidence for "this organism is found in location X" and only *indirect* evidence for "this organism can perform function Y". The split is what the score is measuring, not a defect.
+**Candidate mechanism (post-hoc, untested).** PREGO's environmental-samples score counts taxon–sample co-occurrence, which is *direct* evidence for "found in location X" and only *indirect* evidence for "can perform function Y". This fits the observations but no analysis tests it or excludes alternatives such as taxon ascertainment or benchmark coverage. It should not be stated as established.
+
+<a name="confounds-that-limit-the-verdict"></a>
+### Confounds that limit the verdict
+
+1. **Predicate is inseparable from benchmark.** `location_of` was measured only against BacDive isolation records (positive-only); `capable_of` only against trait, genome, and assay standards. Nothing measures both predicates under one label policy.
+2. **BTO is not an independent replication of ENVO.** Both project the *same* BacDive isolation source. With tie-safe strata it is 6 of 8 terms (n=843 in-stratum), an unclustered one-sided sign test around p≈0.1 — a sensitivity check, not confirmation.
+3. **Within-term stratification controls term identity, not taxon degree.** In the BTO split the high-score half has mean BacDive gold degree 4.85 vs 3.56 and mean PREGO degree 23.10 vs 18.73; ENVO likewise 91.64 vs 70.67. Well-covered taxa remain an open path to apparent discrimination.
+4. **No clustered uncertainty anywhere.** Edges reuse taxa, terms and resources; all intervals quoted are iid and therefore optimistic.
 
 ---
 
@@ -55,7 +69,9 @@ All four are **in-graph**; none required external data.
 | 3 | **BacDive assays** | `strain -METPO:2000302\|2000303-> assay -has_output-> GO`, strain lifted to taxon | 36,844 pos / 67,571 neg, 36 GO terms | **wet-lab phenotype, with negatives** |
 | 4 | BacDive isolation | `ENVO -location_of-> strain` and `UBERON\|CL -location_of-> strain` (BTO via `uberon_nodes.xref`) | 13,212 ENVO + 6,288 BTO pairs | isolation records |
 
-Standard 3 is the only one with **labelled negatives**, so it supports direct precision measurement with no null model.
+Standard 3 is the only one with **labelled negatives**, so it supports precision measurement with no null model.
+
+**But its negatives are strain-level and the claim is taxon-level.** "Taxon capable_of GO" is existential — some strain having the capability makes it true — so strains testing negative do not refute it. Excluding the 12,916 mixed pairs does not repair that mismatch. The 0.3215 figure is agreement with strain-lifted labels, not a taxon-level false-positive rate.
 
 ---
 
@@ -88,7 +104,7 @@ The three standards disagree on the *continuous channel* (1.45x / 1.07x / 0.91x)
 | 4 | 2.103–3.951 | 2,202 | 0.429 | **12.58x** |
 | 5 | 3.951–4.007 | 2,197 | 0.581 | **17.03x** |
 
-**7.89x overall.** Stratified within ENVO term: **18 of 19** terms with ≥100 comparable edges have the higher-score half agreeing more; pooled 0.211 → 0.331 (**1.57x**).
+**7.89x overall.** Stratified within ENVO term (tie-safe boundaries): **18 of 20** terms with ≥100 comparable edges have the higher-score half agreeing more; pooled 0.219 → 0.325 (**1.49x**).
 
 ### `BTO -location_of-> NCBITaxon` — 35,822 edges (0.08%)
 
@@ -99,7 +115,7 @@ The three standards disagree on the *continuous channel* (1.45x / 1.07x / 0.91x)
 | 3 | 1.036–3.000 | 427 | 0.351 | **5.89x** |
 | 4 | 4.000 (tied) | 232 | 0.272 | 4.55x |
 
-**3.86x overall.** Stratified: **7 of 9** BTO terms (≥30 edges) agree; pooled **1.94x**.
+**3.86x overall.** Stratified (tie-safe): **6 of 8** BTO terms (≥30 edges) agree; pooled 0.158 → 0.266 (**1.69x**). The index-median split originally published gave 7 of 9 and 1.94x — the result is tie-sensitive.
 
 ### `NCBITaxon -associated_with-> MONDO` — 5,171 edges (0.01%)
 
@@ -109,11 +125,13 @@ Untested. PREGO is the only source of MONDO edges in the graph. Emitting BacDive
 
 ## Threshold selection for `location_of` edges
 
-Measured on ENVO (the larger of the two):
+Measured on ENVO (the larger of the two).
+
+**Terminology.** BacDive isolation is **positive-only**: an edge absent from it is *unknown*, not false. The column below is therefore an **overlap rate** among comparable edges, not precision. Only the assay standard supports true precision.
 
 Baseline 0.03411, over the entity space shared between PREGO and the gold standard (the TISSUES protocol).
 
-| ≥ T | precision | fold | ENVO kept |
+| ≥ T | overlap rate | fold | ENVO kept |
 |---:|---:|---:|---:|
 | 0.00 | 0.269 | 7.89x | 416,229 (100%) |
 | 0.50 | 0.324 | 9.51x | 301,988 (72.6%) |
@@ -125,9 +143,9 @@ Baseline 0.03411, over the entity space shared between PREGO and the gold standa
 | 3.50 | 0.570 | 16.71x | 54,615 (13.1%) |
 | 4.00 | 0.585 | 17.14x | 52,379 (12.6%) |
 
-**Precision peaks at 3.0 and then falls.** Thresholds above 3.0 lose recall *and* precision, so they are strictly dominated — the upper bound is not a judgement call.
+**Overlap peaks at 3.0 and then falls** — on the same data used to select it, with no held-out validation. Calling 3.0 "strictly dominated above" is only true of observed overlap on this selection set.
 
-Below 3.0 the choice is precision vs recall. Two defensible settings: **3.0** (precision 0.64, keeps 17%) or **1.0** (precision 0.40, keeps 52%, still a 47% precision gain over unfiltered).
+The 83% figure is **retention** loss, not measured recall loss — a positive-only standard cannot enumerate all true edges. Choosing between 3.0 (keeps 17%) and 1.0 (keeps 52%) requires a stated precision/utility target that does not yet exist, and for a recall-oriented KG **unfiltered may well be preferable**. No threshold curve was computed for BTO, so transferring 3.0 to it is unsupported.
 
 Note the floor: **unfiltered ENVO edges are already 7.9x enriched.** The threshold improves a signal that is present without it.
 
@@ -137,17 +155,17 @@ Note the floor: **unfiltered ENVO edges are already 7.9x enriched.** The thresho
 
 | edge type | count | recommendation | basis |
 |---|---:|---|---|
-| `ENVO -location_of->` | 416,229 | keep; threshold at 3.0 (or 1.0) | score validated, 18.8x at optimum |
-| `BTO -location_of->` | 35,822 | keep; same threshold | same predicate, 1.94x within-term |
+| `ENVO -location_of->` | 416,229 | keep; threshold **only against a stated utility target** | overlap rises with score; 3.0 is the in-sample optimum, not a validated operating point |
+| `BTO -location_of->` | 35,822 | keep; **no** threshold transfer | 1.69x tie-safe, 6/8 terms, same BacDive source as ENVO — not independent |
 | `taxon -capable_of-> GO`, flat channels | ~20.9M | keep, **no** threshold | provenance: 1.39x disjoint, 2.19x UniProt |
-| `taxon -capable_of-> GO`, continuous | ~23.3M | **drop** | 0.91x — below chance under the only test with negatives |
+| `taxon -capable_of-> GO`, continuous | 23,289,791 | **not yet — do not drop** | no reliable score ranking, but that is not evidence of no value; the standards reach 0.1–41.5% and PREGO-only content is unmeasurable by construction |
 | `taxon -associated_with-> MONDO` | 5,171 | keep, flag unvalidated | no reference exists |
 
 Supporting arguments:
 
 1. **Filter GO edges by channel, not by score.** The evidence speaks to provenance, not to the score. A channel filter is expressible in `merge.yaml` via `edge_filters` today (exact-string matching), so it needs no numeric comparison.
 2. **Per-predicate thresholds, not one global knob.** A single `min_confidence` is a validated quality filter on `location_of` and an arbitrary cut on `capable_of` simultaneously.
-3. **Dropping the continuous GO block removes ~52% of PREGO** — the part with no supporting evidence under any standard — taking `edges.tsv` from 7.4 GB to roughly 3.5 GB and largely dissolving the 48 GB merge problem in #693 as a side effect, without inventing a confidence claim to justify it.
+3. **Dropping the continuous GO block removes 23,289,791 rows — 52.08% of rows but only 33.33% of bytes**, since those rows are shorter. `edges.tsv` goes from 7.38 GiB to **4.92 GiB**, not the ~3.5 GB stated earlier. **No merge benchmark was run**, so the claim that this "largely dissolves" the 48 GB problem in #693 is unverified.
 
 ---
 
@@ -172,7 +190,12 @@ Recorded because each was stated confidently before being overturned:
 3. **"BTO is untestable."** Wrong — 1,645 anatomy terms in `uberon_nodes.tsv` already carry BTO xrefs, the same reverse-lookup the transform uses for DOID→MONDO. No new mapping was needed.
 4. **A tie-splitting bug in the analysis** sorted `(score, is_hit)` tuples, so the sort tiebreak pushed non-hits below the 4.0 block and hits above it, fabricating a 0.44x window adjacent to a 1.95x one. Fixed in `enrichment_by_window`; two regression tests.
 5. **"The calibration and emit passes can never disagree."** False — the emit pass applies further checks. The 1,200-row delta reported as reassuring was a symptom of this (#699).
-6. **Inconsistent fold baselines between two of my own ENVO runs.** The window table used the shared entity space (baseline 0.03411) while the threshold table used the full gold space (0.02421), so the latter's fold column was inflated — 11.11x rather than 7.89x at T=0. Caught by smoke-testing the extracted scripts against the published figures. Both now use the shared space; precision and the location of the optimum were unaffected, only the multipliers.
+6. **The within-term stratification split ties.** It used an index median, so sort order rather than the score decided which tied rows fell in which half — the same defect fixed in `enrichment_by_window` and then reintroduced in the very check meant to guard against confounding. Tie-safe boundaries move ENVO from 18/19 at 1.57x to 18/20 at 1.49x, and BTO from 7/9 at 1.94x to **6/8 at 1.69x**. Found by external review.
+7. **"Precision" applied to positive-only standards.** ENVO/BTO agreement rates are *overlap* rates; absence from BacDive means unknown, not false. Renamed throughout.
+8. **"BTO independently replicates ENVO."** Both project the same BacDive isolation source, so it is a sensitivity check rather than independent replication.
+9. **Post-filter size "roughly 3.5 GB".** Wrong: the dropped rows are 52.08% of rows but 33.33% of bytes, leaving **4.92 GiB**. And no merge benchmark was run, so "largely dissolves the 48 GB problem" was unsupported.
+10. **Verdict stated as established.** Downgraded to plausible-but-unproven: predicate is confounded with benchmark design.
+11. **Inconsistent fold baselines between two of my own ENVO runs.** The window table used the shared entity space (baseline 0.03411) while the threshold table used the full gold space (0.02421), so the latter's fold column was inflated — 11.11x rather than 7.89x at T=0. Caught by smoke-testing the extracted scripts against the published figures. Both now use the shared space; precision and the location of the optimum were unaffected, only the multipliers.
 
 ---
 

--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -25,10 +25,43 @@ Companion to [`PREGO_INGEST_PLAN.md`](PREGO_INGEST_PLAN.md), which covers acquis
 
 **Candidate mechanism (post-hoc, untested).** PREGO's environmental-samples score counts taxon–sample co-occurrence, which is *direct* evidence for "found in location X" and only *indirect* evidence for "can perform function Y". This fits the observations but no analysis tests it or excludes alternatives such as taxon ascertainment or benchmark coverage. It should not be stated as established.
 
+<a name="matched-taxa-interaction-test"></a>
+### Matched-taxa interaction test — the confound-removing analysis
+
+External review named this the cheapest way to settle the verdict, so it was run
+([`predicate_interaction.py`](../scripts/prego_validation/predicate_interaction.py)).
+It removes the benchmark confound rather than adjusting for it: **only the 4,527 taxa
+carrying BOTH a BacDive isolation record and a BacDive assay result**, with within-term
+comparison, taxon-degree decile stratification, tie-safe boundaries, and a two-way
+clustered bootstrap over taxa and terms.
+
+| predicate | terms | in-stratum n | high/low ratio |
+|---|---:|---:|---:|
+| `location_of` | 66 | 9,682 | **1.502** |
+| `capable_of` | 31 | 12,325 | **1.023** |
+
+**Interaction (location − capable): +0.479, two-way clustered 95% CI [−0.015, +1.128].**
+96.8% of resamples put `location_of` above `capable_of`.
+
+**Reading.** The point estimate is exactly what the verdict predicts — the score
+discriminates for location (1.50) and essentially not at all for function (1.02) — and
+it survives on matched taxa with term and degree controls, which is much stronger than
+the original per-benchmark comparison. The location figure also reproduces the
+independent tie-safe ENVO estimate (1.49). But the 95% interval **just barely includes
+zero**. One-sided the evidence is fairly strong (~0.03); two-sided at 95% it does not
+clear the bar.
+
+**One confound survives even here:** the label policies still differ. Location gold is
+positive-only (absence = unknown) while function gold carries real negatives. Matching
+the taxa does not match that. Closing it needs either negatives for location or a
+positive-only recasting of the assay labels.
+
+Verdict after this test: **strengthened, still not established at 95%.**
+
 <a name="confounds-that-limit-the-verdict"></a>
 ### Confounds that limit the verdict
 
-1. **Predicate is inseparable from benchmark.** `location_of` was measured only against BacDive isolation records (positive-only); `capable_of` only against trait, genome, and assay standards. Nothing measures both predicates under one label policy.
+1. **Predicate was inseparable from benchmark.** Partly addressed by the matched-taxa test above, which uses one resource and one taxon set for both predicates. What remains unmatched is the **label policy**: location gold is positive-only, function gold has negatives.
 2. **BTO is not an independent replication of ENVO.** Both project the *same* BacDive isolation source. With tie-safe strata it is 6 of 8 terms (n=843 in-stratum), an unclustered one-sided sign test around p≈0.1 — a sensitivity check, not confirmation.
 3. **Within-term stratification controls term identity, not taxon degree.** In the BTO split the high-score half has mean BacDive gold degree 4.85 vs 3.56 and mean PREGO degree 23.10 vs 18.73; ENVO likewise 91.64 vs 70.67. Well-covered taxa remain an open path to apparent discrimination.
 4. **No clustered uncertainty anywhere.** Edges reuse taxa, terms and resources; all intervals quoted are iid and therefore optimistic.

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -250,6 +250,11 @@ PREGO_SCORE_COLUMN = "prego_score"
 PREGO_CHANNEL_COLUMN = "prego_channel"
 PREGO_DIRECT_FLAG_COLUMN = "prego_direct_flag"
 PREGO_EVIDENCE_URL_COLUMN = "prego_evidence_url"
+# Originating resource (MGnify / MG-RAST metagenome study / JGI IMG / ...).
+# Required for confidence calibration: the Environmental Samples channel
+# aggregates resources whose score marginals differ, so a single shared
+# cutoff would conflate them.
+PREGO_SOURCE_COLUMN = "prego_source"
 
 MEDIADIVE_MEDIUM_TYPE_COMPLEX_ID = MEDIADIVE_MEDIUM_TYPE_PREFIX + "complex"
 MEDIADIVE_MEDIUM_TYPE_COMPLEX_LABEL = "Complex Medium"

--- a/kg_microbe/transform_utils/prego/calibration.py
+++ b/kg_microbe/transform_utils/prego/calibration.py
@@ -1,0 +1,318 @@
+"""
+Per-resource confidence calibration for PREGO association scores.
+
+``prego_score`` is not one scale. PREGO's authors assign the genome-derived
+channels (Isolates, Genome annotation, MAG, SAG) a flat 4-of-5 and the
+BioProject/PMID rows a flat 3-of-5 — "assigned arbitrarily a confidence
+level of four out of five" (Zafeiropoulos et al. 2022, §2.3) — while only
+the Environmental Samples channel carries a computed, varying score. PREGO
+computes no cross-channel combined score; the shared (0, 5] range is a
+display convention.
+
+So a single global cutoff is a provenance filter wearing a confidence
+filter's clothes: at ``>= 4.0`` it retains 55% of edges, ~85% of which are
+flat rows carrying no ordering, while deleting ~87% of the one channel
+whose score actually varies.
+
+This module implements the alternative used by the same lab for TISSUES and
+DISEASES, and by STRING for its database channel: monotone per-channel
+recalibration onto one shared star axis, with degenerate channels pinned to
+a documented constant tier rather than score-ranked.
+
+- Continuous channel: ``star = 4 * F_r(score)``, where ``F_r`` is the
+  empirical CDF *within resource r* (MGnify / MG-RAST metagenome / MG-RAST
+  amplicon each have their own marginal, so a shared CDF would conflate
+  them).
+- Flat channels: ``star = <author-assigned constant>``.
+
+One user-facing knob, ``tau`` in [0, 4]: keep an edge iff ``star >= tau``.
+
+Determinism is a requirement, not a nicety — a calibration that shifts
+between runs silently changes which edges ship. Cutoffs therefore come from
+fixed-width binned histograms, which are exact to the bin width, O(1) in
+memory, and independent of row order. Streaming quantile sketches (t-digest,
+P-square) are deliberately not used: they are order- and
+implementation-dependent, so two passes over the same file in different
+chunk orders can disagree.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, Mapping, Optional, Tuple
+
+# The paper caps the Environmental Samples score at 4, but the shipped data
+# reaches 4.00735 — so 4.0 is not a safe upper bound for binning. Bin to a
+# hair above the observed maximum and clamp anything beyond it.
+SCORE_MAX = 4.01
+
+# Bin width 1e-4. Retention error at any tau is bounded by the mass in a
+# single bin, which on the measured 23.7M-row channel is well under 0.1%.
+BIN_WIDTH = 1e-4
+BIN_COUNT = int(round(SCORE_MAX / BIN_WIDTH))
+
+# Top of the star axis. Distinct from SCORE_MAX: stars are the calibrated
+# output scale, SCORE_MAX is the raw input bound.
+STAR_MAX = 4.0
+
+# Author-assigned constants for the degenerate channels, from
+# Zafeiropoulos et al. 2022 §2.3 and Appendix C.1. These are tiers, not
+# measurements — every row in the channel carries the same value, so there
+# is no within-channel ordering to threshold on.
+FLAT_CHANNEL_STARS: Dict[str, float] = {
+    "Isolates": 4.0,
+    "Isolates GOLD": 4.0,
+    "Genome annotation": 4.0,
+    "Metagenome-Assembled Genome": 4.0,
+    "Single Amplified Genome": 4.0,
+}
+
+# BioProject rows combine curated metadata with text mining over the linked
+# abstract, which the authors score one tier lower.
+PMID_CHANNEL_STAR = 3.0
+
+
+def is_continuous_channel(channel: str) -> bool:
+    """
+    Return True when ``channel`` is the computed-score (Environmental Samples) channel.
+
+    Identified by shape rather than by name: these rows carry an evidence
+    tally such as ``402 of 487 samples`` in the channel column. The column
+    is a grab-bag upstream (see the prego_channel issue), so matching the
+    tally shape is more robust than enumerating channel names.
+
+    :param channel: Raw value of the ``prego_channel`` column.
+    :return: True if the row's score is computed and varies within-channel.
+    """
+    if not channel:
+        return False
+    parts = channel.split()
+    return len(parts) == 4 and parts[1] == "of" and parts[3] == "samples" and parts[0].isdigit()
+
+
+def flat_channel_star(channel: str) -> Optional[float]:
+    """
+    Return the constant star tier for a degenerate channel, or None.
+
+    :param channel: Raw value of the ``prego_channel`` column.
+    :return: The author-assigned constant, or None if the channel is not a
+        recognised flat channel.
+    """
+    if not channel:
+        return None
+    if channel.startswith("PMID:"):
+        return PMID_CHANNEL_STAR
+    for prefix, star in FLAT_CHANNEL_STARS.items():
+        if channel.startswith(prefix):
+            return star
+    return None
+
+
+def _bin_index(score: float) -> int:
+    """
+    Return the histogram bin for ``score``, clamped into range.
+
+    :param score: Raw PREGO score.
+    :return: Bin index in [0, BIN_COUNT - 1].
+    """
+    if not math.isfinite(score) or score <= 0.0:
+        return 0
+    return min(int(score / BIN_WIDTH), BIN_COUNT - 1)
+
+
+class ScoreHistogram:
+
+    """
+    Fixed-width histogram of raw scores for one resource.
+
+    Accumulates in pass 1; inverted to a cutoff in pass 2. Order-independent
+    by construction, so the cutoff is a pure function of the input bytes.
+    """
+
+    def __init__(self) -> None:
+        """Start an empty histogram."""
+        self._bins: Dict[int, int] = {}
+        self.count = 0
+
+    def add(self, score: float) -> None:
+        """
+        Record one observation.
+
+        :param score: Raw PREGO score.
+        """
+        idx = _bin_index(score)
+        self._bins[idx] = self._bins.get(idx, 0) + 1
+        self.count += 1
+
+    def cutoff(self, tau: float) -> float:
+        """
+        Return the smallest raw score whose star rating is at least ``tau``.
+
+        Solves ``4 * F(s) >= tau`` for the smallest such ``s``, where ``F``
+        is the fraction of observations at or below ``s``. Filtering with
+        ``score >= cutoff`` then retains approximately ``1 - tau/4`` of the
+        resource.
+
+        Ties are never split: every row sharing a bin is kept or dropped
+        together, so the ~13% of rows piled at the score cap move as a unit.
+
+        :param tau: Requested star threshold in [0, STAR_MAX].
+        :return: Raw-score cutoff. 0.0 keeps everything.
+        :raises ValueError: If the histogram is empty.
+        """
+        if self.count == 0:
+            raise ValueError("cannot derive a cutoff from an empty histogram")
+        if tau <= 0.0:
+            return 0.0
+        target = (tau / STAR_MAX) * self.count
+        cumulative = 0
+        for idx in sorted(self._bins):
+            cumulative += self._bins[idx]
+            if cumulative >= target:
+                return idx * BIN_WIDTH
+        return SCORE_MAX
+
+    def as_row(self, resource: str, tau: float) -> Dict[str, object]:
+        """
+        Return a serializable calibration row for this resource.
+
+        ``kept_fraction`` is what the cutoff actually achieves, which can
+        differ from the requested ``1 - tau/4`` when a large tie block
+        straddles the target — reporting the realized value keeps the
+        calibration table honest about that.
+
+        :param resource: Resource name this histogram was built from.
+        :param tau: Star threshold the cutoff was derived for.
+        :return: Mapping of column name to value.
+        """
+        cut = self.cutoff(tau)
+        kept = sum(n for idx, n in self._bins.items() if idx * BIN_WIDTH >= cut)
+        return {
+            "resource": resource,
+            "n": self.count,
+            "tau": tau,
+            "cutoff_score": f"{cut:.4f}",
+            "kept_fraction": f"{kept / self.count:.6f}",
+        }
+
+
+def star_for_row(
+    channel: str,
+    score: float,
+    resource: str,
+    cutoffs: Mapping[str, float],
+) -> Optional[float]:
+    """
+    Return the calibrated star rating for one edge, or None if uncalibratable.
+
+    Flat channels return their constant tier. Continuous rows are compared
+    against their resource's cutoff; because the cutoff already encodes
+    ``tau``, this returns ``STAR_MAX`` for rows at or above it and 0.0 below,
+    which is all the keep/drop decision needs.
+
+    :param channel: Raw ``prego_channel`` value.
+    :param score: Raw ``prego_score`` value.
+    :param resource: Resource the row came from (MGnify, MG-RAST, …).
+    :param cutoffs: Per-resource raw-score cutoffs from :func:`build_cutoffs`.
+    :return: Star rating, or None when the channel is unrecognised.
+    """
+    flat = flat_channel_star(channel)
+    if flat is not None:
+        return flat
+    if not is_continuous_channel(channel):
+        return None
+    cut = cutoffs.get(resource)
+    if cut is None:
+        return None
+    return STAR_MAX if score >= cut else 0.0
+
+
+def keep_row(
+    channel: str,
+    score: float,
+    resource: str,
+    cutoffs: Mapping[str, float],
+    tau: float,
+) -> bool:
+    """
+    Return whether an edge survives the ``tau`` threshold.
+
+    An unrecognised channel is kept. Dropping rows we cannot calibrate would
+    silently delete data for a reason unrelated to confidence — the same
+    failure this module exists to prevent.
+
+    :param channel: Raw ``prego_channel`` value.
+    :param score: Raw ``prego_score`` value.
+    :param resource: Resource the row came from.
+    :param cutoffs: Per-resource raw-score cutoffs.
+    :param tau: Star threshold in [0, STAR_MAX].
+    :return: True if the edge should be emitted.
+    """
+    star = star_for_row(channel, score, resource, cutoffs)
+    if star is None:
+        return True
+    return star >= tau
+
+
+def build_cutoffs(histograms: Mapping[str, ScoreHistogram], tau: float) -> Dict[str, float]:
+    """
+    Invert per-resource histograms into per-resource raw-score cutoffs.
+
+    :param histograms: Resource name to its accumulated histogram.
+    :param tau: Star threshold in [0, STAR_MAX].
+    :return: Resource name to raw-score cutoff.
+    :raises ValueError: If ``tau`` is outside [0, STAR_MAX].
+    """
+    validate_tau(tau)
+    return {resource: hist.cutoff(tau) for resource, hist in histograms.items()}
+
+
+def validate_tau(tau: float) -> None:
+    """
+    Reject a threshold outside the star axis.
+
+    Above ``STAR_MAX`` every channel drops to zero retention, which is never
+    what a caller means; refusing is better than silently emitting nothing.
+
+    :param tau: Requested threshold.
+    :raises ValueError: If ``tau`` is negative or exceeds STAR_MAX.
+    """
+    if not math.isfinite(tau) or tau < 0.0 or tau > STAR_MAX:
+        raise ValueError(f"min-confidence must be in [0, {STAR_MAX}]; got {tau!r}")
+
+
+def estimate_retention(
+    channel_shares: Mapping[str, float],
+    tau: float,
+    continuous_share: float,
+) -> float:
+    """
+    Predict the fraction of edges retained at ``tau``, before running a filter.
+
+    Flat channels contribute all-or-nothing at their constant tier; the
+    continuous channel contributes ``1 - tau/4`` by construction of the
+    percentile remap. Useful for warning that a threshold has become
+    provenance-dominant.
+
+    :param channel_shares: Flat channel name to its share of all edges (0-1).
+    :param tau: Star threshold.
+    :param continuous_share: Share of all edges in the continuous channel.
+    :return: Predicted retained fraction in [0, 1].
+    """
+    validate_tau(tau)
+    retained = sum(share for channel, share in channel_shares.items() if (flat_channel_star(channel) or 0.0) >= tau)
+    return retained + continuous_share * (1.0 - tau / STAR_MAX)
+
+
+def iter_calibration_rows(
+    histograms: Mapping[str, ScoreHistogram], tau: float
+) -> Iterable[Tuple[str, Dict[str, object]]]:
+    """
+    Yield ``(resource, row)`` calibration-table entries in deterministic order.
+
+    :param histograms: Resource name to its accumulated histogram.
+    :param tau: Star threshold the table is being generated for.
+    :return: Iterable of resource name and serializable row.
+    """
+    for resource in sorted(histograms):
+        yield resource, histograms[resource].as_row(resource, tau)

--- a/kg_microbe/transform_utils/prego/calibration.py
+++ b/kg_microbe/transform_utils/prego/calibration.py
@@ -216,6 +216,12 @@ def star_for_row(
     :param cutoffs: Per-resource raw-score cutoffs from :func:`build_cutoffs`.
     :return: Star rating, or None when the channel is unrecognised.
     """
+    if not math.isfinite(score):
+        # A non-finite score is bottom-ranked by _bin_index during
+        # calibration, so retaining it here would be inconsistent: it would
+        # shape the histogram as a zero yet survive every positive cutoff
+        # because ``inf >= cutoff``. Rate it at the bottom in both passes.
+        return 0.0
     if not is_continuous_channel(channel):
         if flat_channel_star(channel) is None:
             # Unrecognised channel. Its score may or may not be on the star

--- a/kg_microbe/transform_utils/prego/calibration.py
+++ b/kg_microbe/transform_utils/prego/calibration.py
@@ -216,11 +216,20 @@ def star_for_row(
     :param cutoffs: Per-resource raw-score cutoffs from :func:`build_cutoffs`.
     :return: Star rating, or None when the channel is unrecognised.
     """
-    flat = flat_channel_star(channel)
-    if flat is not None:
-        return flat
     if not is_continuous_channel(channel):
-        return None
+        if flat_channel_star(channel) is None:
+            # Unrecognised channel. Its score may or may not be on the star
+            # axis, and thresholding on semantics we have not verified is
+            # how data gets dropped for the wrong reason. Decline to rate it.
+            return None
+        # Recognised flat channel: the score is already a star — PREGO
+        # assigns these directly (4 for the genome channels, 3 for
+        # BioProject/PMID). Return the row's own value rather than the
+        # channel constant, so a row disagreeing with its channel's
+        # documented tier is preserved as the data-quality signal it is
+        # instead of being silently promoted. FLAT_CHANNEL_STARS documents
+        # the expected value for validation, not for substitution.
+        return score
     cut = cutoffs.get(resource)
     if cut is None:
         return None

--- a/kg_microbe/transform_utils/prego/calibration.py
+++ b/kg_microbe/transform_utils/prego/calibration.py
@@ -172,6 +172,34 @@ class ScoreHistogram:
                 return idx * BIN_WIDTH
         return SCORE_MAX
 
+    def cutoff_bin(self, tau: float) -> int:
+        """
+        Return the lowest histogram bin retained at ``tau``.
+
+        Both the calibration table and the row filter compare against this,
+        rather than one using a bin edge and the other a raw score. Those are
+        not interchangeable: ``int(score / 1e-4) * 1e-4`` can exceed ``score``
+        for 11.5% of representable 4-dp values — including 1.71, the measured
+        p50 of the real continuous channel. Mixing the two let the table report
+        a tie block as kept while the filter dropped it, a 40-point divergence
+        on a constructed probe.
+
+        :param tau: Star threshold in [0, STAR_MAX].
+        :return: Bin index; 0 retains everything.
+        :raises ValueError: If the histogram is empty.
+        """
+        if self.count == 0:
+            raise ValueError("cannot derive a cutoff from an empty histogram")
+        if tau <= 0.0:
+            return 0
+        target = (tau / STAR_MAX) * self.count
+        cumulative = 0
+        for idx in sorted(self._bins):
+            cumulative += self._bins[idx]
+            if cumulative >= target:
+                return idx
+        return BIN_COUNT
+
     def as_row(self, resource: str, tau: float) -> Dict[str, object]:
         """
         Return a serializable calibration row for this resource.
@@ -185,8 +213,9 @@ class ScoreHistogram:
         :param tau: Star threshold the cutoff was derived for.
         :return: Mapping of column name to value.
         """
-        cut = self.cutoff(tau)
-        kept = sum(n for idx, n in self._bins.items() if idx * BIN_WIDTH >= cut)
+        cut_bin = self.cutoff_bin(tau)
+        cut = cut_bin * BIN_WIDTH
+        kept = sum(n for idx, n in self._bins.items() if idx >= cut_bin)
         return {
             "resource": resource,
             "n": self.count,
@@ -213,7 +242,7 @@ def star_for_row(
     :param channel: Raw ``prego_channel`` value.
     :param score: Raw ``prego_score`` value.
     :param resource: Resource the row came from (MGnify, MG-RAST, …).
-    :param cutoffs: Per-resource raw-score cutoffs from :func:`build_cutoffs`.
+    :param cutoffs: Per-resource cutoff bin indices from :func:`build_cutoffs`.
     :return: Star rating, or None when the channel is unrecognised.
     """
     if not math.isfinite(score):
@@ -236,10 +265,10 @@ def star_for_row(
         # instead of being silently promoted. FLAT_CHANNEL_STARS documents
         # the expected value for validation, not for substitution.
         return score
-    cut = cutoffs.get(resource)
-    if cut is None:
+    cut_bin = cutoffs.get(resource)
+    if cut_bin is None:
         return None
-    return STAR_MAX if score >= cut else 0.0
+    return STAR_MAX if _bin_index(score) >= cut_bin else 0.0
 
 
 def keep_row(
@@ -259,7 +288,7 @@ def keep_row(
     :param channel: Raw ``prego_channel`` value.
     :param score: Raw ``prego_score`` value.
     :param resource: Resource the row came from.
-    :param cutoffs: Per-resource raw-score cutoffs.
+    :param cutoffs: Per-resource cutoff bin indices.
     :param tau: Star threshold in [0, STAR_MAX].
     :return: True if the edge should be emitted.
     """
@@ -275,11 +304,12 @@ def build_cutoffs(histograms: Mapping[str, ScoreHistogram], tau: float) -> Dict[
 
     :param histograms: Resource name to its accumulated histogram.
     :param tau: Star threshold in [0, STAR_MAX].
-    :return: Resource name to raw-score cutoff.
+    :return: Resource name to cutoff BIN INDEX (not a raw score) — the filter
+        and the calibration table must compare on the same quantity.
     :raises ValueError: If ``tau`` is outside [0, STAR_MAX].
     """
     validate_tau(tau)
-    return {resource: hist.cutoff(tau) for resource, hist in histograms.items()}
+    return {resource: hist.cutoff_bin(tau) for resource, hist in histograms.items()}
 
 
 def validate_tau(tau: float) -> None:

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -108,8 +108,11 @@ _BTO_CATEGORY = "biolink:GrossAnatomicalStructure"  # BTO = Brenda Tissue Ontolo
 # header is single-sourced.
 # ---------------------------------------------------------------------------
 # Outcomes of classify_row that result in an emitted edge. Shared by the
-# calibration pass and the emit pass so the two can never disagree about
-# which rows count.
+# calibration pass and the emit pass. Sharing this is necessary but not
+# sufficient for the two populations to match: the emit pass applies further
+# checks (DOID rows needing a MONDO xref, ENVO/BTO prefix agreement) that the
+# calibration pass cannot cheaply replicate, so the histogrammed population
+# remains a slight superset. See the open issue on unifying the predicate.
 _KEEP_OUTCOMES = (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID, KEEP_TAXON_TO_BTO)
 
 _PREGO_EDGE_EXTRA_COLUMNS = (
@@ -218,6 +221,16 @@ class PregoTransform(Transform):
         captured output clean.
         """
         del data_file  # multi-archive ingest; scanned from raw dir
+
+        # Reset run-scoped state. Without this a second run() on the same
+        # instance truncates nodes.tsv but re-emits nothing, because the
+        # node de-dup set still holds every ID from the first run — leaving
+        # edges whose endpoints have no node row.
+        self._emitted_nodes = set()
+        self._drop_examples = defaultdict(lambda: defaultdict(int))
+        self._cutoffs = {}
+        for key, value in list(self._stats.items()):
+            self._stats[key] = defaultdict(int) if isinstance(value, defaultdict) else 0
 
         prego_raw_dir = self.input_base_dir / PREGO
         if not prego_raw_dir.is_dir():
@@ -526,7 +539,16 @@ class PregoTransform(Transform):
                     score = float(row[6])
                 except (ValueError, IndexError):
                     continue
-                if classify_row(entity1_type, entity2_type) not in _KEEP_OUTCOMES:
+                # Mirror the emit pass's cheap eligibility checks. It also
+                # rejects empty IDs and GO-prefix mismatches, so histogramming
+                # on classify_row alone would calibrate over a population
+                # slightly larger than the one that ships.
+                if not row[1] or not row[3]:
+                    continue
+                outcome = classify_row(entity1_type, entity2_type)
+                if outcome not in _KEEP_OUTCOMES:
+                    continue
+                if outcome == KEEP_TAXON_TO_GO and not row[3].startswith("GO:"):
                     continue
                 if not is_continuous_channel(channel):
                     continue

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -108,11 +108,16 @@ _BTO_CATEGORY = "biolink:GrossAnatomicalStructure"  # BTO = Brenda Tissue Ontolo
 # header is single-sourced.
 # ---------------------------------------------------------------------------
 # Outcomes of classify_row that result in an emitted edge. Shared by the
-# calibration pass and the emit pass. Sharing this is necessary but not
-# sufficient for the two populations to match: the emit pass applies further
-# checks (DOID rows needing a MONDO xref, ENVO/BTO prefix agreement) that the
-# calibration pass cannot cheaply replicate, so the histogrammed population
-# remains a slight superset. See the open issue on unifying the predicate.
+# calibration pass and the emit pass. Sharing this is necessary but NOT
+# sufficient: the emit pass applies further checks (DOID rows needing a MONDO
+# xref, ENVO/BTO prefix agreement) that pass 1 cannot cheaply replicate, so the
+# histogrammed population is a superset of what ships.
+#
+# The gap is not merely cosmetic. A resource whose non-emitting rows cluster at
+# one end of the score range gets a cutoff set by rows that never ship — enough
+# to make the filter a no-op for that resource while it reports having halved
+# it. See #699; until that lands, treat per-resource cutoffs as approximate
+# whenever a resource carries many ineligible rows.
 _KEEP_OUTCOMES = (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID, KEEP_TAXON_TO_BTO)
 
 _PREGO_EDGE_EXTRA_COLUMNS = (
@@ -580,10 +585,12 @@ class PregoTransform(Transform):
                 print(
                     f"[prego] WARNING: {row['resource']} retains {realized:.1%} at "
                     f"min-confidence {self.min_confidence} but {target_keep:.1%} was requested. "
-                    f"Its scores pile up at the {row['cutoff_score']} cap, so the threshold "
-                    "has stopped discriminating for this resource."
+                    "Either its scores pile up at a cap (ties are never split) or its "
+                    "calibration population includes rows that do not ship (#699). "
+                    "Check the realized count before relying on this cutoff."
                 )
-        atomic_write(self.calibration_table_file, "\n".join(lines) + "\n")
+        with atomic_write(self.calibration_table_file, "w") as handle:
+            handle.write("\n".join(lines) + "\n")
         print(f"[prego] wrote calibration table → {self.calibration_table_file}")
 
     def _ensure_payload(self, archive_path) -> Path:
@@ -692,12 +699,6 @@ class PregoTransform(Transform):
             self._stats["rows_malformed"] += 1
             return
 
-        if self.min_confidence > 0 and not keep_row(
-            channel, _as_float(score), source, self._cutoffs, self.min_confidence
-        ):
-            self._record_drop("below_min_confidence", entity1_type, entity1_id, entity2_type, entity2_id)
-            return
-
         outcome = classify_row(entity1_type, entity2_type)
         if outcome not in (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID, KEEP_TAXON_TO_BTO):
             self._record_drop(outcome, entity1_type, entity1_id, entity2_type, entity2_id)
@@ -757,6 +758,17 @@ class PregoTransform(Transform):
             relation = _RELATION_LOCATION_OF
             self._emit_node(node_writer, subject, _BTO_CATEGORY)
             self._emit_node(node_writer, obj, _NCBITAXON_CATEGORY)
+
+        # Applied last, after every eligibility check. Run earlier it attributed
+        # rows to "below_min_confidence" that would have been dropped anyway,
+        # inflating the reported cost of the knob (measured 418 vs 198 on a
+        # probe) and emptying unmapped_associations.tsv of the reasons a
+        # curator actually needs.
+        if self.min_confidence > 0 and not keep_row(
+            channel, _as_float(score), source, self._cutoffs, self.min_confidence
+        ):
+            self._record_drop("below_min_confidence", entity1_type, entity1_id, entity2_type, entity2_id)
+            return
 
         edge_writer.writerow(
             self._make_edge_row(

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -28,6 +28,7 @@ threshold on confidence.
 from __future__ import annotations
 
 import csv
+import os
 import pickle
 import tarfile
 from collections import defaultdict
@@ -55,6 +56,14 @@ from kg_microbe.transform_utils.constants import (
     SUBJECT_COLUMN,
     SYNONYM_COLUMN,
 )
+from kg_microbe.transform_utils.prego.calibration import (
+    ScoreHistogram,
+    build_cutoffs,
+    is_continuous_channel,
+    iter_calibration_rows,
+    keep_row,
+    validate_tau,
+)
 from kg_microbe.transform_utils.prego.utils import (
     KEEP_ENVO_TO_TAXON,
     KEEP_TAXON_TO_BTO,
@@ -70,6 +79,7 @@ from kg_microbe.transform_utils.prego.utils import (
     load_doid_to_mondo,
 )
 from kg_microbe.transform_utils.transform import Transform
+from kg_microbe.utils.atomic_io import atomic_write
 
 # ---------------------------------------------------------------------------
 # Edge predicates and relations. PREGO uses only biolink predicates; the
@@ -96,6 +106,11 @@ _BTO_CATEGORY = "biolink:GrossAnatomicalStructure"  # BTO = Brenda Tissue Ontolo
 # Extra edge columns beyond the KGX minimum. Kept as a small tuple so the
 # header is single-sourced.
 # ---------------------------------------------------------------------------
+# Outcomes of classify_row that result in an emitted edge. Shared by the
+# calibration pass and the emit pass so the two can never disagree about
+# which rows count.
+_KEEP_OUTCOMES = (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID, KEEP_TAXON_TO_BTO)
+
 _PREGO_EDGE_EXTRA_COLUMNS = (
     PREGO_SCORE_COLUMN,
     PREGO_CHANNEL_COLUMN,
@@ -103,6 +118,23 @@ _PREGO_EDGE_EXTRA_COLUMNS = (
     PREGO_DIRECT_FLAG_COLUMN,
     PREGO_EVIDENCE_URL_COLUMN,
 )
+
+
+def _as_float(value) -> float:
+    """
+    Parse a score, returning 0.0 when it is absent or unparsable.
+
+    A missing score must not crash a 44M-row run; 0.0 sorts to the bottom,
+    so such a row is dropped by any threshold above zero rather than being
+    silently promoted.
+
+    :param value: Raw score field.
+    :return: Parsed score, or 0.0.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
 
 
 class PregoTransform(Transform):
@@ -113,8 +145,17 @@ class PregoTransform(Transform):
         self,
         input_dir: Optional[Path] = None,
         output_dir: Optional[Path] = None,
+        min_confidence: Optional[float] = None,
     ):
-        """Instantiate; register the source name + extend the edge header with PREGO metadata."""
+        """
+        Instantiate; register the source name + extend the edge header with PREGO metadata.
+
+        :param input_dir: Raw data directory.
+        :param output_dir: Transform output directory.
+        :param min_confidence: Star threshold in [0, 4]; rows below it are
+            dropped. Defaults to the ``PREGO_MIN_CONFIDENCE`` environment
+            variable, else 0.0 (emit everything, preserving current behaviour).
+        """
         super().__init__(PREGO, input_dir, output_dir)
         # Extend edge header with PREGO's per-row metadata columns. Node
         # header is unchanged (id / category / name / description / xref /
@@ -125,6 +166,16 @@ class PregoTransform(Transform):
         # Curation report path — one row per (drop_reason, source_id) pair
         # with an occurrence count, so a curator can prioritise fix targets.
         self.unmapped_report_file = self.output_dir / "unmapped_associations.tsv"
+        # Confidence threshold on the calibrated star axis. 0.0 keeps every
+        # row, so the default is a no-op and existing runs are unchanged.
+        if min_confidence is None:
+            min_confidence = float(os.environ.get("PREGO_MIN_CONFIDENCE", "0") or 0)
+        validate_tau(min_confidence)
+        self.min_confidence = min_confidence
+        self._cutoffs: dict = {}
+        # Per-resource cutoffs actually applied, written next to the outputs
+        # so a filtered run says what it dropped.
+        self.calibration_table_file = self.output_dir / "confidence_calibration.tsv"
         # Per-run counters.
         self._stats = {
             "rows_read": 0,
@@ -194,6 +245,18 @@ class PregoTransform(Transform):
         self._load_dictionary(prego_raw_dir, doid_to_mondo)
 
         Path.mkdir(self.output_dir, exist_ok=True, parents=True)
+
+        # Pass 1 — derive per-resource cutoffs from the rows this run will
+        # actually emit. Skipped entirely at the default threshold, so the
+        # no-filter path stays single-pass.
+        if self.min_confidence > 0:
+            histograms = self._collect_calibration(archives, show_status=show_status)
+            if histograms:
+                self._cutoffs = build_cutoffs(histograms, self.min_confidence)
+                self._write_calibration_table(histograms)
+            else:
+                print("[prego] WARNING: no continuous-channel rows found; only flat-channel tiers will be thresholded.")
+
         with (
             self.output_node_file.open("w", newline="") as node_fh,
             self.output_edge_file.open("w", newline="") as edge_fh,
@@ -425,9 +488,67 @@ class PregoTransform(Transform):
     # Per-archive processing.
     # ------------------------------------------------------------------ #
 
-    def _process_archive(self, archive_path, doid_to_mondo, node_writer, edge_writer, show_status: bool = True):
+    def _collect_calibration(self, archives, show_status: bool = True) -> dict:
         """
-        Extract ``database_pairs.tsv`` from one archive and stream it row-by-row.
+        Build per-resource score histograms over exactly the rows pass 2 will emit.
+
+        This is the reason calibration happens inside the transform rather
+        than from a committed table: the cutoffs must be derived from the
+        emitted edge population, not from the raw file. The raw archives
+        contain rows this transform drops (non-canonical directions,
+        taxon–taxon pairs), and their score distribution differs. Calibrating
+        on the raw file would set cutoffs for a population that never ships.
+
+        Only the continuous channel is histogrammed — the flat channels are
+        constant-valued, so a quantile over them is meaningless.
+
+        :param archives: PREGO association archives to scan.
+        :param show_status: Whether to render the tqdm progress bar.
+        :return: Resource name to its accumulated :class:`ScoreHistogram`.
+        """
+        histograms: dict = {}
+        for archive_path in archives:
+            payload_file = self._ensure_payload(archive_path)
+            print(f"[prego] calibration pass over {payload_file.name}")
+            row_iter = iter_database_pairs(payload_file)
+            if show_status:
+                row_iter = tqdm(row_iter, desc=f"calibrate {archive_path.name}", unit="rows")
+            for row, err in row_iter:
+                if err is not None:
+                    continue
+                try:
+                    entity1_type = int(row[0])
+                    entity2_type = int(row[2])
+                    source = row[4]
+                    channel = row[5]
+                    score = float(row[6])
+                except (ValueError, IndexError):
+                    continue
+                if classify_row(entity1_type, entity2_type) not in _KEEP_OUTCOMES:
+                    continue
+                if not is_continuous_channel(channel):
+                    continue
+                histograms.setdefault(source, ScoreHistogram()).add(score)
+        return histograms
+
+    def _write_calibration_table(self, histograms) -> None:
+        """
+        Record the calibration next to the outputs so a run is auditable.
+
+        Without this the cutoffs live only in memory, and a consumer of the
+        filtered edges has no way to tell what was dropped or reproduce it.
+
+        :param histograms: Resource name to its accumulated histogram.
+        """
+        lines = ["resource\tn\ttau\tcutoff_score\tkept_fraction"]
+        for _resource, row in iter_calibration_rows(histograms, self.min_confidence):
+            lines.append(f"{row['resource']}\t{row['n']}\t{row['tau']}\t{row['cutoff_score']}\t{row['kept_fraction']}")
+        atomic_write(self.calibration_table_file, "\n".join(lines) + "\n")
+        print(f"[prego] wrote calibration table → {self.calibration_table_file}")
+
+    def _ensure_payload(self, archive_path) -> Path:
+        """
+        Return the extracted ``database_pairs.tsv`` for one archive.
 
         Cache-then-reuse: extract once into a sibling ``_extracted`` dir so
         re-runs don't pay the ~30 s decompression cost twice. Guard against
@@ -435,6 +556,12 @@ class PregoTransform(Transform):
         tar member's declared size, re-extract rather than trusting a possibly
         truncated file (the alternative would silently emit fewer edges on a
         retry after Ctrl-C / disk-full / OOM).
+
+        Split out from :meth:`_process_archive` so the calibration pass can
+        reuse the same payload without re-extracting it.
+
+        :param archive_path: Path to one PREGO ``*.tar.gz``.
+        :return: Path to the extracted TSV.
         """
         payload_dir = archive_path.parent / archive_path.stem.replace(".tar", "_extracted")
         payload_dir.mkdir(parents=True, exist_ok=True)
@@ -467,6 +594,19 @@ class PregoTransform(Transform):
                             break
                         dst.write(chunk)
 
+        return payload_file
+
+    def _process_archive(self, archive_path, doid_to_mondo, node_writer, edge_writer, show_status: bool = True):
+        """
+        Stream one archive's ``database_pairs.tsv`` row-by-row into the writers.
+
+        :param archive_path: Path to one PREGO ``*.tar.gz``.
+        :param doid_to_mondo: DOID→MONDO xref map.
+        :param node_writer: CSV writer for nodes.tsv.
+        :param edge_writer: CSV writer for edges.tsv.
+        :param show_status: Whether to render the tqdm progress bar.
+        """
+        payload_file = self._ensure_payload(archive_path)
         print(f"[prego] processing {payload_file.name} ({payload_file.stat().st_size / 1024**3:.1f} GB)")
         row_iter = iter_database_pairs(payload_file)
         if show_status:
@@ -502,6 +642,12 @@ class PregoTransform(Transform):
             evidence_url = row[8]
         except (ValueError, IndexError):
             self._stats["rows_malformed"] += 1
+            return
+
+        if self.min_confidence > 0 and not keep_row(
+            channel, _as_float(score), source, self._cutoffs, self.min_confidence
+        ):
+            self._record_drop("below_min_confidence", entity1_type, entity1_id, entity2_type, entity2_id)
             return
 
         outcome = classify_row(entity1_type, entity2_type)

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -57,6 +57,7 @@ from kg_microbe.transform_utils.constants import (
     SYNONYM_COLUMN,
 )
 from kg_microbe.transform_utils.prego.calibration import (
+    STAR_MAX,
     ScoreHistogram,
     build_cutoffs,
     is_continuous_channel,
@@ -173,6 +174,7 @@ class PregoTransform(Transform):
         validate_tau(min_confidence)
         self.min_confidence = min_confidence
         self._cutoffs: dict = {}
+        self._payload_cache: dict = {}
         # Per-resource cutoffs actually applied, written next to the outputs
         # so a filtered run says what it dropped.
         self.calibration_table_file = self.output_dir / "confidence_calibration.tsv"
@@ -540,9 +542,25 @@ class PregoTransform(Transform):
 
         :param histograms: Resource name to its accumulated histogram.
         """
+        target_keep = 1.0 - self.min_confidence / STAR_MAX
         lines = ["resource\tn\ttau\tcutoff_score\tkept_fraction"]
         for _resource, row in iter_calibration_rows(histograms, self.min_confidence):
             lines.append(f"{row['resource']}\t{row['n']}\t{row['tau']}\t{row['cutoff_score']}\t{row['kept_fraction']}")
+            # A resource whose scores pile up at the cap cannot honour the
+            # request: once the target quantile falls inside that tie block,
+            # raising the threshold changes nothing, because ties are never
+            # split. Measured on the real archives, MG-RAST amplicon holds
+            # 46.4% of its rows at the cap, so every threshold above ~2.5
+            # retains that same 46.4%. Silently returning far more than was
+            # asked for is exactly what has to be said out loud.
+            realized = float(row["kept_fraction"])
+            if realized > target_keep + 0.05:
+                print(
+                    f"[prego] WARNING: {row['resource']} retains {realized:.1%} at "
+                    f"min-confidence {self.min_confidence} but {target_keep:.1%} was requested. "
+                    f"Its scores pile up at the {row['cutoff_score']} cap, so the threshold "
+                    "has stopped discriminating for this resource."
+                )
         atomic_write(self.calibration_table_file, "\n".join(lines) + "\n")
         print(f"[prego] wrote calibration table → {self.calibration_table_file}")
 
@@ -563,6 +581,13 @@ class PregoTransform(Transform):
         :param archive_path: Path to one PREGO ``*.tar.gz``.
         :return: Path to the extracted TSV.
         """
+        # Memoized: listing members of a gzipped tar decompresses the whole
+        # archive — minutes for the 8.7 GB isolates file. A filtered run
+        # resolves each payload twice (calibrate, then emit), so without
+        # this the tar scan is paid twice for no benefit.
+        cached = self._payload_cache.get(archive_path)
+        if cached is not None:
+            return cached
         payload_dir = archive_path.parent / archive_path.stem.replace(".tar", "_extracted")
         payload_dir.mkdir(parents=True, exist_ok=True)
         payload_file = payload_dir / "database_pairs.tsv"
@@ -594,6 +619,7 @@ class PregoTransform(Transform):
                             break
                         dst.write(chunk)
 
+        self._payload_cache[archive_path] = payload_file
         return payload_file
 
     def _process_archive(self, archive_path, doid_to_mondo, node_writer, edge_writer, show_status: bool = True):

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -48,6 +48,7 @@ from kg_microbe.transform_utils.constants import (
     PREGO_EVIDENCE_URL_COLUMN,
     PREGO_KNOWLEDGE_SOURCE,
     PREGO_SCORE_COLUMN,
+    PREGO_SOURCE_COLUMN,
     PRIMARY_KNOWLEDGE_SOURCE_COLUMN,
     PROVIDED_BY_COLUMN,
     RELATION_COLUMN,
@@ -98,6 +99,7 @@ _BTO_CATEGORY = "biolink:GrossAnatomicalStructure"  # BTO = Brenda Tissue Ontolo
 _PREGO_EDGE_EXTRA_COLUMNS = (
     PREGO_SCORE_COLUMN,
     PREGO_CHANNEL_COLUMN,
+    PREGO_SOURCE_COLUMN,
     PREGO_DIRECT_FLAG_COLUMN,
     PREGO_EVIDENCE_URL_COLUMN,
 )
@@ -502,8 +504,6 @@ class PregoTransform(Transform):
             self._stats["rows_malformed"] += 1
             return
 
-        del source  # column carried in edge_attribute space for now; unused
-
         outcome = classify_row(entity1_type, entity2_type)
         if outcome not in (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID, KEEP_TAXON_TO_BTO):
             self._record_drop(outcome, entity1_type, entity1_id, entity2_type, entity2_id)
@@ -572,6 +572,7 @@ class PregoTransform(Transform):
                 relation=relation,
                 score=score,
                 channel=channel,
+                source=source,
                 direct_flag=direct_flag,
                 evidence_url=evidence_url,
             )
@@ -618,6 +619,7 @@ class PregoTransform(Transform):
         relation: str,
         score: str,
         channel: str,
+        source: str,
         direct_flag: str,
         evidence_url: str,
     ) -> list:
@@ -630,6 +632,7 @@ class PregoTransform(Transform):
         row[PRIMARY_KNOWLEDGE_SOURCE_COLUMN] = PREGO_KNOWLEDGE_SOURCE
         row[PREGO_SCORE_COLUMN] = score
         row[PREGO_CHANNEL_COLUMN] = channel
+        row[PREGO_SOURCE_COLUMN] = source
         row[PREGO_DIRECT_FLAG_COLUMN] = direct_flag
         row[PREGO_EVIDENCE_URL_COLUMN] = evidence_url
         return [row[c] for c in self.edge_header]

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -1,0 +1,185 @@
+"""
+Fold-enrichment measurement for PREGO association scores.
+
+The percentile calibration in :mod:`calibration` equalizes **rank**: at
+``min-confidence 2.0`` it keeps the top half of each resource. It makes no
+claim about quality, because nothing anchors it to an external truth.
+
+TISSUES closes that gap by calibrating against a gold standard — "we select
+the genes and tissues that are in common between the dataset and the gold
+standard, sort the gene–tissue pairs by raw expression value and calculate
+fold enrichment in sliding windows of 100 pairs" (Palasca et al. 2018). This
+module is the equivalent measurement for taxon→GO associations.
+
+    fold enrichment = P(pair in gold | pair in window) / P(pair in gold)
+
+where the denominator is the density of the gold standard over the shared
+entity space, i.e. what a random pair would achieve. Fold 1.0 means the
+score carries no information; above 1.0 means the window is enriched for
+curated agreement.
+
+**What this measured on the real data, and why it matters.** Run against
+metatraits + metatraits_gtdb + madin_etal as the gold standard, PREGO's
+score is *anti*-correlated with agreement. Within the continuous channel,
+fold enrichment falls monotonically from 1.61x in the lowest score quintile
+to 1.17x in the highest, and the effect survives stratifying by GO term
+(30 of 47 terms show it; pooled hit rate 0.180 low-half vs 0.151
+high-half). The flat channels sit at exactly 1.00x — random.
+
+So raising a threshold on ``prego_score`` selects edges that agree with
+curated annotation *less* often. The threshold remains a valid **size**
+lever; it is not a quality lever. See the module tests for the invariants
+this implies.
+
+Coverage is the main caveat and is deliberately reported alongside every
+result: only ~1% of PREGO's taxon→GO edges are comparable, over 70 shared
+GO terms. A calibration fitted on that slice should not be extrapolated to
+the whole graph without a broader gold standard.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
+
+
+class GoldStandard:
+
+    """
+    A set of curated ``(subject, object)`` pairs plus the entity space it covers.
+
+    The entity sets matter as much as the pairs: fold enrichment is only
+    meaningful over subjects and objects the gold standard actually knows
+    about. Scoring a pair whose object the gold standard has never seen
+    would count as a miss for a reason that has nothing to do with quality.
+    """
+
+    def __init__(self, pairs: Iterable[Tuple[str, str]]) -> None:
+        """
+        Build a gold standard from curated pairs.
+
+        :param pairs: Iterable of ``(subject, object)`` CURIE pairs.
+        """
+        self.pairs: Set[Tuple[str, str]] = set(pairs)
+        self.subjects: Set[str] = {s for s, _ in self.pairs}
+        self.objects: Set[str] = {o for _, o in self.pairs}
+
+    def covers(self, subject: str, object_: str) -> bool:
+        """
+        Return whether both endpoints are inside the gold standard's entity space.
+
+        :param subject: Subject CURIE.
+        :param object_: Object CURIE.
+        :return: True if the pair is comparable.
+        """
+        return subject in self.subjects and object_ in self.objects
+
+    def contains(self, subject: str, object_: str) -> bool:
+        """
+        Return whether the gold standard asserts this pair.
+
+        :param subject: Subject CURIE.
+        :param object_: Object CURIE.
+        :return: True if the pair is a curated hit.
+        """
+        return (subject, object_) in self.pairs
+
+    def baseline(self, subjects: Set[str], objects: Set[str]) -> float:
+        """
+        Return the density of the gold standard over a shared entity space.
+
+        This is the rate a random pair drawn from ``subjects x objects``
+        would hit, and the denominator of every fold-enrichment figure.
+
+        :param subjects: Subjects shared with the dataset under test.
+        :param objects: Objects shared with the dataset under test.
+        :return: Expected hit rate in [0, 1]; 0.0 if the space is empty.
+        :raises ValueError: If either shared set is empty.
+        """
+        universe = len(subjects) * len(objects)
+        if universe == 0:
+            raise ValueError("no shared entities; fold enrichment is undefined")
+        hits = sum(1 for s, o in self.pairs if s in subjects and o in objects)
+        return hits / universe
+
+
+def fold_enrichment(hit_rate: float, baseline: float) -> float:
+    """
+    Return enrichment of an observed hit rate over the random expectation.
+
+    :param hit_rate: Observed fraction of pairs that are curated hits.
+    :param baseline: Expected fraction for a random pair.
+    :return: Fold enrichment; 1.0 means no information.
+    :raises ValueError: If ``baseline`` is not positive.
+    """
+    if baseline <= 0:
+        raise ValueError("baseline must be positive to compute fold enrichment")
+    return hit_rate / baseline
+
+
+def enrichment_by_window(
+    scored: Sequence[Tuple[float, bool]],
+    baseline: float,
+    windows: int = 5,
+) -> List[Dict[str, float]]:
+    """
+    Return fold enrichment per equal-count score window, ascending by score.
+
+    Equal-count windows rather than equal-width: PREGO's scores pile up at
+    the cap, so equal-width bins would put most of the mass in one bin and
+    measure nothing.
+
+    A window whose score range is a single value is flagged via ``degenerate``.
+    Such a window is an arbitrary slice of tied rows — its hit rate reflects
+    whatever order the ties arrived in, not the score — so it must not be
+    read as signal.
+
+    :param scored: ``(score, is_hit)`` pairs; sorted internally.
+    :param baseline: Random-expectation hit rate.
+    :param windows: Number of equal-count windows.
+    :return: One dict per window with score bounds, n, hit rate, and fold.
+    :raises ValueError: If ``windows`` is not positive.
+    """
+    if windows <= 0:
+        raise ValueError("windows must be positive")
+    rows = sorted(scored, key=lambda r: r[0])
+    if not rows:
+        return []
+    size = max(1, len(rows) // windows)
+    out: List[Dict[str, float]] = []
+    for i in range(windows):
+        lo = i * size
+        hi = len(rows) if i == windows - 1 else min(len(rows), (i + 1) * size)
+        window = rows[lo:hi]
+        if not window:
+            continue
+        rate = sum(1 for _, hit in window if hit) / len(window)
+        out.append(
+            {
+                "window": i + 1,
+                "score_min": window[0][0],
+                "score_max": window[-1][0],
+                "n": len(window),
+                "hit_rate": rate,
+                "fold": fold_enrichment(rate, baseline),
+                "degenerate": window[0][0] == window[-1][0],
+            }
+        )
+    return out
+
+
+def is_monotone_increasing(results: Sequence[Dict[str, float]]) -> bool:
+    """
+    Return whether fold enrichment rises with score across non-degenerate windows.
+
+    This is the property a usable confidence score must have: a higher score
+    should mean a higher chance of agreeing with curated knowledge. PREGO's
+    does not, which is why this predicate exists — to make the failure
+    checkable rather than a matter of opinion.
+
+    Degenerate (all-ties) windows are excluded; their ordering is arbitrary.
+
+    :param results: Output of :func:`enrichment_by_window`.
+    :return: True if fold is non-decreasing across usable windows.
+    """
+    folds = [r["fold"] for r in results if not r["degenerate"]]
+    return all(a <= b for a, b in zip(folds, folds[1:], strict=False))

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -14,9 +14,11 @@ module is the equivalent measurement for taxon→GO associations.
     fold enrichment = P(pair in gold | pair in window) / P(pair in gold)
 
 where the denominator is the density of the gold standard over the shared
-entity space, i.e. what a random pair would achieve. Fold 1.0 means the
-score carries no information; above 1.0 means the window is enriched for
-curated agreement.
+entity space. Fold 1.0 means the window matches that baseline — **not**
+that the score carries no information, since the baseline weights every
+subject x object cell equally and so controls for neither taxon annotation
+depth nor GO-term ubiquity. A degree-preserving null would be a stronger
+test and is not implemented here.
 
 **What this measured, and why the answer depends on the gold standard.**
 Two were tried, and they disagree — which is the most important result
@@ -32,19 +34,21 @@ Against **metatraits + madin_etal** (trait-derived; 78 GO terms, ~1%
 comparable), it *falls*: 1.61x → 1.59x → 1.56x, with the flat channels at
 1.00x.
 
-The reversal is a provenance-alignment artifact, not a contradiction.
-UniProt annotations come from genome annotation, and PREGO's flat channels
-are genome-derived (JGI IMG, Struo-GTDB) — so they agree with each other
-for reasons unrelated to whether either is right. metatraits is
-trait/literature-derived and aligns better with PREGO's environmental
-channel. **Each gold standard flatters the PREGO channel that shares its
-provenance.** Any single-gold-standard verdict on this score should be
-treated as provisional.
+The leading *hypothesis* for the reversal is provenance alignment, which is
+not established: UniProt annotations come from genome annotation and PREGO's
+flat channels are genome-derived (JGI IMG, Struo-GTDB), so their agreement
+may reflect a shared source rather than either being right. metatraits is
+trait/literature-derived. Testing this needs a source-overlap exclusion and
+a degree-matched comparison; until then treat the UniProt figure for the
+genome channels as provenance agreement rather than quality, and treat any
+single-gold-standard verdict as provisional.
 
-What both agree on: the effect is weak. Fold enrichment spans roughly
-1.0–1.2x across the continuous channel's whole score range, so the score
-is at best a soft quality signal, and thresholding on it is not a strong
-quality lever in either direction.
+Effect sizes, stated per benchmark rather than pooled: against UniProt the
+continuous channel spans 0.94x-1.19x; against the trait-derived standard it
+spans 1.56x-1.61x. Neither range is accompanied by an uncertainty estimate.
+The observations are not independent — edges reuse the same taxa, GO terms
+and resources — so clustered intervals are needed before any ordering of
+these point estimates is called directional.
 
 Separately, the score tracks evidence volume: a GO term's edge count
 correlates with its mean score at Spearman +0.26, driven by rare terms
@@ -124,7 +128,7 @@ def fold_enrichment(hit_rate: float, baseline: float) -> float:
 
     :param hit_rate: Observed fraction of pairs that are curated hits.
     :param baseline: Expected fraction for a random pair.
-    :return: Fold enrichment; 1.0 means no information.
+    :return: Fold enrichment relative to ``baseline``; 1.0 matches it.
     :raises ValueError: If ``baseline`` is not positive.
     """
     if baseline <= 0:
@@ -232,4 +236,10 @@ def is_monotone_increasing(results: Sequence[Dict[str, float]]) -> bool:
     :return: True if fold is non-decreasing across usable windows.
     """
     folds = [r["fold"] for r in results if not r["degenerate"]]
+    if len(folds) < 2:
+        # Fewer than two usable windows means there is no comparison to make.
+        # Returning True here would report a fully tied channel — which has no
+        # score ordering at all — as monotonically increasing, because
+        # ``all()`` over an empty sequence is vacuously true.
+        return False
     return all(a <= b for a, b in zip(folds, folds[1:], strict=False))

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -59,7 +59,7 @@ first — a coverage bias worth knowing about independent of quality.
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 
 class GoldStandard:
@@ -243,3 +243,126 @@ def is_monotone_increasing(results: Sequence[Dict[str, float]]) -> bool:
         # ``all()`` over an empty sequence is vacuously true.
         return False
     return all(a <= b for a, b in zip(folds, folds[1:], strict=False))
+
+
+# ---------------------------------------------------------------------------
+# Labelled evidence — precision measurement.
+#
+# Fold enrichment needs a null model, and the uniform subject x object null
+# used above controls for neither taxon annotation depth nor term ubiquity.
+# Where labelled *negatives* exist that problem disappears: precision is
+# measured directly against the empirical base rate, with nothing assumed
+# about how pairs are drawn.
+#
+# KG-Microbe has such labels. BacDive records assay outcomes with polarity —
+# METPO:2000302 "shows activity of" and METPO:2000303 "does not show activity
+# of" — so chaining strain -> assay -> GO and lifting strain to NCBITaxon
+# yields positives and negatives from wet-lab phenotype tests, provenance-
+# disjoint from both genome annotation and trait curation.
+# ---------------------------------------------------------------------------
+
+
+class LabelledEvidence:
+
+    """
+    Positive/negative labels for ``(subject, object)`` pairs.
+
+    Unlike :class:`GoldStandard`, which only knows which pairs are asserted,
+    this knows which are asserted *false*. That is what makes precision
+    measurable without a null model.
+    """
+
+    def __init__(self, positives: Iterable[Tuple[str, str]], negatives: Iterable[Tuple[str, str]]) -> None:
+        """
+        Build labelled evidence from disjoint positive and negative pairs.
+
+        :param positives: Pairs the evidence asserts hold.
+        :param negatives: Pairs the evidence asserts do not hold.
+        :raises ValueError: If a pair appears in both, which would make its
+            label ambiguous rather than merely unknown.
+        """
+        self.positives: Set[Tuple[str, str]] = set(positives)
+        self.negatives: Set[Tuple[str, str]] = set(negatives)
+        overlap = self.positives & self.negatives
+        if overlap:
+            raise ValueError(
+                f"{len(overlap)} pair(s) labelled both positive and negative; "
+                "resolve or exclude conflicting evidence before constructing"
+            )
+
+    def label(self, subject: str, object_: str) -> Optional[bool]:
+        """
+        Return True, False, or None when the pair is unlabelled.
+
+        :param subject: Subject CURIE.
+        :param object_: Object CURIE.
+        :return: The label, or None if this evidence says nothing about the pair.
+        """
+        key = (subject, object_)
+        if key in self.positives:
+            return True
+        if key in self.negatives:
+            return False
+        return None
+
+    def base_rate(self) -> float:
+        """
+        Return the fraction of labelled pairs that are positive.
+
+        This is the precision a selector achieves by picking labelled pairs at
+        random, and the only reference point precision needs — it is measured,
+        not modelled.
+
+        :return: Base rate in [0, 1].
+        :raises ValueError: If there are no labelled pairs.
+        """
+        total = len(self.positives) + len(self.negatives)
+        if total == 0:
+            raise ValueError("no labelled pairs; base rate is undefined")
+        return len(self.positives) / total
+
+
+def precision_by_window(
+    scored: Sequence[Tuple[float, bool]],
+    windows: int = 5,
+) -> List[Dict[str, float]]:
+    """
+    Return precision per equal-count score window, ascending by score.
+
+    Precision is the fraction of labelled edges in the window whose label is
+    positive. Compare against :meth:`LabelledEvidence.base_rate`; a score that
+    discriminates produces windows rising above it.
+
+    Windows break only where the score changes, for the same reason as
+    :func:`enrichment_by_window` — an index-based slice would let the sort's
+    tiebreak decide which tied rows land in which window.
+
+    :param scored: ``(score, is_positive)`` pairs for labelled edges only.
+    :param windows: Number of equal-count windows.
+    :return: One dict per window with score bounds, n, precision, degenerate.
+    :raises ValueError: If ``windows`` is not positive.
+    """
+    results = enrichment_by_window(scored, baseline=1.0, windows=windows)
+    for row in results:
+        # enrichment_by_window with baseline 1.0 makes `fold` the raw rate.
+        row["precision"] = row.pop("fold")
+        row.pop("hit_rate", None)
+    return results
+
+
+def lift(precision: float, base_rate: float) -> float:
+    """
+    Return precision relative to the measured base rate.
+
+    Distinct from :func:`fold_enrichment` in that the denominator is observed
+    rather than derived from a uniform-cell null, so it carries none of that
+    null's assumptions about how pairs are drawn.
+
+    :param precision: Observed precision.
+    :param base_rate: Fraction of labelled pairs that are positive.
+    :return: Lift; 1.0 means no better than picking labelled pairs at random.
+    :raises ValueError: If ``base_rate`` is not positive.
+    """
+    if base_rate <= 0:
+        raise ValueError("base rate must be positive to compute lift")
+    return precision / base_rate

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -50,6 +50,20 @@ The observations are not independent — edges reuse the same taxa, GO terms
 and resources — so clustered intervals are needed before any ordering of
 these point estimates is called directional.
 
+**The score does discriminate — but on environmental edges, not functional
+ones.** Everything above concerns ``NCBITaxon -capable_of-> GO``. Tested
+instead against BacDive isolation sources (``ENVO -location_of-> strain``,
+lifted to taxon), PREGO's ``ENVO -location_of-> NCBITaxon`` edges enrich
+sharply with score: 3.26x, 12.58x, 17.03x across the top three windows,
+7.89x overall. It survives controlling for ENVO-term degree — 18 of 19
+terms with >=100 comparable edges show the higher-score half agreeing more,
+pooled 0.211 vs 0.331 within-term, a 1.57x ratio.
+
+That split has a plausible mechanism: the environmental-samples score counts
+taxon-environment co-occurrence, which is direct evidence for an ENVO edge
+and only indirect evidence for a functional one. Treat the score as
+meaningful for environmental associations and unproven for GO.
+
 Separately, the score tracks evidence volume: a GO term's edge count
 correlates with its mean score at Spearman +0.26, driven by rare terms
 scoring low (mean 0.67 in the lowest-ubiquity decile vs ~2.0 everywhere

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -59,10 +59,17 @@ sharply with score: 3.26x, 12.58x, 17.03x across the top three windows,
 terms with >=100 comparable edges show the higher-score half agreeing more,
 pooled 0.211 vs 0.331 within-term, a 1.57x ratio.
 
-That split has a plausible mechanism: the environmental-samples score counts
-taxon-environment co-occurrence, which is direct evidence for an ENVO edge
-and only indirect evidence for a functional one. Treat the score as
-meaningful for environmental associations and unproven for GO.
+The same holds for the other ``location_of`` edge type. ``BTO
+-location_of-> NCBITaxon`` edges, validated against BacDive host anatomy
+(joined through the BTO xrefs already present in ``uberon_nodes.tsv``),
+enrich 3.86x overall and 1.94x within-term (7 of 9 BTO terms).
+
+So the split is by **predicate**, not by edge type: the score discriminates
+on ``location_of`` (two independent edge types agree) and not on
+``capable_of``. The mechanism fits — PREGO's score counts taxon-sample
+co-occurrence, which is direct evidence for "this organism is found in
+location X" and only indirect evidence for "this organism can perform
+function Y".
 
 Separately, the score tracks evidence volume: a GO term's edge count
 correlates with its mean score at Spearman +0.26, driven by rare terms

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -18,23 +18,39 @@ entity space, i.e. what a random pair would achieve. Fold 1.0 means the
 score carries no information; above 1.0 means the window is enriched for
 curated agreement.
 
-**What this measured on the real data, and why it matters.** Run against
-metatraits + metatraits_gtdb + madin_etal as the gold standard, PREGO's
-score is *anti*-correlated with agreement. Within the continuous channel,
-fold enrichment falls monotonically from 1.61x in the lowest score quintile
-to 1.17x in the highest, and the effect survives stratifying by GO term
-(30 of 47 terms show it; pooled hit rate 0.180 low-half vs 0.151
-high-half). The flat channels sit at exactly 1.00x — random.
+**What this measured, and why the answer depends on the gold standard.**
+Two were tried, and they disagree — which is the most important result
+here.
 
-So raising a threshold on ``prego_score`` selects edges that agree with
-curated annotation *less* often. The threshold remains a valid **size**
-lever; it is not a quality lever. See the module tests for the invariants
-this implies.
+Against **UniProt proteome annotations** (14.4M taxon→GO pairs derived
+from ``kg-microbe-function``; 4,209 GO terms, 41% of PREGO's taxon→GO
+edges comparable), fold enrichment *rises* with score across the
+continuous channel: 0.94x → 0.96x → 1.04x → 1.19x. The flat channels sit
+at 2.19x.
 
-Coverage is the main caveat and is deliberately reported alongside every
-result: only ~1% of PREGO's taxon→GO edges are comparable, over 70 shared
-GO terms. A calibration fitted on that slice should not be extrapolated to
-the whole graph without a broader gold standard.
+Against **metatraits + madin_etal** (trait-derived; 78 GO terms, ~1%
+comparable), it *falls*: 1.61x → 1.59x → 1.56x, with the flat channels at
+1.00x.
+
+The reversal is a provenance-alignment artifact, not a contradiction.
+UniProt annotations come from genome annotation, and PREGO's flat channels
+are genome-derived (JGI IMG, Struo-GTDB) — so they agree with each other
+for reasons unrelated to whether either is right. metatraits is
+trait/literature-derived and aligns better with PREGO's environmental
+channel. **Each gold standard flatters the PREGO channel that shares its
+provenance.** Any single-gold-standard verdict on this score should be
+treated as provisional.
+
+What both agree on: the effect is weak. Fold enrichment spans roughly
+1.0–1.2x across the continuous channel's whole score range, so the score
+is at best a soft quality signal, and thresholding on it is not a strong
+quality lever in either direction.
+
+Separately, the score tracks evidence volume: a GO term's edge count
+correlates with its mean score at Spearman +0.26, driven by rare terms
+scoring low (mean 0.67 in the lowest-ubiquity decile vs ~2.0 everywhere
+above). Raising a threshold therefore strips rare, specific annotations
+first — a coverage bias worth knowing about independent of quality.
 """
 
 from __future__ import annotations
@@ -141,27 +157,60 @@ def enrichment_by_window(
     """
     if windows <= 0:
         raise ValueError("windows must be positive")
-    rows = sorted(scored, key=lambda r: r[0])
-    if not rows:
+    if not scored:
         return []
-    size = max(1, len(rows) // windows)
+    # Aggregate by exact score first. Slicing a sorted list by index splits a
+    # tie block across the boundary, and then *which* tied rows land either
+    # side is decided by the sort's tiebreak rather than by the score. That
+    # is not hypothetical: an earlier ad-hoc analysis sorted (score, is_hit)
+    # tuples, which pushed every non-hit to the low side of the 4.0 block and
+    # every hit to the high side, manufacturing a 0.44x window next to a
+    # 1.95x one out of pure ordering. Windows must break only where the score
+    # actually changes.
+    by_score: Dict[float, List[int]] = {}
+    for score, hit in scored:
+        slot = by_score.setdefault(score, [0, 0])
+        slot[0] += 1
+        slot[1] += 1 if hit else 0
+
+    total = sum(v[0] for v in by_score.values())
+    target = total / windows
     out: List[Dict[str, float]] = []
-    for i in range(windows):
-        lo = i * size
-        hi = len(rows) if i == windows - 1 else min(len(rows), (i + 1) * size)
-        window = rows[lo:hi]
-        if not window:
-            continue
-        rate = sum(1 for _, hit in window if hit) / len(window)
+    n = h = 0
+    lo = hi = None
+    for score in sorted(by_score):
+        count, hits = by_score[score]
+        if lo is None:
+            lo = score
+        hi = score
+        n += count
+        h += hits
+        if n >= target and len(out) < windows - 1:
+            rate = h / n
+            out.append(
+                {
+                    "window": len(out) + 1,
+                    "score_min": lo,
+                    "score_max": hi,
+                    "n": n,
+                    "hit_rate": rate,
+                    "fold": fold_enrichment(rate, baseline),
+                    "degenerate": lo == hi,
+                }
+            )
+            n = h = 0
+            lo = None
+    if n:
+        rate = h / n
         out.append(
             {
-                "window": i + 1,
-                "score_min": window[0][0],
-                "score_max": window[-1][0],
-                "n": len(window),
+                "window": len(out) + 1,
+                "score_min": lo,
+                "score_max": hi,
+                "n": n,
                 "hit_rate": rate,
                 "fold": fold_enrichment(rate, baseline),
-                "degenerate": window[0][0] == window[-1][0],
+                "degenerate": lo == hi,
             }
         )
     return out
@@ -172,9 +221,10 @@ def is_monotone_increasing(results: Sequence[Dict[str, float]]) -> bool:
     Return whether fold enrichment rises with score across non-degenerate windows.
 
     This is the property a usable confidence score must have: a higher score
-    should mean a higher chance of agreeing with curated knowledge. PREGO's
-    does not, which is why this predicate exists — to make the failure
-    checkable rather than a matter of opinion.
+    should mean a higher chance of agreeing with curated knowledge. Whether
+    PREGO's has it depends on the gold standard — rising against UniProt,
+    falling against metatraits — so this predicate exists to make the
+    question checkable per gold standard rather than a matter of opinion.
 
     Degenerate (all-ties) windows are excluded; their ordering is arbitrary.
 

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -50,26 +50,21 @@ The observations are not independent — edges reuse the same taxa, GO terms
 and resources — so clustered intervals are needed before any ordering of
 these point estimates is called directional.
 
-**The score does discriminate — but on environmental edges, not functional
-ones.** Everything above concerns ``NCBITaxon -capable_of-> GO``. Tested
-instead against BacDive isolation sources (``ENVO -location_of-> strain``,
-lifted to taxon), PREGO's ``ENVO -location_of-> NCBITaxon`` edges enrich
-sharply with score: 3.26x, 12.58x, 17.03x across the top three windows,
-7.89x overall. It survives controlling for ENVO-term degree — 18 of 19
-terms with >=100 comparable edges show the higher-score half agreeing more,
-pooled 0.211 vs 0.331 within-term, a 1.57x ratio.
+**Status of the predicate hypothesis: NOT ESTABLISHED.** An earlier version of
+this docstring stated that the score discriminates on ``location_of`` edges and
+not on ``capable_of`` ones, citing 1.57x (18/19 ENVO terms) and 1.94x (7/9 BTO
+terms). Those figures came from a within-term split that used an index median
+and therefore split tied scores; tie-safe boundaries give 1.49x (18/20) and
+1.69x (6/8). BTO is also not an independent replication — it projects the same
+BacDive isolation source as ENVO.
 
-The same holds for the other ``location_of`` edge type. ``BTO
--location_of-> NCBITaxon`` edges, validated against BacDive host anatomy
-(joined through the BTO xrefs already present in ``uberon_nodes.tsv``),
-enrich 3.86x overall and 1.94x within-term (7 of 9 BTO terms).
+Under matched taxa *and* matched label policy the contrast largely dissolves:
+interaction +0.281, two-way clustered 95% CI [-0.237, +0.624], 82.5% one-sided.
+Both predicates show weak positive discrimination (1.40 and 1.12) and the
+difference between them is not distinguishable from zero.
 
-So the split is by **predicate**, not by edge type: the score discriminates
-on ``location_of`` (two independent edge types agree) and not on
-``capable_of``. The mechanism fits — PREGO's score counts taxon-sample
-co-occurrence, which is direct evidence for "this organism is found in
-location X" and only indirect evidence for "this organism can perform
-function Y".
+See ``docs/PREGO_SCORE_VALIDATION.md`` for the full record, including the
+corrections list. Do not cite the withdrawn figures.
 
 Separately, the score tracks evidence volume: a GO term's edge count
 correlates with its mean score at Spearman +0.26, driven by rare terms

--- a/scripts/prego_validation/README.md
+++ b/scripts/prego_validation/README.md
@@ -1,0 +1,41 @@
+# PREGO score validation scripts
+
+Reproduce the measurements in [`docs/PREGO_SCORE_VALIDATION.md`](../../docs/PREGO_SCORE_VALIDATION.md).
+
+These are **analysis scripts, not pipeline code** — they read transform output and
+merged KGs, write nothing into `data/`, and are kept so the findings can be
+re-derived when the PREGO archives are refreshed (`lab42open-team/prego_daemons`
+recomputes them periodically) or when a better gold standard appears.
+
+The reusable measurement API lives in
+`kg_microbe/transform_utils/prego/quality.py` and is tested in
+`tests/test_prego_quality.py`. These scripts predate parts of that module and
+inline some of the same logic; prefer the module for new work.
+
+| script | builds / measures | runtime | reads |
+|---|---|---|---|
+| `build_uniprot_gold.py` | taxon→GO gold from UniProt proteomes | ~25 min | `data/merged/20250222_function/` (28.6 GB) |
+| `build_assay_gold.py` | taxon→GO gold **with negatives** from BacDive assays | seconds | `data/transformed/bacdive/` |
+| `fold_enrichment_go.py` | fold enrichment vs the UniProt gold, tie-safe windows | ~8 min | `data/transformed/prego/` (7.4 GB) |
+| `precision_assay_go.py` | precision + lift vs labelled assay evidence | ~8 min | as above |
+| `fold_enrichment_envo.py` | fold enrichment of ENVO edges vs BacDive isolation sources | ~2 min | as above |
+| `fold_enrichment_bto.py` | fold enrichment of BTO edges vs BacDive host anatomy | ~2 min | as above |
+| `ubiquity_check.py` | Spearman corr. of GO-term degree vs mean score | ~8 min | as above |
+
+Run order: build the gold standards first (they pickle to `/tmp`), then the
+measurements.
+
+## Two traps these scripts exist to document
+
+**Tie splitting.** An earlier version sorted `(score, is_hit)` tuples and sliced
+by index. Because the sort tiebreak decided which tied rows fell either side of a
+window boundary, it pushed every non-hit below the 4.0 block and every hit above
+it — fabricating a 0.44x window adjacent to a 1.95x one out of pure ordering.
+Windows must break only where the score changes; `quality.enrichment_by_window`
+does this correctly.
+
+**Baseline choice.** Fold enrichment here uses a uniform subject × object null,
+which controls for neither taxon annotation depth nor term ubiquity (#698). The
+**within-term stratified ratios** are what address that confound — the raw fold
+numbers do not. Where labelled negatives exist (the assay standard), prefer
+precision, which needs no null at all.

--- a/scripts/prego_validation/build_assay_gold.py
+++ b/scripts/prego_validation/build_assay_gold.py
@@ -1,0 +1,61 @@
+"""Build a taxon->GO gold standard WITH NEGATIVES from BacDive assay results.
+
+BacDive records assay outcomes with polarity — METPO:2000302 "shows activity of"
+and METPO:2000303 "does not show activity of" — so chaining
+
+    strain -(polarity)-> assay -has_output-> GO
+
+and lifting strain to NCBITaxon via subclass_of yields both positives and
+negatives. That is what makes precision measurable without a null model, unlike
+every other gold standard available in-graph.
+
+Pairs where one strain tested positive and another negative for the same species
+are recorded as conflicting and must be excluded by the consumer: picking a side
+would invent evidence.
+
+Writes /tmp/assay_gold.pkl as {(taxon, go): [n_pos, n_neg]}.
+"""
+import pickle
+from collections import defaultdict
+
+EDGES = "data/transformed/bacdive/edges.tsv"
+POS, NEG = "METPO:2000302", "METPO:2000303"
+
+assay_go, strain_tax = {}, {}
+strain_assays = defaultdict(list)
+with open(EDGES) as fh:
+    next(fh)
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) < 3:
+            continue
+        s, p, o = f[0], f[1], f[2]
+        if s.startswith("kgmicrobe.assay:") and p == "biolink:has_output" and o.startswith("GO:"):
+            assay_go.setdefault(s, set()).add(o)
+        elif s.startswith("kgmicrobe.strain:") and p == "biolink:subclass_of" and o.startswith("NCBITaxon:"):
+            strain_tax[s] = o
+        elif p in (POS, NEG) and o.startswith("kgmicrobe.assay:"):
+            strain_assays[s].append((o, p))
+
+print(f"  assays with a GO output : {len(assay_go):,}")
+print(f"  strain->NCBITaxon links : {len(strain_tax):,}")
+print(f"  strains with +/- results: {len(strain_assays):,}")
+
+tri = defaultdict(lambda: [0, 0])
+for strain, results in strain_assays.items():
+    taxon = strain_tax.get(strain)
+    if not taxon:
+        continue
+    for assay, polarity in results:
+        for go in assay_go.get(assay, ()):
+            tri[(taxon, go)][0 if polarity == POS else 1] += 1
+
+pos = sum(1 for v in tri.values() if v[0] and not v[1])
+neg = sum(1 for v in tri.values() if v[1] and not v[0])
+mix = sum(1 for v in tri.values() if v[0] and v[1])
+print(f"\n  (taxon,GO) pairs with assay evidence: {len(tri):,}")
+print(f"    unanimous POSITIVE : {pos:,}")
+print(f"    unanimous NEGATIVE : {neg:,}")
+print(f"    conflicting        : {mix:,}  (exclude — one strain +, another -)")
+print(f"  distinct taxa {len({k[0] for k in tri}):,}  distinct GO {len({k[1] for k in tri}):,}")
+pickle.dump(dict(tri), open("/tmp/assay_gold.pkl", "wb"))

--- a/scripts/prego_validation/build_uniprot_gold.py
+++ b/scripts/prego_validation/build_uniprot_gold.py
@@ -1,0 +1,60 @@
+"""
+Build a taxon->GO gold standard from UniProt proteome annotations.
+
+Joins `protein -derives_from-> NCBITaxon` with `protein -participates_in|located_in-> GO`.
+Rows are grouped by protein, so this needs no protein->taxon dict.
+"""
+import pickle
+
+FUNC = "data/merged/20250222_function/merged/kg-microbe-function/merged-kg_edges.tsv"
+PREGO = "data/transformed/prego/edges.tsv"
+
+# ---- pass 1: PREGO's entity space (bounds everything downstream) ----
+ptaxa, pgos = set(), set()
+with open(PREGO) as fh:
+    h = next(fh).rstrip("\n").split("\t")
+    si, oi = h.index("subject"), h.index("object")
+    for line in fh:
+        f = line.split("\t", oi + 1)
+        if len(f) <= oi: continue
+        s, o = f[si], f[oi]
+        if s.startswith("NCBITaxon:") and o.startswith("GO:"):
+            ptaxa.add(int(s[10:])); pgos.add(int(o[3:]))
+print(f"  prego taxa {len(ptaxa):,}  prego GO {len(pgos):,}", flush=True)
+
+# ---- pass 2: UniProt gold, restricted to PREGO's space ----
+GO_PREDS = ("biolink:participates_in", "biolink:located_in")
+gold = {}
+cur = None; cur_go = []; cur_tax = None
+n_pairs = 0
+
+def flush():
+    global n_pairs
+    if cur_tax is not None and cur_tax in ptaxa and cur_go:
+        s = gold.setdefault(cur_tax, set())
+        for g in cur_go:
+            if g in pgos and g not in s:
+                s.add(g); n_pairs += 1
+
+with open(FUNC) as fh:
+    next(fh)
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) < 3: continue
+        subj, pred, obj = f[0], f[1], f[2]
+        if not subj.startswith("UniprotKB:"): continue
+        if subj != cur:
+            flush(); cur = subj; cur_go = []; cur_tax = None
+        if pred == "biolink:derives_from" and obj.startswith("NCBITaxon:"):
+            try: cur_tax = int(obj[10:])
+            except ValueError: pass
+        elif pred in GO_PREDS and obj.startswith("GO:"):
+            try: cur_go.append(int(obj[3:]))
+            except ValueError: pass
+flush()
+
+gtaxa = set(gold)
+ggos = set()
+for s in gold.values(): ggos |= s
+print(f"  UNIPROT GOLD: {n_pairs:,} pairs | taxa {len(gtaxa):,} | GO {len(ggos):,}", flush=True)
+pickle.dump((gold, gtaxa, ggos), open("/tmp/uniprot_gold.pkl", "wb"), protocol=4)

--- a/scripts/prego_validation/fold_enrichment_bto.py
+++ b/scripts/prego_validation/fold_enrichment_bto.py
@@ -1,0 +1,100 @@
+"""Fold enrichment of PREGO BTO -location_of-> NCBITaxon vs BacDive host anatomy.
+
+BacDive records host/tissue isolation against UBERON and CL, not BTO. The
+crosswalk is already in-repo: 1,645 anatomy terms in the ontologies output carry
+BTO xrefs. This is the same reverse-lookup the prego transform uses for
+DOID->MONDO, so no new mapping is needed — an earlier assessment wrongly
+concluded these edges were untestable.
+"""
+from collections import defaultdict
+
+u2b = defaultdict(set)
+with open("data/transformed/ontologies/uberon_nodes.tsv") as fh:
+    h = next(fh).rstrip("\n").split("\t")
+    xi = h.index("xref")
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) <= xi or "BTO:" not in f[xi]:
+            continue
+        for x in f[xi].split("|"):
+            if x.startswith("BTO:"):
+                u2b[f[0]].add(x)
+print(f"  crosswalk: {len(u2b):,} anatomy terms -> {len({b for v in u2b.values() for b in v}):,} BTO terms")
+
+strain_tax, anat_strain = {}, []
+with open("data/transformed/bacdive/edges.tsv") as fh:
+    next(fh)
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) < 3:
+            continue
+        s, p, o = f[0], f[1], f[2]
+        if s.startswith("kgmicrobe.strain:") and p == "biolink:subclass_of" and o.startswith("NCBITaxon:"):
+            strain_tax[s] = o
+        elif p == "biolink:location_of" and o.startswith("kgmicrobe.strain:") and s.split(":")[0] in ("UBERON", "CL"):
+            anat_strain.append((s, o))
+gold = set()
+for anat, strain in anat_strain:
+    taxon = strain_tax.get(strain)
+    if taxon:
+        for bto in u2b.get(anat, ()):
+            gold.add((bto, taxon))
+gbto = {b for b, _ in gold}
+gtax = {t for _, t in gold}
+print(f"  gold: {len(gold):,} BTO->taxon pairs ({len(gbto):,} BTO, {len(gtax):,} taxa)")
+
+per_term = defaultdict(list)
+agg = defaultdict(lambda: [0, 0])
+shared_bto, shared_tax = set(), set()
+n = 0
+with open("data/transformed/prego/edges.tsv") as fh:
+    h = next(fh).rstrip("\n").split("\t")
+    si, oi, sci = h.index("subject"), h.index("object"), h.index("prego_score")
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) <= sci:
+            continue
+        s, o = f[si], f[oi]
+        if not (s.startswith("BTO:") and o.startswith("NCBITaxon:")):
+            continue
+        n += 1
+        if s in gbto:
+            shared_bto.add(s)
+        if o in gtax:
+            shared_tax.add(o)
+        if s in gbto and o in gtax:
+            try:
+                v = float(f[sci])
+            except ValueError:
+                continue
+            hit = (s, o) in gold
+            slot = agg[round(v, 4)]
+            slot[0] += 1
+            slot[1] += 1 if hit else 0
+            per_term[s].append((v, hit))
+
+comp = sum(v[0] for v in agg.values())
+hits = sum(v[1] for v in agg.values())
+# Baseline over the SHARED entity space, per the TISSUES protocol: gold
+# terms PREGO never mentions are not part of the space it selects from, and
+# including them deflates the null and inflates every fold figure.
+base = sum(1 for b, t in gold if b in shared_bto and t in shared_tax) / (len(shared_bto) * len(shared_tax))
+print(f"  prego BTO edges {n:,} | comparable {comp:,} ({100 * comp / n:.2f}%)")
+print(f"  baseline {base:.5f} | overall fold {(hits / comp) / base:.2f}x")
+
+up = dn = lo_h = lo_n = hi_h = hi_n = 0
+for _term, rows in per_term.items():
+    if len(rows) < 30:
+        continue
+    rows.sort(key=lambda r: r[0])
+    mid = len(rows) // 2
+    lo, hi = rows[:mid], rows[mid:]
+    a = sum(1 for _, x in lo if x) / len(lo)
+    b = sum(1 for _, x in hi if x) / len(hi)
+    lo_h += sum(1 for _, x in lo if x)
+    lo_n += len(lo)
+    hi_h += sum(1 for _, x in hi if x)
+    hi_n += len(hi)
+    up, dn = (up + 1, dn) if b > a else (up, dn + 1)
+print(f"\n  within-term (>=30 edges): {up + dn} terms, higher-score half agrees MORE in {up}")
+print(f"    pooled low {lo_h / lo_n:.4f} vs high {hi_h / hi_n:.4f} -> {(hi_h / hi_n) / (lo_h / lo_n):.2f}x")

--- a/scripts/prego_validation/fold_enrichment_bto.py
+++ b/scripts/prego_validation/fold_enrichment_bto.py
@@ -87,7 +87,15 @@ for _term, rows in per_term.items():
     if len(rows) < 30:
         continue
     rows.sort(key=lambda r: r[0])
+    # Tie-safe boundary: move the split to the next score change. An index
+    # median splits a tie block, letting sort order rather than the score
+    # decide which rows land in which half — the same defect fixed in
+    # quality.enrichment_by_window. It materially moved these numbers.
     mid = len(rows) // 2
+    while mid < len(rows) and rows[mid][0] == rows[mid - 1][0]:
+        mid += 1
+    if mid == 0 or mid >= len(rows):
+        continue
     lo, hi = rows[:mid], rows[mid:]
     a = sum(1 for _, x in lo if x) / len(lo)
     b = sum(1 for _, x in hi if x) / len(hi)

--- a/scripts/prego_validation/fold_enrichment_envo.py
+++ b/scripts/prego_validation/fold_enrichment_envo.py
@@ -1,6 +1,6 @@
 """Fold enrichment of PREGO ENVO -location_of-> NCBITaxon vs BacDive isolation sources.
 
-This is the edge type where the score works. Also prints the threshold curve
+Prints the threshold curve
 (precision and retention at candidate cutoffs) and the within-ENVO-term
 stratified ratio, which is what controls for term degree — the raw fold numbers
 do not (see #698).
@@ -58,7 +58,7 @@ labelled.sort()
 all_scores.sort()
 n_all = len(all_scores)
 print(f"  comparable {len(labelled):,} of {n_all:,} ENVO edges | baseline {base:.5f}\n")
-print(f"  {'>= T':>6} {'precision':>10} {'fold':>8} {'kept':>10} {'kept %':>8}")
+print(f"  {'>= T':>6} {'overlap':>10} {'fold':>8} {'kept':>10} {'kept %':>8}")
 for t in (0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0):
     sub = [h for v, h in labelled if v >= t]
     if not sub:

--- a/scripts/prego_validation/fold_enrichment_envo.py
+++ b/scripts/prego_validation/fold_enrichment_envo.py
@@ -72,7 +72,15 @@ for _term, rows in per_term.items():
     if len(rows) < 100:
         continue
     rows.sort(key=lambda r: r[0])
+    # Tie-safe boundary: move the split to the next score change. An index
+    # median splits a tie block, letting sort order rather than the score
+    # decide which rows land in which half — the same defect fixed in
+    # quality.enrichment_by_window. It materially moved these numbers.
     mid = len(rows) // 2
+    while mid < len(rows) and rows[mid][0] == rows[mid - 1][0]:
+        mid += 1
+    if mid == 0 or mid >= len(rows):
+        continue
     lo, hi = rows[:mid], rows[mid:]
     a = sum(1 for _, x in lo if x) / len(lo)
     b = sum(1 for _, x in hi if x) / len(hi)

--- a/scripts/prego_validation/fold_enrichment_envo.py
+++ b/scripts/prego_validation/fold_enrichment_envo.py
@@ -1,0 +1,85 @@
+"""Fold enrichment of PREGO ENVO -location_of-> NCBITaxon vs BacDive isolation sources.
+
+This is the edge type where the score works. Also prints the threshold curve
+(precision and retention at candidate cutoffs) and the within-ENVO-term
+stratified ratio, which is what controls for term degree — the raw fold numbers
+do not (see #698).
+"""
+import bisect
+from collections import defaultdict
+
+strain_tax, env_strain = {}, []
+with open("data/transformed/bacdive/edges.tsv") as fh:
+    next(fh)
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) < 3:
+            continue
+        s, p, o = f[0], f[1], f[2]
+        if s.startswith("kgmicrobe.strain:") and p == "biolink:subclass_of" and o.startswith("NCBITaxon:"):
+            strain_tax[s] = o
+        elif s.startswith("ENVO:") and p == "biolink:location_of" and o.startswith("kgmicrobe.strain:"):
+            env_strain.append((s, o))
+gold = {(e, strain_tax[s]) for e, s in env_strain if s in strain_tax}
+genv = {e for e, _ in gold}
+gtax = {t for _, t in gold}
+print(f"  gold: {len(gold):,} ENVO->taxon pairs ({len(genv):,} ENVO, {len(gtax):,} taxa)")
+
+labelled, all_scores = [], []
+per_term = defaultdict(list)
+shared_env, shared_tax = set(), set()
+with open("data/transformed/prego/edges.tsv") as fh:
+    h = next(fh).rstrip("\n").split("\t")
+    si, oi, sci = h.index("subject"), h.index("object"), h.index("prego_score")
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) <= sci:
+            continue
+        s, o = f[si], f[oi]
+        if not (s.startswith("ENVO:") and o.startswith("NCBITaxon:")):
+            continue
+        try:
+            v = float(f[sci])
+        except ValueError:
+            continue
+        all_scores.append(v)
+        if s in genv:
+            shared_env.add(s)
+        if o in gtax:
+            shared_tax.add(o)
+        if s in genv and o in gtax:
+            hit = (s, o) in gold
+            labelled.append((v, hit))
+            per_term[s].append((v, hit))
+
+# Baseline over the SHARED entity space, per the TISSUES protocol.
+base = sum(1 for e, t in gold if e in shared_env and t in shared_tax) / (len(shared_env) * len(shared_tax))
+labelled.sort()
+all_scores.sort()
+n_all = len(all_scores)
+print(f"  comparable {len(labelled):,} of {n_all:,} ENVO edges | baseline {base:.5f}\n")
+print(f"  {'>= T':>6} {'precision':>10} {'fold':>8} {'kept':>10} {'kept %':>8}")
+for t in (0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0):
+    sub = [h for v, h in labelled if v >= t]
+    if not sub:
+        continue
+    p = sum(sub) / len(sub)
+    kept = n_all - bisect.bisect_left(all_scores, t)
+    print(f"  {t:>6.2f} {p:>10.4f} {p / base:>7.2f}x {kept:>10,} {100 * kept / n_all:>7.2f}%")
+
+up = dn = lo_h = lo_n = hi_h = hi_n = 0
+for _term, rows in per_term.items():
+    if len(rows) < 100:
+        continue
+    rows.sort(key=lambda r: r[0])
+    mid = len(rows) // 2
+    lo, hi = rows[:mid], rows[mid:]
+    a = sum(1 for _, x in lo if x) / len(lo)
+    b = sum(1 for _, x in hi if x) / len(hi)
+    lo_h += sum(1 for _, x in lo if x)
+    lo_n += len(lo)
+    hi_h += sum(1 for _, x in hi if x)
+    hi_n += len(hi)
+    up, dn = (up + 1, dn) if b > a else (up, dn + 1)
+print(f"\n  within-term (>=100 edges): {up + dn} terms, higher-score half agrees MORE in {up}")
+print(f"    pooled low {lo_h / lo_n:.4f} vs high {hi_h / hi_n:.4f} -> {(hi_h / hi_n) / (lo_h / lo_n):.2f}x")

--- a/scripts/prego_validation/fold_enrichment_go.py
+++ b/scripts/prego_validation/fold_enrichment_go.py
@@ -1,0 +1,57 @@
+"""Fold enrichment with tie-safe windows (boundaries only fall on score changes)."""
+import pickle
+from collections import defaultdict
+
+gold, gtaxa, ggos = pickle.load(open("/tmp/uniprot_gold.pkl", "rb"))
+
+def is_cont(ch):
+    p = ch.split()
+    return len(p) == 4 and p[1] == "of" and p[3] == "samples" and p[0].isdigit()
+
+# score -> [n, hits], per channel. Aggregating by exact score keeps ties atomic.
+agg = {"continuous": defaultdict(lambda: [0, 0]), "flat": defaultdict(lambda: [0, 0])}
+stax, sgos = set(), set()
+n = 0
+with open("data/transformed/prego/edges.tsv") as fh:
+    h = next(fh).rstrip("\n").split("\t")
+    si, oi, sci, chi = h.index("subject"), h.index("object"), h.index("prego_score"), h.index("prego_channel")
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) <= max(sci, chi): continue
+        s, o = f[si], f[oi]
+        if not (s.startswith("NCBITaxon:") and o.startswith("GO:")): continue
+        n += 1
+        try: t = int(s[10:]); g = int(o[3:]); v = float(f[sci])
+        except ValueError: continue
+        if t in gtaxa: stax.add(t)
+        if g in ggos: sgos.add(g)
+        if t in gtaxa and g in ggos:
+            key = "continuous" if is_cont(f[chi]) else "flat"
+            slot = agg[key][round(v, 4)]
+            slot[0] += 1
+            slot[1] += 1 if g in gold.get(t, ()) else 0
+
+base = sum(len(gold[t] & sgos) for t in stax if t in gold) / (len(stax) * len(sgos))
+print(f"  baseline {base:.5f} | shared taxa {len(stax):,} GO {len(sgos):,}\n")
+
+for name in ("continuous", "flat"):
+    d = agg[name]
+    if not d: continue
+    total = sum(v[0] for v in d.values()); hits = sum(v[1] for v in d.values())
+    print(f"  === {name}: {total:,} pairs, hit rate {hits/total:.4f}, fold {(hits/total)/base:.2f}x")
+    print(f"    {'window':>7} {'score range':>20} {'n':>11} {'hit rate':>9} {'fold':>7}  note")
+    target = total / 5
+    cn = ch_ = 0; lo = None; prev = None; w = 0
+    for sv in sorted(d):
+        cnt, hh = d[sv]
+        if lo is None: lo = sv
+        cn += cnt; ch_ += hh; prev = sv
+        if cn >= target and w < 4:
+            w += 1
+            note = "TIED — ordering artifact, ignore" if lo == prev else ""
+            print(f"    {w:>7} {lo:>9.3f}-{prev:<9.3f} {cn:>11,} {ch_/cn:>8.4f} {(ch_/cn)/base:>6.2f}x  {note}")
+            cn = ch_ = 0; lo = None
+    if cn:
+        note = "TIED — ordering artifact, ignore" if lo == prev else ""
+        print(f"    {w+1:>7} {lo:>9.3f}-{prev:<9.3f} {cn:>11,} {ch_/cn:>8.4f} {(ch_/cn)/base:>6.2f}x  {note}")
+    print()

--- a/scripts/prego_validation/precision_assay_go.py
+++ b/scripts/prego_validation/precision_assay_go.py
@@ -1,0 +1,69 @@
+"""
+Direct precision test: do PREGO's high-score edges hit assay-POSITIVE pairs?
+
+Assay evidence gives labelled negatives, so precision is measurable without
+any null model — sidestepping the Cartesian-baseline confound entirely.
+BacDive phenotype assays are also provenance-disjoint from both UniProt
+(genome annotation) and metatraits (trait curation).
+"""
+import pickle
+from collections import defaultdict
+
+tri = pickle.load(open("/tmp/assay_gold.pkl", "rb"))
+# Unanimous labels only; conflicting strain-level evidence is excluded.
+label = {}
+for k, (p, n) in tri.items():
+    if p and not n: label[k] = 1
+    elif n and not p: label[k] = 0
+
+def is_cont(ch):
+    q = ch.split()
+    return len(q) == 4 and q[1] == "of" and q[3] == "samples" and q[0].isdigit()
+
+agg = {"continuous": defaultdict(lambda: [0, 0]), "flat": defaultdict(lambda: [0, 0])}
+n = matched = 0
+with open("data/transformed/prego/edges.tsv") as fh:
+    h = next(fh).rstrip("\n").split("\t")
+    si, oi, sci, chi = h.index("subject"), h.index("object"), h.index("prego_score"), h.index("prego_channel")
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) <= max(sci, chi): continue
+        s, o = f[si], f[oi]
+        if not (s.startswith("NCBITaxon:") and o.startswith("GO:")): continue
+        n += 1
+        lab = label.get((s, o))
+        if lab is None: continue
+        matched += 1
+        try: v = float(f[sci])
+        except ValueError: continue
+        slot = agg["continuous" if is_cont(f[chi]) else "flat"][round(v, 4)]
+        slot[0] += 1
+        slot[1] += lab
+
+print(f"  prego taxon->GO edges          : {n:,}")
+print(f"  with unanimous assay evidence  : {matched:,} ({100*matched/n:.3f}%)")
+print(f"  assay labels available         : {len(label):,} "
+      f"({sum(label.values()):,} positive / {len(label)-sum(label.values()):,} negative)\n")
+
+for name in ("continuous", "flat"):
+    d = agg[name]
+    tot = sum(v[0] for v in d.values())
+    if not tot: continue
+    hits = sum(v[1] for v in d.values())
+    print(f"  === {name}: {tot:,} labelled edges | precision {hits/tot:.4f}")
+    print(f"    {'window':>7} {'score range':>20} {'n':>9} {'precision':>10}  note")
+    target = tot / 5
+    cn = ch_ = 0; lo = prev = None; w = 0
+    for sv in sorted(d):
+        c, hh = d[sv]
+        if lo is None: lo = sv
+        cn += c; ch_ += hh; prev = sv
+        if cn >= target and w < 4:
+            w += 1
+            note = "TIED" if lo == prev else ""
+            print(f"    {w:>7} {lo:>9.3f}-{prev:<9.3f} {cn:>9,} {ch_/cn:>9.4f}  {note}")
+            cn = ch_ = 0; lo = None
+    if cn:
+        note = "TIED" if lo == prev else ""
+        print(f"    {w+1:>7} {lo:>9.3f}-{prev:<9.3f} {cn:>9,} {ch_/cn:>9.4f}  {note}")
+    print()

--- a/scripts/prego_validation/predicate_interaction.py
+++ b/scripts/prego_validation/predicate_interaction.py
@@ -1,0 +1,201 @@
+"""Does the score behave differently for location_of vs capable_of, on matched taxa?
+
+The headline verdict — score discriminates on `location_of`, not on `capable_of` —
+was measured with a different gold standard per predicate, so predicate was
+confounded with benchmark ascertainment, coverage (0.1%-41.5%) and taxon degree.
+External review downgraded it to plausible-but-unproven and named this analysis
+as the cheapest way to settle it.
+
+Design, chosen to remove those confounds rather than adjust for them:
+
+* **Matched taxa.** Only taxa carrying BOTH a BacDive isolation record and a
+  BacDive assay result are used, so both predicates are judged on the same
+  organisms drawn from the same resource.
+* **Within-term.** The high/low score comparison happens inside a term, so term
+  identity cannot drive it. Boundaries are tie-safe — an index median lets sort
+  order decide which tied rows fall in which half, which is exactly the defect
+  that inflated the published BTO figure.
+* **Degree-stratified.** Comparisons are additionally confined to a taxon-degree
+  decile, closing the path where the high-score half simply holds better-covered
+  taxa (measured: BTO 23.10 vs 18.73, ENVO 91.64 vs 70.67).
+* **Two-way clustered bootstrap.** Taxa and terms are resampled together, since
+  edges reuse both. iid intervals are optimistic here.
+
+Reports the high/low ratio per predicate with clustered CIs, and the interaction
+(their difference). A confidently positive interaction supports the verdict; one
+whose interval spans zero does not.
+"""
+
+import pickle
+import random
+from collections import defaultdict
+
+BACDIVE = "data/transformed/bacdive/edges.tsv"
+PREGO = "data/transformed/prego/edges.tsv"
+UBERON = "data/transformed/ontologies/uberon_nodes.tsv"
+POS, NEG = "METPO:2000302", "METPO:2000303"
+BOOTSTRAP = 400
+SEED = 20260806
+
+
+def build_location_gold():
+    """Return (gold pairs, term set, taxon set) for ENVO+BTO isolation records."""
+    u2b = defaultdict(set)
+    with open(UBERON) as fh:
+        h = next(fh).rstrip("\n").split("\t")
+        xi = h.index("xref")
+        for line in fh:
+            f = line.rstrip("\n").split("\t")
+            if len(f) > xi and "BTO:" in f[xi]:
+                for x in f[xi].split("|"):
+                    if x.startswith("BTO:"):
+                        u2b[f[0]].add(x)
+    strain_tax, hits = {}, []
+    with open(BACDIVE) as fh:
+        next(fh)
+        for line in fh:
+            f = line.rstrip("\n").split("\t")
+            if len(f) < 3:
+                continue
+            s, p, o = f[0], f[1], f[2]
+            if s.startswith("kgmicrobe.strain:") and p == "biolink:subclass_of" and o.startswith("NCBITaxon:"):
+                strain_tax[s] = o
+            elif p == "biolink:location_of" and o.startswith("kgmicrobe.strain:"):
+                hits.append((s, o))
+    gold = set()
+    for term, strain in hits:
+        taxon = strain_tax.get(strain)
+        if not taxon:
+            continue
+        if term.startswith("ENVO:"):
+            gold.add((term, taxon))
+        elif term.split(":")[0] in ("UBERON", "CL"):
+            for bto in u2b.get(term, ()):
+                gold.add((bto, taxon))
+    return gold, {t for t, _ in gold}, {x for _, x in gold}
+
+
+def build_function_labels():
+    """Return {(taxon, GO): bool} from unanimous BacDive assay results."""
+    tri = pickle.load(open("/tmp/assay_gold.pkl", "rb"))
+    out = {}
+    for key, (pos, neg) in tri.items():
+        if pos and not neg:
+            out[key] = True
+        elif neg and not pos:
+            out[key] = False
+    return out
+
+
+def collect(loc_gold, loc_terms, loc_taxa, fn_labels, taxa):
+    """Return per-predicate {term: [(score, hit, taxon)]} restricted to ``taxa``."""
+    obs = {"location_of": defaultdict(list), "capable_of": defaultdict(list)}
+    with open(PREGO) as fh:
+        h = next(fh).rstrip("\n").split("\t")
+        si, oi, sci = h.index("subject"), h.index("object"), h.index("prego_score")
+        for line in fh:
+            f = line.rstrip("\n").split("\t")
+            if len(f) <= sci:
+                continue
+            s, o = f[si], f[oi]
+            try:
+                score = float(f[sci])
+            except ValueError:
+                continue
+            if (s.startswith("ENVO:") or s.startswith("BTO:")) and o.startswith("NCBITaxon:"):
+                if o in taxa and s in loc_terms and o in loc_taxa:
+                    obs["location_of"][s].append((score, (s, o) in loc_gold, o))
+            elif s.startswith("NCBITaxon:") and o.startswith("GO:") and s in taxa:
+                lab = fn_labels.get((s, o))
+                if lab is not None:
+                    obs["capable_of"][o].append((score, lab, s))
+    return obs
+
+
+def ratio(per_term, degree, keep_taxa=None, keep_terms=None):
+    """Return the pooled high/low hit-rate ratio, tie-safe and degree-stratified."""
+    lo_h = lo_n = hi_h = hi_n = 0
+    for term, rows in per_term.items():
+        if keep_terms is not None and term not in keep_terms:
+            continue
+        rows = [r for r in rows if keep_taxa is None or r[2] in keep_taxa]
+        by_dec = defaultdict(list)
+        for score, hit, taxon in rows:
+            by_dec[degree.get(taxon, 0)].append((score, hit))
+        for stratum in by_dec.values():
+            if len(stratum) < 10:
+                continue
+            stratum.sort(key=lambda r: r[0])
+            mid = len(stratum) // 2
+            while mid < len(stratum) and stratum[mid][0] == stratum[mid - 1][0]:
+                mid += 1
+            if mid == 0 or mid >= len(stratum):
+                continue
+            lo, hi = stratum[:mid], stratum[mid:]
+            lo_h += sum(1 for _, x in lo if x)
+            lo_n += len(lo)
+            hi_h += sum(1 for _, x in hi if x)
+            hi_n += len(hi)
+    if not lo_n or not hi_n or not lo_h:
+        return None, lo_n + hi_n
+    return (hi_h / hi_n) / (lo_h / lo_n), lo_n + hi_n
+
+
+def main():
+    """Run the matched-taxa predicate-by-score interaction analysis."""
+    loc_gold, loc_terms, loc_taxa = build_location_gold()
+    fn_labels = build_function_labels()
+    fn_taxa = {t for t, _ in fn_labels}
+    matched = loc_taxa & fn_taxa
+    print(f"  taxa with isolation records : {len(loc_taxa):,}")
+    print(f"  taxa with assay results     : {len(fn_taxa):,}")
+    print(f"  MATCHED (used below)        : {len(matched):,}\n")
+
+    obs = collect(loc_gold, loc_terms, loc_taxa, fn_labels, matched)
+    # Taxon degree = number of comparable observations, decile-binned.
+    counts = defaultdict(int)
+    for per_term in obs.values():
+        for rows in per_term.values():
+            for _s, _h, taxon in rows:
+                counts[taxon] += 1
+    ordered = sorted(counts, key=lambda t: counts[t])
+    degree = {t: (10 * i) // max(1, len(ordered)) for i, t in enumerate(ordered)}
+
+    point = {}
+    for pred, per_term in obs.items():
+        r, n = ratio(per_term, degree)
+        point[pred] = r
+        terms = sum(1 for rows in per_term.values() if rows)
+        print(f"  {pred:<12} terms {terms:>4} | in-stratum n {n:>7,} | high/low ratio "
+              f"{'n/a' if r is None else f'{r:.3f}'}")
+
+    if point["location_of"] is None or point["capable_of"] is None:
+        print("\n  insufficient matched data for an interaction estimate")
+        return
+
+    rng = random.Random(SEED)
+    all_taxa, diffs = sorted(matched), []
+    for _ in range(BOOTSTRAP):
+        tx = set(rng.choices(all_taxa, k=len(all_taxa)))
+        vals = {}
+        for pred, per_term in obs.items():
+            terms = sorted(per_term)
+            tm = set(rng.choices(terms, k=len(terms))) if terms else set()
+            vals[pred], _ = ratio(per_term, degree, keep_taxa=tx, keep_terms=tm)
+        if vals["location_of"] and vals["capable_of"]:
+            diffs.append(vals["location_of"] - vals["capable_of"])
+    diffs.sort()
+    obs_diff = point["location_of"] - point["capable_of"]
+    print(f"\n  INTERACTION (location_of ratio - capable_of ratio): {obs_diff:+.3f}")
+    if len(diffs) >= 20:
+        lo = diffs[int(0.025 * len(diffs))]
+        hi = diffs[int(0.975 * len(diffs))]
+        print(f"  two-way clustered 95% CI over {len(diffs)} resamples: [{lo:+.3f}, {hi:+.3f}]")
+        print(f"  fraction of resamples with location_of > capable_of: "
+              f"{sum(1 for d in diffs if d > 0) / len(diffs):.3f}")
+        print("\n  -> " + ("supports the predicate split" if lo > 0 else
+                           "CI spans zero; the split is NOT established on matched taxa"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prego_validation/predicate_interaction.py
+++ b/scripts/prego_validation/predicate_interaction.py
@@ -75,19 +75,38 @@ def build_location_gold():
     return gold, {t for t, _ in gold}, {x for _, x in gold}
 
 
-def build_function_labels():
-    """Return {(taxon, GO): bool} from unanimous BacDive assay results."""
+def build_function_labels(positive_only: bool):
+    """
+    Return function labels from unanimous BacDive assay results.
+
+    Two policies, because the label policy is itself a confound. The location
+    gold is positive-only — a pair absent from BacDive isolation is *unknown*,
+    but the hit-rate calculation necessarily counts it as a miss. The function
+    gold has explicit negatives, and pairs with no assay evidence are excluded
+    rather than counted.
+
+    ``positive_only=True`` recasts function to match location exactly: keep only
+    the positives as the gold set, and count any comparable pair not in it as a
+    miss. That makes the two predicates' label semantics identical, which is the
+    last confound the matched-taxa design does not remove.
+
+    :param positive_only: Whether to discard the explicit negatives.
+    :return: (labels dict or gold set, gold terms, gold taxa).
+    """
     tri = pickle.load(open("/tmp/assay_gold.pkl", "rb"))
-    out = {}
+    pos_pairs, labels = set(), {}
     for key, (pos, neg) in tri.items():
         if pos and not neg:
-            out[key] = True
+            pos_pairs.add(key)
+            labels[key] = True
         elif neg and not pos:
-            out[key] = False
-    return out
+            labels[key] = False
+    if positive_only:
+        return pos_pairs, {g for _, g in pos_pairs}, {t for t, _ in pos_pairs}
+    return labels, {g for _, g in labels}, {t for t, _ in labels}
 
 
-def collect(loc_gold, loc_terms, loc_taxa, fn_labels, taxa):
+def collect(loc_gold, loc_terms, loc_taxa, fn, fn_terms, fn_taxa_all, taxa, positive_only):
     """Return per-predicate {term: [(score, hit, taxon)]} restricted to ``taxa``."""
     obs = {"location_of": defaultdict(list), "capable_of": defaultdict(list)}
     with open(PREGO) as fh:
@@ -106,9 +125,15 @@ def collect(loc_gold, loc_terms, loc_taxa, fn_labels, taxa):
                 if o in taxa and s in loc_terms and o in loc_taxa:
                     obs["location_of"][s].append((score, (s, o) in loc_gold, o))
             elif s.startswith("NCBITaxon:") and o.startswith("GO:") and s in taxa:
-                lab = fn_labels.get((s, o))
-                if lab is not None:
-                    obs["capable_of"][o].append((score, lab, s))
+                if positive_only:
+                    # Same semantics as location: comparable if both endpoints are
+                    # in the gold entity space; absent from the gold set = miss.
+                    if s in fn_taxa_all and o in fn_terms:
+                        obs["capable_of"][o].append((score, (s, o) in fn, s))
+                else:
+                    lab = fn.get((s, o))
+                    if lab is not None:
+                        obs["capable_of"][o].append((score, lab, s))
     return obs
 
 
@@ -141,17 +166,22 @@ def ratio(per_term, degree, keep_taxa=None, keep_terms=None):
     return (hi_h / hi_n) / (lo_h / lo_n), lo_n + hi_n
 
 
-def main():
-    """Run the matched-taxa predicate-by-score interaction analysis."""
+def main(positive_only: bool = False):
+    """
+    Run the matched-taxa predicate-by-score interaction analysis.
+
+    :param positive_only: Recast function labels to match location's
+        positive-only policy, removing the last unmatched confound.
+    """
     loc_gold, loc_terms, loc_taxa = build_location_gold()
-    fn_labels = build_function_labels()
-    fn_taxa = {t for t, _ in fn_labels}
+    fn, fn_terms, fn_taxa = build_function_labels(positive_only)
     matched = loc_taxa & fn_taxa
+    print(f"  label policy: {'POSITIVE-ONLY (matched to location)' if positive_only else 'positives + explicit negatives'}")
     print(f"  taxa with isolation records : {len(loc_taxa):,}")
     print(f"  taxa with assay results     : {len(fn_taxa):,}")
     print(f"  MATCHED (used below)        : {len(matched):,}\n")
 
-    obs = collect(loc_gold, loc_terms, loc_taxa, fn_labels, matched)
+    obs = collect(loc_gold, loc_terms, loc_taxa, fn, fn_terms, fn_taxa, matched, positive_only)
     # Taxon degree = number of comparable observations, decile-binned.
     counts = defaultdict(int)
     for per_term in obs.values():
@@ -198,4 +228,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+
+    main(positive_only="--positive-only" in sys.argv)

--- a/scripts/prego_validation/ubiquity_check.py
+++ b/scripts/prego_validation/ubiquity_check.py
@@ -1,0 +1,56 @@
+"""
+Test whether PREGO's score measures ubiquity rather than confidence.
+
+Hypothesis: the environmental-samples score rewards co-occurrence frequency,
+so a GO term attached to many taxa (generic, ubiquitous) scores higher than a
+specific one. If true, thresholding up selects generic annotations.
+
+Prediction: within the continuous channel, a GO term's taxon degree should
+correlate POSITIVELY with its mean score.
+"""
+from collections import defaultdict
+
+
+def is_cont(ch):
+    p = ch.split()
+    return len(p) == 4 and p[1] == "of" and p[3] == "samples" and p[0].isdigit()
+
+deg = defaultdict(int)      # GO -> distinct taxa (approximated by edge count)
+tot = defaultdict(float)    # GO -> summed score
+with open("data/transformed/prego/edges.tsv") as fh:
+    h = next(fh).rstrip("\n").split("\t")
+    si, oi, sci, chi = h.index("subject"), h.index("object"), h.index("prego_score"), h.index("prego_channel")
+    for line in fh:
+        f = line.rstrip("\n").split("\t")
+        if len(f) <= max(sci, chi): continue
+        if not (f[si].startswith("NCBITaxon:") and f[oi].startswith("GO:")): continue
+        if not is_cont(f[chi]): continue
+        try: sc = float(f[sci])
+        except ValueError: continue
+        deg[f[oi]] += 1
+        tot[f[oi]] += sc
+
+rows = [(deg[g], tot[g] / deg[g], g) for g in deg if deg[g] >= 50]
+rows.sort()
+print(f"  GO terms with >=50 continuous-channel edges: {len(rows):,}\n")
+print(f"  {'ubiquity decile':>15} {'degree range':>22} {'terms':>7} {'mean score':>11}")
+k = len(rows) // 10
+for d in range(10):
+    lo, hi = d * k, (d + 1) * k if d < 9 else len(rows)
+    w = rows[lo:hi]
+    if not w: continue
+    ms = sum(r[1] for r in w) / len(w)
+    print(f"  {d+1:>15} {w[0][0]:>9,}-{w[-1][0]:<11,} {len(w):>7,} {ms:>10.3f}")
+
+# Spearman-ish: rank correlation between degree and mean score
+n = len(rows)
+by_deg = sorted(range(n), key=lambda i: rows[i][0])
+by_scr = sorted(range(n), key=lambda i: rows[i][1])
+rd = [0]*n; rs = [0]*n
+for r, i in enumerate(by_deg): rd[i] = r
+for r, i in enumerate(by_scr): rs[i] = r
+mean_d = mean_s = (n - 1) / 2
+num = sum((rd[i]-mean_d)*(rs[i]-mean_s) for i in range(n))
+den = (sum((rd[i]-mean_d)**2 for i in range(n)) * sum((rs[i]-mean_s)**2 for i in range(n))) ** 0.5
+print(f"\n  Spearman rank correlation (GO degree vs mean score): {num/den:+.4f}")
+print("    positive => score tracks ubiquity, supporting the hypothesis")

--- a/tests/resources/prego/database_pairs.tsv
+++ b/tests/resources/prego/database_pairs.tsv
@@ -9,3 +9,15 @@
 -2	562	-25	BTO:0000763	BioProject	PMID:12345680	3	TRUE	
 -2	1000570	-2	9606	JGI IMG	Human	4	TRUE	
 badrow_with_only_three_columns	x	y
+-2	100	-21	GO:0005000	MGnify	1 of 20 samples	0.2	TRUE	
+-2	100	-21	GO:0005001	MGnify	2 of 20 samples	0.4	TRUE	
+-2	100	-21	GO:0005002	MGnify	3 of 20 samples	0.6	TRUE	
+-2	100	-21	GO:0005003	MGnify	4 of 20 samples	0.8	TRUE	
+-2	100	-21	GO:0005004	MGnify	5 of 20 samples	1.2	TRUE	
+-2	100	-21	GO:0005005	MGnify	6 of 20 samples	1.71	TRUE	
+-2	100	-21	GO:0005006	MGnify	7 of 20 samples	1.71	TRUE	
+-2	100	-21	GO:0005007	MGnify	8 of 20 samples	1.71	TRUE	
+-2	100	-21	GO:0005008	MGnify	9 of 20 samples	2.4	TRUE	
+-2	100	-21	GO:0005009	MGnify	10 of 20 samples	3.2	TRUE	
+-2	100	-21	GO:0005010	MGnify	11 of 20 samples	4.0	TRUE	
+-2	100	-21	GO:0005011	MGnify	12 of 20 samples	4.0	TRUE	

--- a/tests/test_prego_calibration.py
+++ b/tests/test_prego_calibration.py
@@ -259,3 +259,26 @@ def test_build_cutoffs_validates_before_inverting():
     """A bad tau must fail before any histogram work."""
     with pytest.raises(ValueError):
         build_cutoffs({"MGnify": _hist([1.0, 2.0])}, tau=STAR_MAX + 1)
+
+
+def test_cap_tie_block_makes_the_threshold_stop_discriminating():
+    """
+    A resource piled up at the cap plateaus instead of honouring the request.
+
+    Measured on the real archives: MG-RAST amplicon holds 46.4% of its rows
+    at the score cap, so every threshold above ~2.5 retains that same 46.4%
+    rather than the requested fraction. Ties are deliberately never split,
+    so this is correct behaviour — but it means the knob silently stops
+    responding, which the transform has to warn about.
+    """
+    # 46% of rows at the cap, the rest spread below it.
+    h = _hist([4.0] * 460 + [i / 540.0 * 2.0 for i in range(540)])
+    for tau in (2.5, 3.0, 3.5):
+        row = h.as_row("MG-RAST amplicon study", tau)
+        realized = float(row["kept_fraction"])
+        requested = 1.0 - tau / STAR_MAX
+        assert realized >= 0.46, "the capped block must survive intact"
+        assert realized > requested + 0.05, (
+            f"tau={tau} should over-retain (realized {realized:.3f} vs requested {requested:.3f}), "
+            "which is what the transform warns about"
+        )

--- a/tests/test_prego_calibration.py
+++ b/tests/test_prego_calibration.py
@@ -163,14 +163,24 @@ def test_scores_above_the_documented_cap_are_binned():
 # ---------------------------------------------------------------------------
 
 
-def test_flat_channels_survive_below_their_tier_and_drop_above():
-    """A flat channel is all-or-nothing at its constant."""
+def test_flat_channel_rows_are_rated_by_their_own_score():
+    """
+    A recognised flat channel is thresholded on the row's own value.
+
+    Its score is already on the star axis, so it is used directly rather
+    than substituting the channel's documented constant. Overriding would
+    silently promote a row that disagrees with its channel — the fixture
+    has Isolates rows scoring 3, and a constant-substituting implementation
+    rated them 4.
+    """
     cutoffs = {"MGnify": 2.0}
-    assert keep_row("Isolates", 4.0, "MGnify", cutoffs, tau=3.0) is True
-    assert keep_row("PMID:1", 3.0, "MGnify", cutoffs, tau=3.0) is True
-    # PMID sits at 3.0, so a 3.5 threshold must drop it while Isolates stays.
-    assert keep_row("PMID:1", 3.0, "MGnify", cutoffs, tau=3.5) is False
     assert keep_row("Isolates", 4.0, "MGnify", cutoffs, tau=3.5) is True
+    # An Isolates row that actually scores 3 must not be promoted to 4.
+    assert keep_row("Isolates", 3.0, "MGnify", cutoffs, tau=3.5) is False
+    assert star_for_row("Isolates", 3.0, "MGnify", cutoffs) == 3.0
+    # PMID sits at 3.0, so a 3.5 threshold drops it.
+    assert keep_row("PMID:1", 3.0, "MGnify", cutoffs, tau=3.0) is True
+    assert keep_row("PMID:1", 3.0, "MGnify", cutoffs, tau=3.5) is False
 
 
 def test_continuous_rows_are_judged_against_their_own_resource():

--- a/tests/test_prego_calibration.py
+++ b/tests/test_prego_calibration.py
@@ -1,0 +1,251 @@
+"""
+Tests for per-resource PREGO confidence calibration.
+
+The failure this module exists to prevent is subtle: a global cutoff on
+``prego_score`` looks like a confidence filter but behaves as a provenance
+filter, because ~47% of PREGO edges carry a flat author-assigned constant
+(4.0 for the genome channels, 3.0 for PMID rows) while only the
+Environmental Samples channel has a score that varies. At ``>= 4.0`` a
+global cut keeps essentially all of the flat rows and deletes ~87% of the
+one channel carrying real signal.
+
+These tests therefore pin behaviour, not just arithmetic: that flat channels
+are tiered rather than ranked, that ties at the score cap move as a unit,
+and that cutoffs do not depend on row order.
+"""
+
+import pytest
+
+from kg_microbe.transform_utils.prego.calibration import (
+    STAR_MAX,
+    ScoreHistogram,
+    build_cutoffs,
+    estimate_retention,
+    flat_channel_star,
+    is_continuous_channel,
+    keep_row,
+    star_for_row,
+    validate_tau,
+)
+
+# Channel shares measured over all 44,716,161 emitted PREGO edges.
+MEASURED_FLAT_SHARES = {
+    "Isolates": 0.2866,
+    "Genome annotation": 0.0917,
+    "Metagenome-Assembled Genome": 0.0727,
+    "Single Amplified Genome": 0.0179,
+    "PMID:12345678": 0.0005,
+}
+MEASURED_CONTINUOUS_SHARE = 0.5300
+
+
+# ---------------------------------------------------------------------------
+# Channel classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "channel",
+    ["402 of 487 samples", "1 of 1597 samples", "12183 of 40405 samples"],
+)
+def test_evidence_tally_is_the_continuous_channel(channel):
+    """Environmental Samples rows are identified by their tally shape."""
+    assert is_continuous_channel(channel)
+    assert flat_channel_star(channel) is None
+
+
+@pytest.mark.parametrize(
+    "channel,expected",
+    [
+        ("Isolates", 4.0),
+        ("Genome annotation", 4.0),
+        ("Metagenome-Assembled Genome", 4.0),
+        ("Single Amplified Genome", 4.0),
+        ("PMID:24914180", 3.0),
+    ],
+)
+def test_flat_channels_get_their_author_assigned_tier(channel, expected):
+    """
+    Flat channels carry a constant assigned by PREGO's authors.
+
+    These are tiers, not measurements — every row in the channel has the
+    same value, so there is nothing within the channel to threshold on.
+    """
+    assert flat_channel_star(channel) == expected
+    assert not is_continuous_channel(channel)
+
+
+def test_unrecognised_channel_is_neither():
+    """An unknown channel must not be silently coerced into a tier."""
+    assert flat_channel_star("Kidneys") is None or isinstance(flat_channel_star("Kidneys"), float)
+    assert not is_continuous_channel("Kidneys")
+
+
+# ---------------------------------------------------------------------------
+# Histogram / cutoff inversion
+# ---------------------------------------------------------------------------
+
+
+def _hist(scores):
+    """Build a histogram from an iterable of scores."""
+    h = ScoreHistogram()
+    for s in scores:
+        h.add(s)
+    return h
+
+
+def test_cutoff_retains_the_requested_fraction():
+    """tau=2.0 must keep about the top half of a uniform resource."""
+    h = _hist(i / 1000.0 * 4.0 for i in range(1000))
+    cut = h.cutoff(2.0)
+    kept = sum(1 for i in range(1000) if i / 1000.0 * 4.0 >= cut)
+    assert 0.49 <= kept / 1000 <= 0.51
+
+
+def test_tau_zero_keeps_everything():
+    """The most permissive setting must not drop rows."""
+    h = _hist([0.0, 1.0, 2.0, 3.0, 4.0])
+    assert h.cutoff(0.0) == 0.0
+
+
+def test_cutoff_is_order_independent():
+    """
+    Two runs over the same data must produce an identical cutoff.
+
+    This is why fixed-width histograms are used instead of t-digest or
+    P-square: those are order-dependent, so a re-run could silently ship a
+    different edge set.
+    """
+    # Same multiset, two orders — built by a stride permutation rather than
+    # an RNG so the test itself is deterministic.
+    scores = [(i % 4001) / 1000.0 for i in range(5000)]
+    reordered = [scores[(i * 37) % 5000] for i in range(5000)]
+    assert sorted(scores) == sorted(reordered), "reordering must preserve the multiset"
+    assert scores != reordered, "the two orders must actually differ"
+    assert _hist(scores).cutoff(2.5) == _hist(reordered).cutoff(2.5)
+
+
+def test_tie_block_at_the_cap_moves_as_a_unit():
+    """
+    Rows sharing the capped score must be kept or dropped together.
+
+    ~13% of the real continuous channel piles up at the cap. Splitting that
+    block would delete some edges and keep others with identical evidence.
+    """
+    h = _hist([4.0] * 300 + [1.0] * 700)
+    cut = h.cutoff(2.0)
+    # Every capped row lands on the same side of the cutoff.
+    assert (4.0 >= cut) is True
+    kept_capped = sum(1 for _ in range(300) if 4.0 >= cut)
+    assert kept_capped in (0, 300)
+
+
+def test_empty_histogram_refuses_to_produce_a_cutoff():
+    """A resource with no rows must fail loudly rather than return 0."""
+    with pytest.raises(ValueError):
+        ScoreHistogram().cutoff(2.0)
+
+
+def test_scores_above_the_documented_cap_are_binned():
+    """
+    The shipped data reaches 4.00735, above the paper's stated cap of 4.
+
+    Binning to exactly 4.0 would silently clamp those rows into the top bin
+    and misreport the distribution.
+    """
+    h = _hist([4.00735, 4.0, 3.0])
+    assert h.count == 3
+    assert h.cutoff(0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Row-level keep/drop
+# ---------------------------------------------------------------------------
+
+
+def test_flat_channels_survive_below_their_tier_and_drop_above():
+    """A flat channel is all-or-nothing at its constant."""
+    cutoffs = {"MGnify": 2.0}
+    assert keep_row("Isolates", 4.0, "MGnify", cutoffs, tau=3.0) is True
+    assert keep_row("PMID:1", 3.0, "MGnify", cutoffs, tau=3.0) is True
+    # PMID sits at 3.0, so a 3.5 threshold must drop it while Isolates stays.
+    assert keep_row("PMID:1", 3.0, "MGnify", cutoffs, tau=3.5) is False
+    assert keep_row("Isolates", 4.0, "MGnify", cutoffs, tau=3.5) is True
+
+
+def test_continuous_rows_are_judged_against_their_own_resource():
+    """
+    Continuous rows are judged against their own resource's cutoff.
+
+    Per-resource cutoffs are the point: a shared cutoff would conflate
+    MGnify with MG-RAST, whose score marginals differ.
+    """
+    cutoffs = {"MGnify": 1.0, "MG-RAST metagenome study": 3.0}
+    assert keep_row("10 of 20 samples", 2.0, "MGnify", cutoffs, tau=4.0) is True
+    assert keep_row("10 of 20 samples", 2.0, "MG-RAST metagenome study", cutoffs, tau=4.0) is False
+
+
+def test_uncalibratable_row_is_kept_not_dropped():
+    """
+    An unknown channel must not be deleted.
+
+    Dropping rows we cannot calibrate would remove data for a reason
+    unrelated to confidence — the exact failure mode this module prevents.
+    """
+    assert keep_row("Kidneys", 4.0, "unknown", {}, tau=2.0) is True
+    assert star_for_row("Kidneys", 4.0, "unknown", {}) is None
+
+
+def test_continuous_row_with_no_cutoff_for_its_resource_is_kept():
+    """A resource missing from the calibration table must not silently vanish."""
+    assert keep_row("10 of 20 samples", 2.0, "BrandNewResource", {}, tau=2.0) is True
+
+
+# ---------------------------------------------------------------------------
+# Retention model — checked against the measured distribution
+# ---------------------------------------------------------------------------
+
+
+def test_default_tau_lands_inside_the_75_percent_budget():
+    """
+    tau=2.0 must retain ~73.5% of edges on the real channel shares.
+
+    Independently derived: 47.00% flat + (53.00% x 50%) = 73.50%, and the
+    continuous channel's measured p50 is raw score 1.71.
+    """
+    retained = estimate_retention(MEASURED_FLAT_SHARES, 2.0, MEASURED_CONTINUOUS_SHARE)
+    assert 0.73 <= retained <= 0.745
+    assert retained <= 0.75
+
+
+def test_retention_is_monotone_decreasing_in_tau():
+    """A stricter threshold can never retain more."""
+    values = [estimate_retention(MEASURED_FLAT_SHARES, t / 2, MEASURED_CONTINUOUS_SHARE) for t in range(9)]
+    assert values == sorted(values, reverse=True)
+
+
+def test_tau_four_is_provenance_dominated():
+    """
+    At tau=4.0 the flat channels dominate what survives.
+
+    This is the failure mode the design exists to avoid, so it must be
+    detectable — a caller can compare these two numbers to decide whether
+    to warn.
+    """
+    retained = estimate_retention(MEASURED_FLAT_SHARES, 4.0, MEASURED_CONTINUOUS_SHARE)
+    flat_only = sum(s for c, s in MEASURED_FLAT_SHARES.items() if (flat_channel_star(c) or 0) >= 4.0)
+    assert retained == pytest.approx(flat_only, abs=1e-9)
+    assert flat_only / retained > 0.99
+
+
+@pytest.mark.parametrize("bad", [-0.1, 4.1, float("nan"), float("inf")])
+def test_out_of_range_threshold_is_refused(bad):
+    """Above STAR_MAX every channel drops out; refuse rather than emit nothing."""
+    with pytest.raises(ValueError):
+        validate_tau(bad)
+
+
+def test_build_cutoffs_validates_before_inverting():
+    """A bad tau must fail before any histogram work."""
+    with pytest.raises(ValueError):
+        build_cutoffs({"MGnify": _hist([1.0, 2.0])}, tau=STAR_MAX + 1)

--- a/tests/test_prego_calibration.py
+++ b/tests/test_prego_calibration.py
@@ -19,6 +19,7 @@ import pytest
 from kg_microbe.transform_utils.prego.calibration import (
     STAR_MAX,
     ScoreHistogram,
+    _bin_index,
     build_cutoffs,
     estimate_retention,
     flat_channel_star,
@@ -173,7 +174,7 @@ def test_flat_channel_rows_are_rated_by_their_own_score():
     has Isolates rows scoring 3, and a constant-substituting implementation
     rated them 4.
     """
-    cutoffs = {"MGnify": 2.0}
+    cutoffs = {"MGnify": _bin_index(2.0)}
     assert keep_row("Isolates", 4.0, "MGnify", cutoffs, tau=3.5) is True
     # An Isolates row that actually scores 3 must not be promoted to 4.
     assert keep_row("Isolates", 3.0, "MGnify", cutoffs, tau=3.5) is False
@@ -190,7 +191,10 @@ def test_continuous_rows_are_judged_against_their_own_resource():
     Per-resource cutoffs are the point: a shared cutoff would conflate
     MGnify with MG-RAST, whose score marginals differ.
     """
-    cutoffs = {"MGnify": 1.0, "MG-RAST metagenome study": 3.0}
+    # Cutoffs are BIN INDICES, not raw scores: the filter and the calibration
+    # table have to compare on the same quantity, and a bin's lower edge can
+    # exceed the scores inside it for ~11.5% of representable 4-dp values.
+    cutoffs = {"MGnify": _bin_index(1.0), "MG-RAST metagenome study": _bin_index(3.0)}
     assert keep_row("10 of 20 samples", 2.0, "MGnify", cutoffs, tau=4.0) is True
     assert keep_row("10 of 20 samples", 2.0, "MG-RAST metagenome study", cutoffs, tau=4.0) is False
 

--- a/tests/test_prego_quality.py
+++ b/tests/test_prego_quality.py
@@ -3,10 +3,10 @@ Tests for fold-enrichment measurement of PREGO scores.
 
 This module exists because the percentile calibration equalizes rank, not
 quality, and the difference is not rhetorical: measured against curated
-taxon→GO annotations, PREGO's score turns out to be *anti*-correlated with
-agreement. These tests pin the measurement machinery that established that,
-so the finding stays checkable and can be re-run against a better gold
-standard.
+taxon→GO annotations the direction of the score/agreement relationship is
+**gold-standard dependent** — falling against the trait-derived benchmark,
+rising against UniProt. These tests pin the measurement machinery, so the
+question stays checkable and can be re-run against a better gold standard.
 """
 
 import pytest
@@ -145,9 +145,12 @@ def test_monotonicity_ignores_degenerate_windows():
     Otherwise the flat channels' arbitrary tie ordering would flip the
     answer at random.
     """
-    scored = [(0.1, False)] * 25 + [(0.5, True)] * 25 + [(4.0, False)] * 50
+    # Two windows where the score varies, plus a dominant tie block.
+    varied = [(i / 200.0, i >= 25) for i in range(50)]
+    scored = varied + [(4.0, False)] * 50
     results = enrichment_by_window(scored, baseline=0.5, windows=4)
     assert any(r["degenerate"] for r in results), "fixture must produce a tied window"
+    assert sum(1 for r in results if not r["degenerate"]) >= 2, "and >=2 usable windows"
     # Verdict rests only on the windows where the score actually varies.
     assert is_monotone_increasing(results)
 
@@ -195,3 +198,24 @@ def test_tie_split_cannot_be_faked_by_hit_ordering():
     a = enrichment_by_window(block_sorted, baseline=0.5, windows=4)
     b = enrichment_by_window(block_reversed, baseline=0.5, windows=4)
     assert [r["fold"] for r in a] == [r["fold"] for r in b]
+
+
+def test_all_degenerate_is_insufficient_data_not_success():
+    """
+    A fully tied channel has no score ordering, so monotonicity is undefined.
+
+    ``all()`` over an empty sequence is vacuously true, so filtering out every
+    degenerate window and then calling ``all()`` reported a channel with zero
+    usable comparisons as monotonically increasing.
+    """
+    results = enrichment_by_window([(4.0, i < 10) for i in range(100)], baseline=0.1, windows=5)
+    assert all(r["degenerate"] for r in results)
+    assert is_monotone_increasing(results) is False
+
+
+def test_single_usable_window_is_also_insufficient():
+    """One window is not a comparison either."""
+    scored = [(0.1, True)] * 10 + [(4.0, False)] * 90
+    results = enrichment_by_window(scored, baseline=0.1, windows=5)
+    assert sum(1 for r in results if not r["degenerate"]) < 2
+    assert is_monotone_increasing(results) is False

--- a/tests/test_prego_quality.py
+++ b/tests/test_prego_quality.py
@@ -69,16 +69,30 @@ def test_fold_refuses_a_zero_baseline():
         fold_enrichment(0.5, 0.0)
 
 
-def test_windows_are_equal_count_not_equal_width():
+def test_windows_are_equal_count_where_the_score_varies():
     """
-    Equal-count windows are required because scores pile up at the cap.
+    Windows are equal-count, not equal-width.
 
-    Equal-width bins would put most of the mass in a single bin and measure
-    nothing.
+    PREGO's scores pile up at the cap, so equal-width bins would put most of
+    the mass in one bin and measure nothing.
+    """
+    scored = [(i / 100.0, i % 3 == 0) for i in range(100)]
+    results = enrichment_by_window(scored, baseline=0.3, windows=5)
+    assert [r["n"] for r in results] == [20, 20, 20, 20, 20]
+
+
+def test_a_dominant_tie_block_yields_fewer_windows():
+    """
+    Tie-safety outranks hitting the requested window count.
+
+    With 90% of rows sharing one score there is no way to cut five windows
+    without splitting that block, and splitting it would fabricate signal
+    from sort order. Returning fewer, honest windows is the right trade.
     """
     scored = [(0.1, True)] * 10 + [(4.0, False)] * 90
     results = enrichment_by_window(scored, baseline=0.1, windows=5)
-    assert [r["n"] for r in results] == [20, 20, 20, 20, 20]
+    assert len(results) < 5
+    assert sum(r["n"] for r in results) == 100, "no rows may be dropped"
 
 
 def test_tied_window_is_flagged_degenerate():
@@ -112,10 +126,12 @@ def test_monotonicity_predicate_detects_the_prego_failure():
     """
     An anti-correlated score must be reported as failing.
 
-    This is PREGO's measured shape: fold enrichment falls from 1.61x in the
-    lowest continuous-channel quintile to 1.17x in the highest. A threshold
-    on such a score selects edges that agree with curated knowledge less
-    often, so the predicate has to catch it.
+    This is PREGO's shape against the trait-derived gold standard: fold
+    enrichment falls from 1.61x in the lowest continuous-channel quintile to
+    1.56x by the third. (Against UniProt it rises instead — the direction is
+    gold-standard dependent.) A threshold on an anti-correlated score selects
+    edges that agree with curated knowledge less often, so the predicate has
+    to catch that case.
     """
     scored = [(i / 100.0, i < 50) for i in range(100)]
     results = enrichment_by_window(scored, baseline=0.5, windows=2)
@@ -145,3 +161,37 @@ def test_windows_must_be_positive():
     """A non-positive window count is a caller bug, not a silent no-op."""
     with pytest.raises(ValueError):
         enrichment_by_window([(1.0, True)], baseline=0.1, windows=0)
+
+
+def test_windows_never_split_a_tie_block():
+    """
+    A window boundary must fall only where the score changes.
+
+    Slicing a sorted list by index splits a tie block, and which tied rows
+    land either side is then decided by the sort's tiebreak rather than the
+    score. An ad-hoc analysis that sorted ``(score, is_hit)`` tuples did
+    exactly this on the real data: it pushed every non-hit to the low side
+    of the 4.0 block and every hit to the high side, manufacturing a 0.44x
+    window next to a 1.95x one out of pure ordering. Those numbers were
+    reported before the bug was caught.
+    """
+    # 20 varied rows then a 80-row tie block that no boundary may cut.
+    scored = [(i / 100.0, i % 2 == 0) for i in range(20)] + [(4.0, i < 40) for i in range(80)]
+    results = enrichment_by_window(scored, baseline=0.5, windows=5)
+    tied = [r for r in results if r["score_min"] == 4.0 or r["score_max"] == 4.0]
+    assert len(tied) == 1, f"the 4.0 block must live in exactly one window, got {len(tied)}"
+    assert tied[0]["n"] == 80, "the whole tie block belongs to that window"
+    assert tied[0]["degenerate"] is True
+
+
+def test_tie_split_cannot_be_faked_by_hit_ordering():
+    """
+    Ordering hits within a tie block must not change any window's fold.
+
+    This is the direct regression for the artifact above.
+    """
+    block_sorted = [(4.0, False)] * 40 + [(4.0, True)] * 40
+    block_reversed = [(4.0, True)] * 40 + [(4.0, False)] * 40
+    a = enrichment_by_window(block_sorted, baseline=0.5, windows=4)
+    b = enrichment_by_window(block_reversed, baseline=0.5, windows=4)
+    assert [r["fold"] for r in a] == [r["fold"] for r in b]

--- a/tests/test_prego_quality.py
+++ b/tests/test_prego_quality.py
@@ -305,3 +305,20 @@ def test_lift_refuses_a_zero_base_rate():
     """A zero base rate would report infinite lift from nothing."""
     with pytest.raises(ValueError):
         lift(0.5, 0.0)
+
+
+def test_within_stratum_ratio_detects_a_real_signal():
+    """
+    Controlling for term degree is what separates signal from a degree artifact.
+
+    On real data this distinguished two opposite outcomes. For taxon→GO the
+    within-term split ran the wrong way (30 of 47 GO terms had the
+    higher-score half agreeing *less*). For ENVO→taxon it ran strongly the
+    right way — 18 of 19 terms, pooled 0.211 vs 0.331, a 1.57x ratio — so the
+    score genuinely discriminates on environmental edges.
+    """
+    # Higher scores carry more positives within a single stratum.
+    scored = [(i / 100.0, i >= 60) for i in range(100)]
+    results = enrichment_by_window(scored, baseline=0.4, windows=2)
+    assert is_monotone_increasing(results)
+    assert results[-1]["fold"] > results[0]["fold"]

--- a/tests/test_prego_quality.py
+++ b/tests/test_prego_quality.py
@@ -13,9 +13,12 @@ import pytest
 
 from kg_microbe.transform_utils.prego.quality import (
     GoldStandard,
+    LabelledEvidence,
     enrichment_by_window,
     fold_enrichment,
     is_monotone_increasing,
+    lift,
+    precision_by_window,
 )
 
 
@@ -219,3 +222,86 @@ def test_single_usable_window_is_also_insufficient():
     results = enrichment_by_window(scored, baseline=0.1, windows=5)
     assert sum(1 for r in results if not r["degenerate"]) < 2
     assert is_monotone_increasing(results) is False
+
+
+# ---------------------------------------------------------------------------
+# Labelled evidence — precision without a null model
+# ---------------------------------------------------------------------------
+
+
+def test_labelled_evidence_reports_three_states():
+    """Unlabelled must be distinguishable from labelled-negative."""
+    ev = LabelledEvidence(positives=[("T:1", "GO:1")], negatives=[("T:1", "GO:2")])
+    assert ev.label("T:1", "GO:1") is True
+    assert ev.label("T:1", "GO:2") is False
+    assert ev.label("T:1", "GO:9") is None, "unknown is not the same as negative"
+
+
+def test_conflicting_labels_are_refused():
+    """
+    A pair labelled both ways is ambiguous, not merely unknown.
+
+    Real assay data has this: 12,916 (taxon, GO) pairs had one strain testing
+    positive and another negative. Silently picking a side would invent
+    evidence, so construction refuses and the caller must exclude them.
+    """
+    with pytest.raises(ValueError):
+        LabelledEvidence(positives=[("T:1", "GO:1")], negatives=[("T:1", "GO:1")])
+
+
+def test_base_rate_is_measured_not_modelled():
+    """
+    The reference point is the observed positive fraction.
+
+    This is what makes precision free of the uniform-cell assumption that
+    fold enrichment's null carries.
+    """
+    ev = LabelledEvidence(
+        positives=[("T:1", "GO:1"), ("T:2", "GO:1")],
+        negatives=[("T:3", "GO:1"), ("T:4", "GO:1"), ("T:5", "GO:1"), ("T:6", "GO:1")],
+    )
+    assert ev.base_rate() == pytest.approx(2 / 6)
+
+
+def test_base_rate_refuses_empty_evidence():
+    """No labels means no reference point, not a zero one."""
+    with pytest.raises(ValueError):
+        LabelledEvidence([], []).base_rate()
+
+
+def test_precision_windows_are_tie_safe():
+    """Same tie guarantee as the enrichment path."""
+    scored = [(i / 100.0, i % 2 == 0) for i in range(20)] + [(4.0, False)] * 80
+    results = precision_by_window(scored, windows=5)
+    tied = [r for r in results if r["score_min"] == 4.0]
+    assert len(tied) == 1 and tied[0]["n"] == 80
+
+
+def test_precision_is_the_positive_fraction():
+    """Precision must be the raw rate, not scaled by any baseline."""
+    # Six rows per score so the two windows split cleanly on the score change.
+    scored = [(0.1, i < 3) for i in range(6)] + [(0.9, i < 5) for i in range(6)]
+    results = precision_by_window(scored, windows=2)
+    assert [r["n"] for r in results] == [6, 6]
+    assert results[0]["precision"] == pytest.approx(3 / 6)
+    assert results[1]["precision"] == pytest.approx(5 / 6)
+    assert all("hit_rate" not in r for r in results), "precision replaces hit_rate"
+
+
+def test_lift_of_one_means_no_better_than_random():
+    """
+    Lift compares against measured base rate, not a modelled null.
+
+    Measured on real assay data: the continuous channel scored 0.3215 against
+    a 0.3529 base rate — lift 0.91, i.e. slightly worse than picking labelled
+    pairs at random — while the flat channels reached 0.4897, lift 1.39.
+    """
+    assert lift(0.3529, 0.3529) == pytest.approx(1.0)
+    assert lift(0.3215, 0.3529) == pytest.approx(0.911, abs=1e-3)
+    assert lift(0.4897, 0.3529) == pytest.approx(1.388, abs=1e-3)
+
+
+def test_lift_refuses_a_zero_base_rate():
+    """A zero base rate would report infinite lift from nothing."""
+    with pytest.raises(ValueError):
+        lift(0.5, 0.0)

--- a/tests/test_prego_quality.py
+++ b/tests/test_prego_quality.py
@@ -1,0 +1,147 @@
+"""
+Tests for fold-enrichment measurement of PREGO scores.
+
+This module exists because the percentile calibration equalizes rank, not
+quality, and the difference is not rhetorical: measured against curated
+taxon→GO annotations, PREGO's score turns out to be *anti*-correlated with
+agreement. These tests pin the measurement machinery that established that,
+so the finding stays checkable and can be re-run against a better gold
+standard.
+"""
+
+import pytest
+
+from kg_microbe.transform_utils.prego.quality import (
+    GoldStandard,
+    enrichment_by_window,
+    fold_enrichment,
+    is_monotone_increasing,
+)
+
+
+@pytest.fixture()
+def gold():
+    """Return a small curated set over 3 subjects x 2 objects."""
+    return GoldStandard(
+        [
+            ("NCBITaxon:1", "GO:1"),
+            ("NCBITaxon:2", "GO:1"),
+            ("NCBITaxon:3", "GO:2"),
+        ]
+    )
+
+
+def test_entity_space_is_tracked_not_just_pairs(gold):
+    """
+    Comparability is about entities, not only pairs.
+
+    Scoring a pair whose object the gold standard has never seen would count
+    as a miss for a reason unrelated to quality, so the entity space has to
+    be explicit.
+    """
+    assert gold.subjects == {"NCBITaxon:1", "NCBITaxon:2", "NCBITaxon:3"}
+    assert gold.objects == {"GO:1", "GO:2"}
+    assert gold.covers("NCBITaxon:1", "GO:2") is True
+    assert gold.covers("NCBITaxon:1", "GO:99") is False, "unseen object is not comparable"
+    assert gold.contains("NCBITaxon:1", "GO:2") is False, "covered but not asserted"
+
+
+def test_baseline_is_gold_density_over_the_shared_space(gold):
+    """3 curated pairs in a 3x2 space means a random pair hits half the time."""
+    assert gold.baseline({"NCBITaxon:1", "NCBITaxon:2", "NCBITaxon:3"}, {"GO:1", "GO:2"}) == 0.5
+
+
+def test_baseline_refuses_an_empty_shared_space(gold):
+    """No shared entities means fold enrichment is undefined, not zero."""
+    with pytest.raises(ValueError):
+        gold.baseline(set(), {"GO:1"})
+
+
+def test_fold_of_one_means_no_information():
+    """A hit rate equal to the baseline carries no signal."""
+    assert fold_enrichment(0.25, 0.25) == 1.0
+    assert fold_enrichment(0.50, 0.25) == 2.0
+
+
+def test_fold_refuses_a_zero_baseline():
+    """Dividing by a zero baseline would report infinite enrichment from nothing."""
+    with pytest.raises(ValueError):
+        fold_enrichment(0.5, 0.0)
+
+
+def test_windows_are_equal_count_not_equal_width():
+    """
+    Equal-count windows are required because scores pile up at the cap.
+
+    Equal-width bins would put most of the mass in a single bin and measure
+    nothing.
+    """
+    scored = [(0.1, True)] * 10 + [(4.0, False)] * 90
+    results = enrichment_by_window(scored, baseline=0.1, windows=5)
+    assert [r["n"] for r in results] == [20, 20, 20, 20, 20]
+
+
+def test_tied_window_is_flagged_degenerate():
+    """
+    An all-ties window's hit rate reflects arrival order, not score.
+
+    On the real data the flat channels produced windows reading 0.00x and
+    5.00x purely from how ties happened to sort. Those must never be read as
+    signal, so they are flagged.
+    """
+    scored = [(4.0, i < 10) for i in range(100)]
+    results = enrichment_by_window(scored, baseline=0.1, windows=5)
+    assert all(r["degenerate"] for r in results)
+
+
+def test_varying_window_is_not_degenerate():
+    """A window spanning a real score range is usable."""
+    scored = [(i / 100.0, i % 2 == 0) for i in range(100)]
+    results = enrichment_by_window(scored, baseline=0.5, windows=5)
+    assert not any(r["degenerate"] for r in results)
+
+
+def test_monotonicity_predicate_detects_a_good_score():
+    """A score that works has fold enrichment rising with score."""
+    scored = [(i / 100.0, i >= 50) for i in range(100)]
+    results = enrichment_by_window(scored, baseline=0.5, windows=2)
+    assert is_monotone_increasing(results)
+
+
+def test_monotonicity_predicate_detects_the_prego_failure():
+    """
+    An anti-correlated score must be reported as failing.
+
+    This is PREGO's measured shape: fold enrichment falls from 1.61x in the
+    lowest continuous-channel quintile to 1.17x in the highest. A threshold
+    on such a score selects edges that agree with curated knowledge less
+    often, so the predicate has to catch it.
+    """
+    scored = [(i / 100.0, i < 50) for i in range(100)]
+    results = enrichment_by_window(scored, baseline=0.5, windows=2)
+    assert not is_monotone_increasing(results)
+
+
+def test_monotonicity_ignores_degenerate_windows():
+    """
+    Tied windows must not decide the verdict either way.
+
+    Otherwise the flat channels' arbitrary tie ordering would flip the
+    answer at random.
+    """
+    scored = [(0.1, False)] * 25 + [(0.5, True)] * 25 + [(4.0, False)] * 50
+    results = enrichment_by_window(scored, baseline=0.5, windows=4)
+    assert any(r["degenerate"] for r in results), "fixture must produce a tied window"
+    # Verdict rests only on the windows where the score actually varies.
+    assert is_monotone_increasing(results)
+
+
+def test_empty_input_yields_no_windows():
+    """Nothing to measure is not an error."""
+    assert enrichment_by_window([], baseline=0.1) == []
+
+
+def test_windows_must_be_positive():
+    """A non-positive window count is a caller bug, not a silent no-op."""
+    with pytest.raises(ValueError):
+        enrichment_by_window([(1.0, True)], baseline=0.1, windows=0)

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -141,6 +141,26 @@ def test_run_emits_nodes_and_edges(prego_transform: PregoTransform):
     assert len(edges) >= 5, "expected ≥5 emitted edges from the fixture"
 
 
+def test_edges_carry_the_originating_resource(prego_transform: PregoTransform):
+    """
+    The source/resource column must survive onto emitted edges.
+
+    It used to be read and immediately discarded (``del source``), so edges
+    carried ``prego_score`` and ``prego_channel`` but no way to tell which
+    resource produced them. Confidence calibration has to be per-resource —
+    the Environmental Samples channel aggregates MGnify and MG-RAST, whose
+    score marginals differ — so a shared cutoff across them would conflate
+    distributions that are not comparable.
+    """
+    prego_transform.run()
+    edges = _read_tsv(prego_transform.output_edge_file)
+    assert "prego_source" in edges[0], "prego_source missing from the edge header"
+    assert all(e["prego_source"] for e in edges), "every emitted edge must carry its resource"
+    # Passed through verbatim from the fixture's source column, so the values
+    # are real resource names rather than a derived or normalized label.
+    assert {e["prego_source"] for e in edges} == {"BioProject", "JGI IMG"}
+
+
 def test_taxon_to_go_edges_use_capable_of(prego_transform: PregoTransform):
     """NCBITaxon→GO edges use biolink:capable_of, all 3 GO namespaces."""
     prego_transform.run()

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -158,7 +158,7 @@ def test_edges_carry_the_originating_resource(prego_transform: PregoTransform):
     assert all(e["prego_source"] for e in edges), "every emitted edge must carry its resource"
     # Passed through verbatim from the fixture's source column, so the values
     # are real resource names rather than a derived or normalized label.
-    assert {e["prego_source"] for e in edges} == {"BioProject", "JGI IMG"}
+    assert {e["prego_source"] for e in edges} == {"BioProject", "JGI IMG", "MGnify"}
 
 
 def test_taxon_to_go_edges_use_capable_of(prego_transform: PregoTransform):
@@ -166,7 +166,9 @@ def test_taxon_to_go_edges_use_capable_of(prego_transform: PregoTransform):
     prego_transform.run()
     edges = _read_tsv(prego_transform.output_edge_file)
     tax_go = [e for e in edges if e["subject"] == "NCBITaxon:100" and e["object"].startswith("GO:")]
-    assert len(tax_go) == 3, f"expected 3 canonical NCBITaxon:100→GO edges (BP/CC/MF), got {len(tax_go)}"
+    # 3 flat-channel rows (BP/CC/MF) plus the 12 continuous-channel rows that
+    # exercise the calibration path.
+    assert len(tax_go) == 15, f"expected 15 canonical NCBITaxon:100→GO edges, got {len(tax_go)}"
     assert all(e["predicate"] == CAPABLE_OF_PREDICATE for e in tax_go)
 
 
@@ -749,3 +751,62 @@ def test_running_twice_produces_identical_output(prego_input_dir: Path, prego_ou
     nodes = {n["id"] for n in _read_tsv(transform.output_node_file)}
     for edge in _read_tsv(transform.output_edge_file):
         assert edge["subject"] in nodes or edge["object"] in nodes
+
+
+def test_calibration_table_is_written_and_matches_what_ships(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    The calibration table must exist and agree with the emitted edge count.
+
+    This covers three defects that all hid behind the same gap. ``atomic_write``
+    is a context manager; calling it as a plain function returned an un-entered
+    generator, so the table was never written while the run printed that it
+    was. Separately, the table measured retention by histogram bin while the
+    filter measured it by raw score — not interchangeable, since a bin's lower
+    edge can exceed the scores inside it for ~11.5% of representable 4-dp
+    values, including 1.71.
+
+    Neither was caught because the fixture had no continuous-channel rows at
+    all: pass 1 always returned an empty histogram, so the whole
+    histogram → cutoff → filter path was dead in every test.
+    """
+    transform = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, min_confidence=2.0)
+    transform.run(show_status=False)
+
+    assert transform.calibration_table_file.exists(), "the calibration table was not written"
+    lines = [ln for ln in transform.calibration_table_file.read_text().splitlines() if ln.strip()]
+    assert lines[0].split("\t") == ["resource", "n", "tau", "cutoff_score", "kept_fraction"]
+    assert len(lines) > 1, "a resource row is required, not just a header"
+
+    table = {}
+    for line in lines[1:]:
+        resource, n, _tau, _cut, kept = line.split("\t")
+        table[resource] = (int(n), float(kept))
+
+    edges = _read_tsv(transform.output_edge_file)
+    for resource, (n_calibrated, kept_fraction) in table.items():
+        shipped = sum(1 for e in edges if e["prego_source"] == resource and " of " in e["prego_channel"])
+        expected = round(kept_fraction * n_calibrated)
+        assert shipped == expected, (
+            f"{resource}: table claims {kept_fraction:.4f} of {n_calibrated} ({expected} edges) but {shipped} shipped"
+        )
+
+
+def test_default_threshold_drops_no_edges(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    The default must emit exactly what an unfiltered run emits.
+
+    Asserting only that ``min_confidence == 0.0`` is a literal check that would
+    still pass if the default silently dropped most edges — the same
+    assert-one-spelling weakness found twice before in this PR.
+    """
+    baseline = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    baseline.run(show_status=False)
+    unfiltered = len(_read_tsv(baseline.output_edge_file))
+
+    explicit_zero = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, min_confidence=0.0)
+    explicit_zero.run(show_status=False)
+    assert len(_read_tsv(explicit_zero.output_edge_file)) == unfiltered
+
+    filtered = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, min_confidence=4.0)
+    filtered.run(show_status=False)
+    assert len(_read_tsv(filtered.output_edge_file)) < unfiltered, "the knob must actually do something"

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -668,3 +668,57 @@ def test_missing_archives_raises(tmp_path: Path):
     transform = PregoTransform(input_dir=tmp_path / "raw", output_dir=out)
     with pytest.raises(SystemExit, match="no .* archives"):
         transform.run()
+
+
+# ---------------------------------------------------------------------------
+# Confidence thresholding (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_default_threshold_emits_everything(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    The default must be a no-op so existing runs are byte-identical.
+
+    Filtering is opt-in; a transform that started silently dropping edges on
+    upgrade would be far worse than one that needs a flag.
+    """
+    baseline = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    assert baseline.min_confidence == 0.0
+    baseline.run(show_status=False)
+    edges = _read_tsv(baseline.output_edge_file)
+    assert edges, "fixture must emit edges at the default threshold"
+    # No calibration pass runs, so no table is written.
+    assert not baseline.calibration_table_file.exists()
+
+
+def test_threshold_drops_only_rows_below_it(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    Raising the threshold drops flat-channel rows scoring below it.
+
+    The fixture's Isolates rows score 3 and 4, so a 3.5 cut must keep the 4s
+    and drop the 3s — and must do so on each row's own score, not on the
+    channel's documented constant.
+    """
+    baseline = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    baseline.run(show_status=False)
+    all_edges = _read_tsv(baseline.output_edge_file)
+
+    filtered_transform = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, min_confidence=3.5)
+    filtered_transform.run(show_status=False)
+    kept = _read_tsv(filtered_transform.output_edge_file)
+
+    assert len(kept) < len(all_edges), "a 3.5 threshold must drop the score-3 rows"
+    assert kept, "it must not drop everything"
+    assert all(float(e["prego_score"]) >= 3.5 for e in kept)
+
+
+def test_threshold_is_read_from_the_environment(prego_input_dir, prego_output_dir, monkeypatch):
+    """PREGO_MIN_CONFIDENCE configures the run, matching the repo's env-var idiom."""
+    monkeypatch.setenv("PREGO_MIN_CONFIDENCE", "2.5")
+    assert PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir).min_confidence == 2.5
+
+
+def test_out_of_range_threshold_is_refused(prego_input_dir: Path, prego_output_dir: Path):
+    """Above the star ceiling every channel drops out; refuse rather than emit nothing."""
+    with pytest.raises(ValueError):
+        PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, min_confidence=4.5)

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -677,7 +677,11 @@ def test_missing_archives_raises(tmp_path: Path):
 
 def test_default_threshold_emits_everything(prego_input_dir: Path, prego_output_dir: Path):
     """
-    The default must be a no-op so existing runs are byte-identical.
+    The default must leave the emitted edge set unchanged.
+
+    Note this branch also adds a prego_source column, so the files are not
+    byte-identical to a pre-branch run; the invariant is that no edge is
+    dropped at the default threshold.
 
     Filtering is opt-in; a transform that started silently dropping edges on
     upgrade would be far worse than one that needs a flag.
@@ -722,3 +726,26 @@ def test_out_of_range_threshold_is_refused(prego_input_dir: Path, prego_output_d
     """Above the star ceiling every channel drops out; refuse rather than emit nothing."""
     with pytest.raises(ValueError):
         PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, min_confidence=4.5)
+
+
+def test_running_twice_produces_identical_output(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    A second run() on the same instance must not emit a truncated nodes.tsv.
+
+    run() rewrites nodes.tsv from scratch, but the node de-dup set used to
+    persist across runs, so every ID was suppressed as already-seen. The
+    second run left edges whose endpoints had no node row.
+    """
+    transform = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    transform.run(show_status=False)
+    first_nodes = transform.output_node_file.read_text()
+    first_edges = transform.output_edge_file.read_text()
+
+    transform.run(show_status=False)
+    assert transform.output_node_file.read_text() == first_nodes, "nodes.tsv must be reproducible"
+    assert transform.output_edge_file.read_text() == first_edges, "edges.tsv must be reproducible"
+
+    # Every edge endpoint still resolves to a node row emitted by this run.
+    nodes = {n["id"] for n in _read_tsv(transform.output_node_file)}
+    for edge in _read_tsv(transform.output_edge_file):
+        assert edge["subject"] in nodes or edge["object"] in nodes


### PR DESCRIPTION
Prototype for #696. Depends on nothing; unblocks the size reduction in #693.

## Why a global cutoff is wrong — confirmed by PREGO's authors

Not inference. Zafeiropoulos et al. 2022 §2.3, verified against PMC8879827 / Europe PMC XML:

> "All associations extracted from these resources were assigned **arbitrarily a confidence level of four out of five**."

Appendix C.1: *"The Genome Annotation and Isolates channel has **fixed values of scores** depending on the resource."* BioProject/PMID rows get 3/5. **PREGO computes no cross-channel combined score** — the shared (0,5] range is a display convention, and STRING-style integration is listed as unimplemented future work.

Measured over all 44,716,161 edges, a `>= 4.0` cut retains 55.34%, of which **~85% are flat rows carrying no ordering**, while deleting **~87% of the only channel whose score varies**.

## What this adds

`kg_microbe/transform_utils/prego/calibration.py` — the mechanism used by the same lab for TISSUES and DISEASES, and by STRING for its database channel:

```
continuous:  star = 4 * F_r(score)    # empirical CDF within resource r
flat:        star = <author-assigned constant>
keep iff     star >= tau              # one knob, tau in [0, 4]
```

Per-resource because the continuous channel aggregates MGnify and MG-RAST, whose score marginals differ — a shared CDF would conflate them. Both are confirmed present in `data/raw/prego/environmental_samples_extracted/`.

### Retention

| tau | retained |
|---|---:|
| 1.0 | 86.7% |
| 1.5 | 80.1% |
| **2.0** | **73.5%** ← recommended default |
| 3.0 | 60.2% |
| 4.0 | ~53.9% — provenance-dominated |

tau=2.0 reconciles independently: 47.00% flat + (53.00% × 50%) = 73.50%, and the continuous channel's measured p50 is raw score **1.71**. A test pins this against the measured channel shares.

### Determinism

Cutoffs come from fixed-width binned histograms (width 1e-4 over [0, 4.01]) — exact to bin width, O(1) memory, order-independent. **Not** t-digest or P-square: those are order- and implementation-dependent, so two passes over the same file in different chunk orders can disagree, silently changing which edges ship. A test asserts cutoff equality across two orderings of the same multiset.

Ties are never split — the ~13% of rows piled at the score cap move as a unit, so we never delete some Isolates edges and keep others with identical evidence.

Binning goes to 4.01, not 4.0: the shipped data reaches **4.00735**, above the paper's documented cap.

## Blocker fixed

`prego.py` read the resource column and immediately discarded it:

```python
del source  # column carried in edge_attribute space for now; unused
```

It is now emitted as `prego_source`. Per-resource calibration is impossible without it.

## Not done here — deliberately

Wiring the two-pass filter into the 7.4 GB streaming path and adding the CLI knob. That needs a real run to validate realized retention against the model, and the research's per-resource quantiles came from a **1-in-101 sample of the raw file** (including rows the transform drops), so cutoffs must be recomputed on emitted edges before anything is hard-coded.

## Honest caveat on the design

~~**No verified precedent exists for a single global knob after per-channel calibration.**~~ **CORRECTED — see the recheck comment below.** Both refutations were checked against primary sources and the caveat was over-drawn:

- **STRING does expose a single global knob.** Its API documents `required_score` as "a number between 0 and 1000 (default depends on the network)"; per-channel values are output columns, not filter parameters. Only the *specifics* I had been given were wrong (0–999, default 400).
- **TISSUES 2.0 verifies the calibration half verbatim:** "To make the datasets comparable, we converted the raw expression scores into a common scoring scheme," using "a single, monotonic calibration function for all datasets from all organisms." The paper says nothing about per-channel sliders.

The genuine residual caveat is narrower: TISSUES anchors calibration on fold enrichment against a UniProtKB gold standard, so its scores are *quality*-calibrated. **We have no gold standard, so this percentile remap equalises rank only** — it makes no claim about comparable quality until anchored (see the validation path in #696).

## Testing

27 calibration tests plus one on the transform, pinning behaviour rather than arithmetic: that flat channels are tiered rather than ranked, that ties move as a unit, that cutoffs are order-independent, that an uncalibratable row is **kept** rather than silently dropped, and that the default lands inside the 75% budget.

The new transform test caught a wrong assumption while being written — the fixture's resources are `BioProject`/`JGI IMG`, not what I first assumed — which is the assertion doing its job.

`poetry run tox` green: **867 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
