### PR TITLE
docs(prego): delete the surviving false score-3 claim

### DIFF
--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -958,14 +958,15 @@ def test_habitat_evidence_is_an_observation_not_an_assertion():
     """
     A habitat-evidenced genome row must not claim the highest provenance tier.
 
-    ``Marginal Sea`` / ``Hydrothermal vents`` / ``Birds`` rows in the real
-    genome archive carry score 3 — PREGO's lower tier, the same one it assigns
-    text-mined rows — because they come from sample metadata rather than the
-    annotation pipeline the channel is named for. They previously inherited the
-    genome channel's ``knowledge_assertion`` regardless (#716).
+    ``Marginal Sea`` / ``Hydrothermal vents`` / ``Birds`` rows come from
+    sample/isolation metadata rather than the annotation pipeline the genome
+    channel is named for, yet they inherited that channel's
+    ``knowledge_assertion`` (#716).
 
-    This is not a confidence demotion — measured over the real archive, all
-    1,693 habitat rows score 4, PREGO's *highest* tier. Biolink's
+    This is not a confidence demotion, and the two signals are orthogonal:
+    measured over the first 3M rows of the real archive, all 1,693 habitat rows
+    carry score 4 — PREGO's *highest* tier, none at 3 — including the three
+    named above (16, 17 and 18 rows respectively, all at 4). Biolink's
     ``knowledge_level`` describes how knowledge was produced, not how confident
     it is, so a high-confidence observation is coherent.
     """


### PR DESCRIPTION
Completes the C1 correction from #718's independent review, which arrived after I merged.

## The defect

My C1 fix in #718 was incomplete. I replaced the closing paragraph of `test_habitat_evidence_is_an_observation_not_an_assertion`'s docstring and left the opening one, so it **contradicted itself three lines apart**:

> …rows in the real genome archive carry score 3 — PREGO's lower tier…
>
> This is not a confidence demotion — measured over the real archive, all 1,693 habitat rows score 4, PREGO's *highest* tier.

## It was false about its own examples

Measured over the first 3M rows of the real genome archive:

| value | rows | scores |
|---|---:|---|
| `Marginal Sea` | 16 | all 4 |
| `Hydrothermal vents` | 17 | all 4 |
| `Birds` | 18 | all 4 |

Habitat rows at any score other than 4: **none**.

## Why it mattered enough to fix separately

This was the last uncorrected instance of the claim. Left in place it invites the next reader to conclude the demotion is confidence-based and re-derive the finding — or, worse, "fix" the code to match a premise the data contradicts.

I checked the other `score 3` strings on master are about different things and are all true:
- `utils.py:353` — the note recording that this claim *was* false.
- `test_prego_transform.py:63` and `:730` — ~0.1% of *all* genome rows scoring 3 (7,262 of 3M, including `Isolates` and `Single Amplified Genome`), a separate verified measurement.

## Process note

This is a consequence of my merging #718 before its review completed. The review's other conclusions were a clean bill: it independently enumerated all 35 (channel × evidence_class) pairs and confirmed exactly one differs from pre-PR behaviour, and confirmed the B1/B2/F2 deletions removed no real coverage.

Docs only — no code paths touched. `poetry run tox`: **925 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)