### PR TITLE
fix(prego): drift detection over dropped rows, provenance snapshot, merge budget

### DIFF
--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -236,10 +236,33 @@ and `agent_type`, plus `prego_channel` changing from PREGO's verbatim column 6
 to a channel name. The raw column-6 string is not double-counted — it *moves*
 to `prego_evidence`, so it cancels.
 
-This matters for #693: KGX holds every source graph in the parent
-simultaneously, and PREGO is the single largest edge block in the merged KG. A
-48% increase on that block is material to the merge's peak RSS, and it lands on
-the same axis the two levers below are trying to reduce.
+#### What that does to the merge budget
+
+KGX holds every source graph in the parent simultaneously, so the number that
+matters for #693 is total merge input, not PREGO alone. Measured across the 20
+`merge.yaml` sources present on disk:
+
+| | total input | prego | prego share |
+|---|---:|---:|---:|
+| today | **9.72 GiB** | 7.40 GiB | **76.2%** |
+| after the #703 columns | **13.26 GiB** | 10.94 GiB | **82.5%** |
+| `merge.noprego.yaml` | **2.32 GiB** | — | — |
+
+Three things follow, and they are the actual budgeting answer:
+
+1. **Merge input grows 36.4% overall** (9.72 → 13.26 GiB) from a change that
+   touches one source. PREGO's own +48% dilutes to +36% at the merge level only
+   because the other 19 sources together are 2.32 GiB.
+2. **PREGO goes from dominant to overwhelming** — 76.2% → 82.5% of input. Any
+   future work on merge memory that is not about PREGO is rounding error.
+3. **`merge.noprego.yaml` is a 4.2x reduction today and 5.7x after #703.**
+   Nothing else available comes close: even deleting every non-PREGO source
+   would save less than PREGO's growth alone.
+
+Peak RSS is not measured here — this is input bytes, and KGX's in-memory
+representation is several times larger and not a fixed multiple. Treat these as
+the ratio to reason with, not as an RSS prediction. **No merge benchmark has
+been run at the new size.**
 
 The columns are still worth having — `knowledge_level` and `agent_type` were
 shipping empty, which made 44.7M text-mined and statistically-derived

--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -253,16 +253,46 @@ Three things follow, and they are the actual budgeting answer:
 1. **Merge input grows 36.4% overall** (9.72 → 13.26 GiB) from a change that
    touches one source. PREGO's own +48% dilutes to +36% at the merge level only
    because the other 19 sources together are 2.32 GiB.
-2. **PREGO goes from dominant to overwhelming** — 76.2% → 82.5% of input. Any
-   future work on merge memory that is not about PREGO is rounding error.
+2. **PREGO's share of bytes goes 76.2% → 82.5%**, so it dominates input size
+   more than before. But see the caveat below before treating that as a
+   memory ranking — it is not one.
 3. **`merge.noprego.yaml` is a 4.2x reduction today and 5.7x after #703.**
    Nothing else available comes close: even deleting every non-PREGO source
    would save less than PREGO's growth alone.
 
-Peak RSS is not measured here — this is input bytes, and KGX's in-memory
-representation is several times larger and not a fixed multiple. Treat these as
-the ratio to reason with, not as an RSS prediction. **No merge benchmark has
-been run at the new size.**
+#### Bytes and objects rank differently — do not read the table as memory
+
+Peak RSS is not measured here. This is input bytes, and KGX's in-memory
+representation is several times larger and not a fixed multiple. **No merge
+benchmark has been run at the new size.**
+
+More than a magnitude gap, though: KGX peak RSS is dominated by per-object
+Python overhead, which scales with the **number** of nodes and edges, not their
+width. On that axis the picture shifts:
+
+| source | rows | share of rows | share of bytes |
+|---|---:|---:|---:|
+| prego | 44,768,164 | **68.6%** | **76.2%** |
+| metatraits | 4,651,069 | 7.1% | |
+| bacdive | 4,516,195 | 6.9% | |
+| metatraits_gtdb | 4,239,260 | 6.5% | |
+| gtdb | 2,619,745 | 4.0% | |
+| ncbitaxon | 1,850,570 | 2.8% | |
+| **total** | **65,258,838** | | |
+
+Two things follow that the bytes table hides:
+
+- **Non-PREGO is ~31% of objects (20.5M), not ~24%**, and it is concentrated in
+  four sources. Halving metatraits + metatraits_gtdb + bacdive would be a real
+  memory win, not a rounding error.
+- **The #703 columns add zero rows.** They widen existing rows by ~85 B. So in
+  object terms PREGO stays at 68.6% before and after, and if RSS is
+  object-dominated the merge's peak grows by considerably less than the 36.4%
+  the byte table implies.
+
+An earlier version of this section concluded "any future work on merge memory
+that is not about PREGO is rounding error." That was a memory ranking argued
+from a byte measurement, and the row counts do not support it.
 
 The columns are still worth having — `knowledge_level` and `agent_type` were
 shipping empty, which made 44.7M text-mined and statistically-derived

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -736,6 +736,25 @@ class PregoTransform(Transform):
             entity2_id = row[3]
             source = row[4]
             evidence = row[5]
+            # Drift detection runs over every row whose evidence column parsed,
+            # not just emitted ones. The habitat class is a residual bucket, so
+            # its job is to reveal an upstream change — and a new PREGO resource
+            # class that happened to land only on dropped shapes would be
+            # invisible to a check further down the emit path (#719).
+            #
+            # Placed above the empty-id check deliberately: that check returns
+            # inside this try, so tracking below it would silently exclude
+            # empty-id rows — reintroducing the same blind spot one drop reason
+            # further along.
+            #
+            # This does mean classify_evidence runs twice for an emitted row
+            # (again in _as_edge_row). Measured rather than assumed: 319 ns per
+            # call, so ~14 s added across all 44.7M rows — well under 1% of a
+            # run that streams 14 GB of archives. Threading the result through
+            # would remove it at the cost of a wider signature on every emit
+            # path; not worth it at that ratio.
+            if classify_evidence(evidence) == EVIDENCE_HABITAT:
+                self._record_habitat_value(evidence)
             # Defensive: an empty entity_id would produce a malformed
             # CURIE like `NCBITaxon:` on emit. Not seen in the canary,
             # but a two-line check is cheap insurance.
@@ -748,15 +767,6 @@ class PregoTransform(Transform):
         except (ValueError, IndexError):
             self._stats["rows_malformed"] += 1
             return
-
-        # Drift detection runs over every well-formed row, not just emitted
-        # ones. The habitat class is a residual bucket, so its job is to reveal
-        # an upstream change — and a new PREGO resource class that happened to
-        # land only on dropped shapes (taxon-taxon rows, inverse directions,
-        # DOID rows with no MONDO xref) would be invisible to a check on the
-        # emit path (#719).
-        if classify_evidence(evidence) == EVIDENCE_HABITAT:
-            self._record_habitat_value(evidence)
 
         outcome = classify_row(entity1_type, entity2_type)
         if outcome not in (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID, KEEP_TAXON_TO_BTO):

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -216,6 +216,7 @@ class PregoTransform(Transform):
             # Distinct values in the habitat catch-all — see _record_habitat_value.
             "evidence_habitat_values": defaultdict(int),
             "evidence_habitat_values_uncounted": 0,
+            "evidence_habitat_emitted": 0,
             "doid_no_mondo_xref": 0,
             "unique_nodes_emitted": 0,
             "nodes_enriched_with_synonyms": 0,
@@ -748,6 +749,15 @@ class PregoTransform(Transform):
             self._stats["rows_malformed"] += 1
             return
 
+        # Drift detection runs over every well-formed row, not just emitted
+        # ones. The habitat class is a residual bucket, so its job is to reveal
+        # an upstream change — and a new PREGO resource class that happened to
+        # land only on dropped shapes (taxon-taxon rows, inverse directions,
+        # DOID rows with no MONDO xref) would be invisible to a check on the
+        # emit path (#719).
+        if classify_evidence(evidence) == EVIDENCE_HABITAT:
+            self._record_habitat_value(evidence)
+
         outcome = classify_row(entity1_type, entity2_type)
         if outcome not in (KEEP_TAXON_TO_GO, KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_DOID, KEEP_TAXON_TO_BTO):
             self._record_drop(outcome, entity1_type, entity1_id, entity2_type, entity2_id)
@@ -893,7 +903,10 @@ class PregoTransform(Transform):
         row[PREGO_EVIDENCE_COLUMN] = evidence
         evidence_class = classify_evidence(evidence)
         if evidence_class == EVIDENCE_HABITAT:
-            self._record_habitat_value(evidence)
+            # Values are recorded in _process_row over ALL rows; here we only
+            # count how many of them actually ship. A divergence between the
+            # two is itself a signal (#719).
+            self._stats["evidence_habitat_emitted"] += 1
         row[PREGO_EVIDENCE_CLASS_COLUMN] = evidence_class
         knowledge_level, agent_type = edge_metadata_for(channel, evidence_class)
         row[KNOWLEDGE_LEVEL_COLUMN] = knowledge_level
@@ -1037,8 +1050,9 @@ class PregoTransform(Transform):
             top = sorted(habitat_values.items(), key=lambda kv: (-kv[1], kv[0]))[:10]
             total = sum(habitat_values.values())
             print(
-                f"[prego] evidence_class=habitat is a residual bucket: {total:,} rows across "
-                f"{len(habitat_values):,} distinct values (top: {', '.join(f'{v}({n:,})' for v, n in top)})"
+                f"[prego] evidence_class=habitat is a residual bucket: {total:,} rows seen across "
+                f"{len(habitat_values):,} distinct values, {self._stats['evidence_habitat_emitted']:,} "
+                f"emitted (top: {', '.join(f'{v}({n:,})' for v, n in top)})"
             )
             if len(habitat_values) >= self._HABITAT_VALUE_CAP:
                 print(

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -736,8 +736,10 @@ class PregoTransform(Transform):
             entity2_id = row[3]
             source = row[4]
             evidence = row[5]
-            # Drift detection runs over every row whose evidence column parsed,
-            # not just emitted ones. The habitat class is a residual bucket, so
+            # Drift detection runs over every row whose evidence column read,
+            # not just emitted ones. "Well-formed" would be the wrong word:
+            # an empty-id row parses fine and fails a CONTENT check, and it is
+            # exactly the row this needs to cover. The habitat class is a residual bucket, so
             # its job is to reveal an upstream change — and a new PREGO resource
             # class that happened to land only on dropped shapes would be
             # invisible to a check further down the emit path (#719).

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -1034,6 +1034,12 @@ def test_emitted_provenance_snapshot(prego_transform: PregoTransform):
     }
     expected.update({("NCBITaxon:100", f"GO:000{5000 + i}"): env for i in range(12)})
 
+    # Count first. `actual` is keyed on (subject, object), so two edges sharing
+    # that pair collapse into one entry — and the transform does NOT dedupe.
+    # Without this line a refactor that processes an archive twice would double
+    # all 44.7M edges and every prego test would still pass, including this one,
+    # which exists to be the tripwire.
+    assert len(edges) == len(expected), f"expected {len(expected)} edges, got {len(edges)} (duplicates?)"
     assert actual == expected
 
 

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -993,6 +993,16 @@ def test_emitted_provenance_snapshot(prego_transform: PregoTransform):
     unrecognised channels, and genome rows emitting as ``literature`` because
     they sat in the wrong archive. Both show up here as a changed value rather
     than as an absent test.
+
+    The expected values were cross-checked against the fixture *source* rather
+    than copied from the transform's output — generating a snapshot from
+    current behaviour is how a bug gets enshrined as the expectation. Each is
+    derivable from the archive a row lives in plus its column-6 value:
+    ``literature`` + ``PMID:*`` -> publication -> text-mined;
+    ``annotated_genomes_isolates`` + ``Isolates`` -> resource_class ->
+    knowledge_assertion; the same archive + ``Aquatic`` -> habitat ->
+    observation; ``environmental_samples`` + a tally -> sample_count ->
+    statistical_association.
     """
     prego_transform.run(show_status=False)
     edges = _read_tsv(prego_transform.output_edge_file)
@@ -1149,6 +1159,40 @@ def test_habitat_bucket_is_reported_as_a_residual(prego_input_dir: Path, prego_o
     assert "2 rows seen" in out and "1 emitted" in out, f"summary must separate seen from emitted; got:\n{out}"
     # The values must be named, so a new resource class would be legible.
     assert "Aquatic" in out and "Human" in out
+
+
+def test_habitat_drift_covers_every_drop_reason(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    A habitat value must be tracked no matter why its row is dropped.
+
+    #719 moved tracking off the emit path, but the empty-id guard returns from
+    inside the same try block, so tracking placed below it would have excluded
+    `empty_id` rows — the identical blind spot, one drop reason further along.
+
+    This asserts coverage across three distinct fates: emitted, dropped by
+    shape, and dropped by the empty-id guard.
+    """
+    extra = FIXTURE_DIR / "database_pairs_genomes.tsv"
+    rows = extra.read_text().rstrip("\n").split("\n")
+    # A habitat-valued row with an empty entity2_id -> dropped as empty_id.
+    rows.append("-2\t100\t-21\t\tJGI IMG\tSubglacial Lake\t4\tTRUE\thttps://example/x")
+    payload = prego_input_dir / "prego" / "genomes_with_empty_id.tsv"
+    payload.write_text("\n".join(rows) + "\n")
+    archive = prego_input_dir / "prego" / "annotated_genomes_isolates.tar.gz"
+    archive.unlink()
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(payload, arcname="database_pairs.tsv")
+
+    transform = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    transform.run(show_status=False)
+    tracked = transform._stats["evidence_habitat_values"]
+
+    assert "Subglacial Lake" in tracked, (
+        f"a habitat value on an empty-id row must still be tracked; got {dict(tracked)}"
+    )
+    # All three fates represented: emitted, dropped-by-shape, dropped-by-empty-id.
+    assert {"Aquatic", "Human", "Subglacial Lake"} <= set(tracked)
+    assert transform._stats["evidence_habitat_emitted"] == 1, "only Aquatic ships"
 
 
 def test_habitat_value_tracking_is_bounded(prego_transform: PregoTransform):

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -977,6 +977,56 @@ def test_habitat_evidence_is_an_observation_not_an_assertion():
     assert edge_metadata_for(CHANNEL_GENOMES, "publication") == ("prediction", "text_mining_agent")
 
 
+def test_emitted_provenance_snapshot(prego_transform: PregoTransform):
+    """
+    Pin the provenance of EVERY fixture edge, so any flip is caught.
+
+    ``test_edge_metadata_matrix_is_pinned`` covers the pure function; this
+    covers the wiring — that each real row reaches it with the channel and
+    evidence class it should. A bug in `channel_for_archive`, in
+    `classify_evidence`, or in which archive a row lives in would leave the
+    matrix test green while changing what ships.
+
+    This is the before/after coverage #720 asked for. Point assertions could
+    not catch a provenance flip on a pre-existing edge, which is exactly how
+    two defects reached master: the habitat rule silently answering for
+    unrecognised channels, and genome rows emitting as ``literature`` because
+    they sat in the wrong archive. Both show up here as a changed value rather
+    than as an absent test.
+    """
+    prego_transform.run(show_status=False)
+    edges = _read_tsv(prego_transform.output_edge_file)
+
+    actual = {
+        (e["subject"], e["object"]): (
+            e["prego_channel"],
+            e["prego_evidence_class"],
+            e["knowledge_level"],
+            e["agent_type"],
+        )
+        for e in edges
+    }
+    genome_assertion = ("annotated_genomes_isolates", "resource_class", "knowledge_assertion", "automated_agent")
+    text_mined = ("literature", "publication", "prediction", "text_mining_agent")
+    env = ("environmental_samples", "sample_count", "statistical_association", "data_analysis_pipeline")
+
+    expected = {
+        ("BTO:0000763", "NCBITaxon:562"): text_mined,
+        ("NCBITaxon:562", "MONDO:0007256"): text_mined,
+        # Genome-annotation rows. These emitted as `literature`/`prediction`
+        # before #713 moved them into the archive they belong to.
+        ("ENVO:00000011", "NCBITaxon:693444"): genome_assertion,
+        ("NCBITaxon:100", "GO:0000034"): genome_assertion,
+        ("NCBITaxon:100", "GO:0005634"): genome_assertion,
+        ("NCBITaxon:100", "GO:0006355"): genome_assertion,
+        # The habitat exception: sample metadata, not genome annotation.
+        ("NCBITaxon:100", "GO:0008150"): ("annotated_genomes_isolates", "habitat", "observation", "automated_agent"),
+    }
+    expected.update({("NCBITaxon:100", f"GO:000{5000 + i}"): env for i in range(12)})
+
+    assert actual == expected
+
+
 def test_edge_metadata_matrix_is_pinned():
     """
     Pin the whole (channel x evidence_class) matrix, not sampled cells.
@@ -1083,10 +1133,22 @@ def test_habitat_bucket_is_reported_as_a_residual(prego_input_dir: Path, prego_o
     out = capsys.readouterr().out
 
     tracked = transform._stats["evidence_habitat_values"]
-    assert tracked, "the fixture's habitat-valued row must be tracked"
     assert "residual bucket" in out, f"the habitat summary must be printed; got:\n{out}"
-    # The value itself must appear, so a new resource class would be legible.
-    assert any(value in out for value in tracked), "the distinct values must be named in the summary"
+
+    # Drift detection must cover DROPPED rows too (#719). The fixture has two
+    # habitat values: `Aquatic` on a taxon→GO row that emits, and `Human` on a
+    # taxon-taxon row that drops as taxon_taxon_host. Tracking only the emit
+    # path saw one of them, which would make a new PREGO resource class landing
+    # on a dropped shape invisible to the check built to catch it.
+    assert set(tracked) == {"Aquatic", "Human"}, (
+        f"habitat tracking must cover dropped rows, not just emitted ones; got {dict(tracked)}"
+    )
+    assert transform._stats["evidence_habitat_emitted"] == 1, "only Aquatic ships"
+
+    # Seen and emitted are reported separately, since a divergence is a signal.
+    assert "2 rows seen" in out and "1 emitted" in out, f"summary must separate seen from emitted; got:\n{out}"
+    # The values must be named, so a new resource class would be legible.
+    assert "Aquatic" in out and "Human" in out
 
 
 def test_habitat_value_tracking_is_bounded(prego_transform: PregoTransform):


### PR DESCRIPTION
Closes #719, #720. Completes #715 with a merge-level measurement.

## #719 — drift detection was blind where it mattered

The habitat tracking added in #714 ran on the emit path, so a new PREGO resource class landing only on dropped shapes was invisible to the check built to catch it.

Demonstrated on the fixture — the `Human` habitat row drops as `taxon_taxon_host`:

```
before: habitat is a residual bucket: 1 rows across 1 distinct values (top: Aquatic(1))
after:  habitat is a residual bucket: 2 rows seen across 2 distinct values, 1 emitted (top: Aquatic(1), Human(1))
```

Values are now recorded over every well-formed row, with a separate emitted count. A divergence between seen and emitted is itself a signal, so both are reported.

## #720 — the coverage gap that let two defects through

The only habitat row in the fixture was one #718 *added*, so no test could catch the branch flipping provenance on a row that previously emitted something else. This is precisely why mutation testing missed the two MEDIUMs in #718: **mutations show a test can fail, not that a combination is untested.**

`test_emitted_provenance_snapshot` now pins channel, evidence class, `knowledge_level` and `agent_type` for all 19 fixture edges. Where `test_edge_metadata_matrix_is_pinned` covers the pure function, this covers the *wiring* — which archive a row lives in, what `channel_for_archive` returns, what `classify_evidence` makes of column 6. A bug in any of those leaves the matrix test green while changing what ships.

Mutation-verified:

| mutation | tests failed |
|---|---:|
| genome rows back in `literature.tar.gz` (the #713 defect) | **13** |
| habitat rule re-hoisted above channel checks (the C2 defect) | **2** |
| drift tracking back on the emit path (#719) | **1** |

## #715 — the merge budget, measured

PREGO alone was never the number that matters: KGX holds every source graph in the parent simultaneously. Measured across the 20 `merge.yaml` sources present on disk:

| | total input | prego | prego share |
|---|---:|---:|---:|
| today | **9.72 GiB** | 7.40 GiB | **76.2%** |
| after the #703 columns | **13.26 GiB** | 10.94 GiB | **82.5%** |
| `merge.noprego.yaml` | **2.32 GiB** | — | — |

1. Merge input grows **36.4% overall** from a change touching one source. PREGO's own +48% dilutes to +36% only because the other 19 sources together are 2.32 GiB.
2. PREGO goes from dominant to **overwhelming** — 76.2% → 82.5%. Future work on merge memory that isn't about PREGO is rounding error.
3. `merge.noprego.yaml` is a **4.2x reduction today, 5.7x after #703**. Deleting every other source combined would save less than PREGO's growth alone.

Stated explicitly in the doc: these are **input bytes, not peak RSS** — KGX's in-memory representation is several times larger and not a fixed multiple — and **no merge benchmark has been run at the new size.**

---

`poetry run tox`: **926 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)