### PR TITLE
Close the ENVO ubiquity gap and recommend a habitat threshold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,16 @@ Optional, for the ontology transforms:
   data-quality signal instead of being silently promoted), those rows drop once
   `τ > 3` — on the order of 20k edges.
 
+  **That 0.1% is not spread evenly, and "incidental" is the wrong reading.** It
+  is a whole-channel average dominated by the 44.3M `capable_of` edges. Counted
+  on the habitat shapes alone (measured 2026-08-10, full `edges.tsv`), the genome
+  channel is 33.3% score-3 for ENVO (12,562 of 37,749) and 80.5% for BTO (5,360
+  of 6,661) — no value other than 3 or 4 occurs. Those 17,922 rows are ~89% of
+  the ~20k above, so **`τ > 3` deletes 4.0% of all habitat edges**, and the
+  habitat data is where PREGO has measured enrichment (7.89x unfiltered for
+  ENVO). See `docs/PREGO_SCORE_VALIDATION.md` for the habitat threshold
+  recommendation, which keeps this channel whole.
+
   Two consequences worth internalising. Above `τ = 3` you delete the literature
   channel outright — on provenance, not on quality. And within the continuous
   channel the score tracks how *common* a GO term is rather than how well

--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -360,6 +360,122 @@ the rare, taxon-specific annotations — while barely discriminating within the
 bulk. That is the opposite of what a confidence filter should do if the goal is
 to keep specific, informative edges.
 
+### Habitat terms do **not** repeat the GO pattern
+
+Measured 2026-08-10 on the current `edges.tsv` (12.17 GB, post-#722) with
+`ubiquity_check.py --shape envo|bto`. Degree here is **distinct taxa**, not edge
+count: MG-RAST contributes both amplicon and metagenome studies, so one
+(term, taxon) pair can be reported twice (ENVO 1.063 edges per distinct taxon;
+BTO exactly 1.000). The published GO run used edge count, which was sound for
+that shape but would have overstated habitat degree by ~6%.
+
+| decile | ENVO degree range | ENVO mean score | BTO degree range | BTO mean score |
+|---:|---|---:|---|---:|
+| 1 | 56–106 | 1.050 | 50–68 | 0.559 |
+| 2 | 120–275 | 1.017 | 70–110 | 0.747 |
+| 3 | 292–510 | 1.093 | 117–142 | 0.511 |
+| 4 | 561–868 | **0.675** | 147–179 | 0.561 |
+| 5 | 890–1,289 | **0.633** | 204–345 | 0.775 |
+| 6 | 1,291–1,693 | 0.727 | 383–401 | 1.277 |
+| 7 | 1,694–2,129 | 1.010 | 417–506 | 1.202 |
+| 8 | 2,159–2,518 | 1.060 | 528–606 | 1.349 |
+| 9 | 2,563–3,086 | 1.330 | 676–856 | 1.664 |
+| 10 | 3,187–8,582 | 1.586 | 891–1,657 | 1.550 |
+
+**Spearman: ENVO +0.3016 (223 terms), BTO +0.5967 (70 terms).**
+
+Read the shape, not the coefficient — the same instruction as for GO, with the
+opposite conclusion. **ENVO is U-shaped, not monotone.** The rarest three
+deciles score ~1.0–1.09, *above* the mid-ubiquity deciles 4–6 (0.63–0.73), and
+only the top two deciles rise clearly (1.33, 1.59). So for ENVO the score does
+**not** systematically punish rare, specific habitats — the pathology that makes
+`τ` dangerous for GO does not transfer. The positive Spearman is carried by the
+rising top tail, not by a rare-terms-score-low gradient.
+
+**BTO is closer to monotone** (+0.5967, rising 0.56 → 1.66) and does look like a
+ubiquity ranking. It is also only 70 terms and, per the caveats, not independent
+of ENVO.
+
+### The genome channel is not flat for habitat edges
+
+`CLAUDE.md` records that the `annotated_genomes_isolates` channel is
+"predominantly a flat 4.0" with "roughly 0.1% of rows" carrying a 3, worth "on
+the order of 20k edges" above `τ = 3`. That is true of the channel *overall*,
+which is dominated by the 44.3M `capable_of` edges. It is badly wrong for the
+habitat subset:
+
+| shape | channel | score 3 | score 4 | share at 3 |
+|---|---|---:|---:|---:|
+| ENVO | `annotated_genomes_isolates` | 12,562 | 25,187 | **33.3%** |
+| BTO | `annotated_genomes_isolates` | 5,360 | 1,301 | **80.5%** |
+
+Genome-channel habitat scores are *exactly* 3 or 4 — no other value occurs.
+Those 17,922 rows at 3 are ~89% of the ~20k the docs attribute to the whole
+channel, so the "small incidental data-quality signal" is in fact almost
+entirely habitat. **Any `τ > 3` deletes 4.0% of all habitat edges outright**, on
+provenance rather than on quality.
+
+Note also that the BTO *continuous* channel is not continuous above 2.0: 23,565
+edges score < 2.0 and 5,596 score exactly 4.0, with **nothing in between**. Every
+threshold from 2.0 to 4.0 is therefore the same filter.
+
+---
+
+## Threshold recommendation for habitat ingest
+
+Coverage cost per threshold, continuous channel only
+(`habitat_threshold_check.py`). Median term degree is the distinct-taxon degree
+of the term each *surviving edge* belongs to, computed once on the unfiltered
+set so the baseline does not move with the filter:
+
+| ≥ τ | ENVO edges | kept | terms kept | taxa kept | median term degree |
+|---:|---:|---:|---:|---:|---:|
+| 0.0 | 378,480 | 100% | 100% (275) | 100% (13,316) | 2,585 |
+| 0.5 | 264,239 | 69.8% | 82.2% | 72.2% | 2,691 |
+| **1.0** | **180,205** | **47.6%** | **70.9%** | **60.6%** | **2,958** |
+| 1.5 | 116,124 | 30.7% | 61.8% | 51.1% | 3,187 |
+| 2.0 | 72,172 | 19.1% | 55.3% | 44.6% | 3,582 |
+| 2.5 | 44,078 | 11.6% | 49.5% | 41.1% | 4,198 |
+| 3.0 | 32,809 | 8.7% | 47.3% | 37.3% | 4,140 |
+| 4.0 | 27,192 | 7.2% | 47.3% | 31.1% | 3,325 |
+
+**Recommendation: `τ = 1.0` on the continuous channel, genome channel kept
+whole.** The reasoning, and its limits:
+
+- It is the knee. Fold enrichment goes 7.89x → 11.59x (+47%) while retaining
+  **70.9% of distinct habitat terms and 60.6% of taxa**. Every further step buys
+  less: 1.0 → 2.0 costs 15.6 points of term coverage for +2.9x.
+- Specificity damage is small here (median degree +14%, 2,585 → 2,958) and the
+  U-shaped ubiquity curve says the rarest habitats are not the ones being cut.
+  The damage peaks at τ = 2.5 (4,198, +62%) and then *eases*, so the mid-range
+  thresholds are the worst of both worlds.
+- `τ = 3.0` maximises measured overlap (18.79x) but keeps 8.7% of edges and 37%
+  of taxa. That optimum was selected in-sample with no held-out validation, and
+  overlap is not precision — the standard is positive-only. Paying 63% of taxa
+  for an unvalidated peak is not a good trade for a recall-oriented KG.
+- The genome channel must stay whole: at `τ > 3` it loses 17,922 habitat edges
+  for provenance reasons that say nothing about quality.
+
+**This is a judgement, not a measurement.** No precision/utility target exists
+for habitat edges, and one would change the answer: a precision-first consumer
+should prefer 3.0, and a pure-recall consumer 0.0. What the data settles is the
+*shape* of the trade, not the point on it.
+
+**For BTO, do not threshold** beyond 1.0. Its ubiquity correlation is twice
+ENVO's (+0.5967), so a threshold does preferentially keep ubiquitous anatomy
+terms, and its score gap makes every τ in [2.0, 4.0] identical anyway.
+
+`PREGO_MIN_CONFIDENCE` **cannot express this policy** — it applies one star
+threshold globally, so it cannot keep the genome channel whole while filtering
+the continuous one, and at τ > 3 it would also delete the literature channel.
+Ingest everything and filter downstream on `(prego_channel, prego_score)`:
+
+```bash
+awk -F'\t' 'NR==1 || ($2=="biolink:location_of" &&
+  ($9!="environmental_samples" || $8>=1.0))' \
+  data/transformed/prego/edges.tsv > habitat_tau1.tsv
+```
+
 ---
 
 ## Caveats

--- a/docs/PREGO_SCORE_VALIDATION.md
+++ b/docs/PREGO_SCORE_VALIDATION.md
@@ -423,6 +423,13 @@ threshold from 2.0 to 4.0 is therefore the same filter.
 
 ## Threshold recommendation for habitat ingest
 
+**Mind the denominator.** The threshold table above is **all-channel** ENVO
+(416,229 edges); the coverage table below is **continuous-channel only**
+(378,480). They reconcile exactly — at every τ the difference is the genome
+contribution, 37,749 for τ ≤ 3 and 25,187 at τ = 4 — but the fold figures and
+the retention figures are not quoted against the same base, so do not divide one
+by the other. Policy-level retention is given after the table.
+
 Coverage cost per threshold, continuous channel only
 (`habitat_threshold_check.py`). Median term degree is the distinct-taxon degree
 of the term each *surviving edge* belongs to, computed once on the unfiltered
@@ -440,11 +447,26 @@ set so the baseline does not move with the filter:
 | 4.0 | 27,192 | 7.2% | 47.3% | 31.1% | 3,325 |
 
 **Recommendation: `τ = 1.0` on the continuous channel, genome channel kept
-whole.** The reasoning, and its limits:
+whole.** What that policy actually retains, counted over *all* habitat edges —
+not just the continuous ones, since 125 of the 400 ENVO terms appear only in the
+genome channel:
+
+| shape | edges | terms | taxa |
+|---|---|---|---|
+| ENVO | 416,229 → 217,954 (52.4%) | 400 → 351 (**87.8%**) | 21,183 → 16,008 (**75.6%**) |
+| BTO | 35,822 → 19,791 (55.2%) | 382 → 368 (**96.3%**) | 7,248 → 6,629 (**91.5%**) |
+
+The 52.4% is exactly the threshold table's `τ = 1.0` row (217,954), because every
+genome-channel habitat edge scores 3 or 4 and so survives `τ = 1.0` regardless.
+**11.59x therefore applies precisely to this set** — the two tables agree once
+the denominator is made explicit.
+
+The reasoning, and its limits:
 
 - It is the knee. Fold enrichment goes 7.89x → 11.59x (+47%) while retaining
-  **70.9% of distinct habitat terms and 60.6% of taxa**. Every further step buys
-  less: 1.0 → 2.0 costs 15.6 points of term coverage for +2.9x.
+  **87.8% of distinct ENVO habitat terms and 75.6% of taxa**. Every further step
+  buys less: within the continuous channel, 1.0 → 2.0 costs 15.6 points of term
+  coverage for +2.9x.
 - Specificity damage is small here (median degree +14%, 2,585 → 2,958) and the
   U-shaped ubiquity curve says the rarest habitats are not the ones being cut.
   The damage peaks at τ = 2.5 (4,198, +62%) and then *eases*, so the mid-range

--- a/scripts/prego_validation/README.md
+++ b/scripts/prego_validation/README.md
@@ -20,7 +20,8 @@ inline some of the same logic; prefer the module for new work.
 | `precision_assay_go.py` | precision + lift vs labelled assay evidence | ~8 min | as above |
 | `fold_enrichment_envo.py` | fold enrichment of ENVO edges vs BacDive isolation sources | ~2 min | as above |
 | `fold_enrichment_bto.py` | fold enrichment of BTO edges vs BacDive host anatomy | ~2 min | as above |
-| `ubiquity_check.py` | Spearman corr. of GO-term degree vs mean score | ~8 min | as above |
+| `ubiquity_check.py` | Spearman corr. of term degree vs mean score, any shape (`--shape go\|envo\|bto`) | ~1 min | as above |
+| `habitat_threshold_check.py` | edges / terms / taxa retained per threshold, and whether survivors are the ubiquitous habitats | ~40 s | as above |
 
 Run order: build the gold standards first (they pickle to `/tmp`), then the
 measurements.

--- a/scripts/prego_validation/habitat_threshold_check.py
+++ b/scripts/prego_validation/habitat_threshold_check.py
@@ -1,0 +1,136 @@
+"""
+Cost of each habitat score threshold, in coverage and in specificity.
+
+``fold_enrichment_envo.py`` answers "does precision improve as tau rises?" using
+the BacDive isolation gold. It cannot answer "what do we lose?", because a
+positive-only standard cannot enumerate the true edges a threshold discards.
+This script measures the losses that *are* observable without a gold standard:
+
+* how many edges, distinct habitat terms and distinct taxa survive;
+* whether the survivors are the specific habitats or the ubiquitous ones.
+
+The second is the question ``ubiquity_check.py`` raises. For GO the score rises
+steeply out of the rare deciles and then flattens, so raising tau strips the
+rare, informative annotations first. Whether habitat terms behave the same way
+determines whether a habitat threshold is safe, and the answer is not
+transferable between shapes.
+
+Term degree is distinct taxa, not edge count: MG-RAST contributes both amplicon
+and metagenome studies, so one (term, taxon) pair can appear twice.
+
+Usage:
+
+    python habitat_threshold_check.py [--shape {envo,bto}] [--edges PATH]
+"""
+
+import argparse
+import statistics
+from collections import defaultdict
+from typing import Dict, List, Set, Tuple
+
+from channel_compat import assert_non_empty, continuous_predicate
+
+THRESHOLDS = (0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0)
+PREFIX = {"envo": "ENVO:", "bto": "BTO:"}
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse the command line.
+
+    :return: Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--shape", choices=sorted(PREFIX), default="envo", help="habitat vocabulary (default: envo)")
+    parser.add_argument("--edges", default="data/transformed/prego/edges.tsv", help="path to edges.tsv")
+    return parser.parse_args()
+
+
+def load(path: str, prefix: str) -> Tuple[List[Tuple[str, str, float]], str]:
+    """
+    Read every continuous-channel habitat edge.
+
+    :param path: Path to ``edges.tsv``.
+    :param prefix: CURIE prefix of the habitat vocabulary.
+    :return: ``(rows, layout)`` where each row is ``(term, taxon, score)``.
+    """
+    rows: List[Tuple[str, str, float]] = []
+    with open(path) as handle:
+        header = next(handle).rstrip("\n").split("\t")
+        subject_i, object_i = header.index("subject"), header.index("object")
+        score_i = header.index("prego_score")
+        is_continuous, layout = continuous_predicate(header)
+        n_continuous = 0
+        for line in handle:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) <= score_i:
+                continue
+            if not (fields[subject_i].startswith(prefix) and fields[object_i].startswith("NCBITaxon:")):
+                continue
+            if not is_continuous(fields):
+                continue
+            n_continuous += 1
+            try:
+                rows.append((fields[subject_i], fields[object_i], float(fields[score_i])))
+            except ValueError:
+                continue
+    assert_non_empty(n_continuous, layout)
+    return rows, layout
+
+
+def degrees(rows: List[Tuple[str, str, float]]) -> Dict[str, int]:
+    """
+    Distinct-taxon degree per habitat term, over the unfiltered edge set.
+
+    Computed once on the full set so that "specificity of what survives" is
+    measured against a fixed notion of how ubiquitous each term is. Recomputing
+    degree inside each threshold would make the baseline move with the filter.
+
+    :param rows: ``(term, taxon, score)`` tuples.
+    :return: Term to distinct-taxon count.
+    """
+    taxa: Dict[str, Set[str]] = defaultdict(set)
+    for term, taxon, _ in rows:
+        taxa[term].add(taxon)
+    return {term: len(t) for term, t in taxa.items()}
+
+
+def main() -> None:
+    """Print the retention and specificity table across thresholds."""
+    args = parse_args()
+    rows, layout = load(args.edges, PREFIX[args.shape])
+    degree = degrees(rows)
+    total_edges = len(rows)
+    total_terms = len(degree)
+    total_taxa = len({taxon for _, taxon, _ in rows})
+
+    print(f"  layout: {layout}")
+    print(f"  {args.shape.upper()} continuous-channel edges: {total_edges:,}")
+    print(f"  distinct terms: {total_terms:,}   distinct taxa: {total_taxa:,}\n")
+    print(
+        f"  {'>= tau':>7} {'edges':>10} {'kept':>7} {'terms':>7} {'kept':>7} "
+        f"{'taxa':>8} {'kept':>7} {'median term degree':>19}"
+    )
+    for tau in THRESHOLDS:
+        kept = [r for r in rows if r[2] >= tau]
+        if not kept:
+            print(f"  {tau:>7.1f} {0:>10,} {0.0:>6.1f}% {0:>7,} {0.0:>6.1f}% {0:>8,} {0.0:>6.1f}% {'-':>19}")
+            continue
+        terms = {r[0] for r in kept}
+        taxa = {r[1] for r in kept}
+        # Degree of the term each surviving edge belongs to: the ubiquity of what
+        # the threshold actually keeps, weighted by how much of it there is.
+        median_degree = statistics.median(degree[r[0]] for r in kept)
+        print(
+            f"  {tau:>7.1f} {len(kept):>10,} {100 * len(kept) / total_edges:>6.1f}% "
+            f"{len(terms):>7,} {100 * len(terms) / total_terms:>6.1f}% "
+            f"{len(taxa):>8,} {100 * len(taxa) / total_taxa:>6.1f}% {median_degree:>19,.0f}"
+        )
+    print(
+        "\n  median term degree rising with tau => the threshold preferentially keeps\n"
+        "  ubiquitous habitats; flat or falling => specific habitats survive too."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prego_validation/ubiquity_check.py
+++ b/scripts/prego_validation/ubiquity_check.py
@@ -2,57 +2,179 @@
 Test whether PREGO's score measures ubiquity rather than confidence.
 
 Hypothesis: the environmental-samples score rewards co-occurrence frequency,
-so a GO term attached to many taxa (generic, ubiquitous) scores higher than a
+so a term attached to many taxa (generic, ubiquitous) scores higher than a
 specific one. If true, thresholding up selects generic annotations.
 
-Prediction: within the continuous channel, a GO term's taxon degree should
+Prediction: within the continuous channel, a term's taxon degree should
 correlate POSITIVELY with its mean score.
+
+Runs over any of the three continuous-channel edge shapes. The GO shape was
+measured first and its numbers are published; ``--shape go --degree edges``
+reproduces them exactly.
+
+Two things differ by shape and are easy to get silently wrong:
+
+* **Orientation.** For GO the taxon is the *subject* and the term the object
+  (``NCBITaxon -capable_of-> GO``); for the habitat shapes the term is the
+  *subject* (``ENVO -location_of-> NCBITaxon``). Reading the wrong column
+  measures taxon degree instead of term degree — a different quantity that
+  answers a different question, with no error to notice.
+* **Degree.** The original run approximated distinct taxa by edge count. That
+  holds only while one (term, taxon) pair appears once. It does not hold for
+  the habitat shapes: MG-RAST contributes both amplicon and metagenome studies,
+  so a pair can be reported twice and edge count overstates degree.
+
+Usage:
+
+    python ubiquity_check.py [--shape {go,envo,bto}] [--degree {taxa,edges}]
+                             [--min-edges N] [--edges PATH]
 """
+
+import argparse
 from collections import defaultdict
+from typing import Callable, Dict, List, Set, Tuple
 
 from channel_compat import assert_non_empty, continuous_predicate
 
-deg = defaultdict(int)      # GO -> distinct taxa (approximated by edge count)
-tot = defaultdict(float)    # GO -> summed score
-with open("data/transformed/prego/edges.tsv") as fh:
-    h = next(fh).rstrip("\n").split("\t")
-    si, oi, sci, chi = h.index("subject"), h.index("object"), h.index("prego_score"), h.index("prego_channel")
-    is_cont, layout = continuous_predicate(h)
-    n_cont = 0
-    for line in fh:
-        f = line.rstrip("\n").split("\t")
-        if len(f) <= max(sci, chi): continue
-        if not (f[si].startswith("NCBITaxon:") and f[oi].startswith("GO:")): continue
-        if not is_cont(f): continue
-        n_cont += 1
-        try: sc = float(f[sci])
-        except ValueError: continue
-        deg[f[oi]] += 1
-        tot[f[oi]] += sc
+# shape -> (term prefix, taxon prefix, which column holds the term)
+SHAPES = {
+    "go": ("GO:", "NCBITaxon:", "object"),
+    "envo": ("ENVO:", "NCBITaxon:", "subject"),
+    "bto": ("BTO:", "NCBITaxon:", "subject"),
+}
 
-assert_non_empty(n_cont, layout)
-print(f"  layout: {layout}")
-rows = [(deg[g], tot[g] / deg[g], g) for g in deg if deg[g] >= 50]
-rows.sort()
-print(f"  GO terms with >=50 continuous-channel edges: {len(rows):,}\n")
-print(f"  {'ubiquity decile':>15} {'degree range':>22} {'terms':>7} {'mean score':>11}")
-k = len(rows) // 10
-for d in range(10):
-    lo, hi = d * k, (d + 1) * k if d < 9 else len(rows)
-    w = rows[lo:hi]
-    if not w: continue
-    ms = sum(r[1] for r in w) / len(w)
-    print(f"  {d+1:>15} {w[0][0]:>9,}-{w[-1][0]:<11,} {len(w):>7,} {ms:>10.3f}")
 
-# Spearman-ish: rank correlation between degree and mean score
-n = len(rows)
-by_deg = sorted(range(n), key=lambda i: rows[i][0])
-by_scr = sorted(range(n), key=lambda i: rows[i][1])
-rd = [0]*n; rs = [0]*n
-for r, i in enumerate(by_deg): rd[i] = r
-for r, i in enumerate(by_scr): rs[i] = r
-mean_d = mean_s = (n - 1) / 2
-num = sum((rd[i]-mean_d)*(rs[i]-mean_s) for i in range(n))
-den = (sum((rd[i]-mean_d)**2 for i in range(n)) * sum((rs[i]-mean_s)**2 for i in range(n))) ** 0.5
-print(f"\n  Spearman rank correlation (GO degree vs mean score): {num/den:+.4f}")
-print("    positive => score tracks ubiquity, supporting the hypothesis")
+def parse_args() -> argparse.Namespace:
+    """
+    Parse the command line.
+
+    :return: Parsed arguments, with ``degree`` defaulted per shape.
+    """
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--shape", choices=sorted(SHAPES), default="go", help="edge shape to measure (default: go)")
+    parser.add_argument(
+        "--degree",
+        choices=("taxa", "edges"),
+        default=None,
+        help=(
+            "how to count a term's degree: distinct taxa, or rows. Default is 'edges' for go, "
+            "which reproduces the published run, and 'taxa' otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--min-edges", type=int, default=50, help="minimum continuous-channel edges per term (default: 50)"
+    )
+    parser.add_argument("--edges", default="data/transformed/prego/edges.tsv", help="path to edges.tsv")
+    args = parser.parse_args()
+    if args.degree is None:
+        args.degree = "edges" if args.shape == "go" else "taxa"
+    return args
+
+
+def accumulate(path: str, shape: str) -> Tuple[Dict[str, Set[str]], Dict[str, int], Dict[str, float], str]:
+    """
+    Scan ``edges.tsv`` once, collecting per-term taxa, edge counts and score sums.
+
+    :param path: Path to ``edges.tsv``.
+    :param shape: Key into :data:`SHAPES`.
+    :return: ``(taxa_by_term, edges_by_term, score_sum_by_term, layout)``.
+    """
+    term_prefix, taxon_prefix, term_col = SHAPES[shape]
+    taxa: Dict[str, Set[str]] = defaultdict(set)
+    edges: Dict[str, int] = defaultdict(int)
+    total: Dict[str, float] = defaultdict(float)
+    with open(path) as handle:
+        header = next(handle).rstrip("\n").split("\t")
+        subject_i, object_i = header.index("subject"), header.index("object")
+        score_i = header.index("prego_score")
+        is_continuous, layout = continuous_predicate(header)
+        term_i, taxon_i = (subject_i, object_i) if term_col == "subject" else (object_i, subject_i)
+        n_continuous = 0
+        for line in handle:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) <= score_i:
+                continue
+            if not (fields[term_i].startswith(term_prefix) and fields[taxon_i].startswith(taxon_prefix)):
+                continue
+            if not is_continuous(fields):
+                continue
+            n_continuous += 1
+            try:
+                score = float(fields[score_i])
+            except ValueError:
+                continue
+            taxa[fields[term_i]].add(fields[taxon_i])
+            edges[fields[term_i]] += 1
+            total[fields[term_i]] += score
+    assert_non_empty(n_continuous, layout)
+    return taxa, edges, total, layout
+
+
+def spearman(rows: List[Tuple[int, float, str]]) -> float:
+    """
+    Rank correlation between each row's degree and its mean score.
+
+    :param rows: Sequence of ``(degree, mean_score, term)`` tuples.
+    :return: Spearman's rho, or 0.0 when it is undefined.
+    """
+    n = len(rows)
+    by_degree = sorted(range(n), key=lambda i: rows[i][0])
+    by_score = sorted(range(n), key=lambda i: rows[i][1])
+    rank_d, rank_s = [0] * n, [0] * n
+    for rank, i in enumerate(by_degree):
+        rank_d[i] = rank
+    for rank, i in enumerate(by_score):
+        rank_s[i] = rank
+    mean = (n - 1) / 2
+    num = sum((rank_d[i] - mean) * (rank_s[i] - mean) for i in range(n))
+    den = (sum((rank_d[i] - mean) ** 2 for i in range(n)) * sum((rank_s[i] - mean) ** 2 for i in range(n))) ** 0.5
+    return num / den if den else 0.0
+
+
+def report(rows: List[Tuple[int, float, str]], label: str) -> None:
+    """
+    Print the ubiquity decile table.
+
+    :param rows: ``(degree, mean_score, term)`` tuples, sorted by degree.
+    :param label: Shape name for the header.
+    """
+    print(f"  {'ubiquity decile':>15} {'degree range':>22} {'terms':>7} {'mean score':>11}")
+    width = max(1, len(rows) // 10)
+    for decile in range(10):
+        lo, hi = decile * width, (decile + 1) * width if decile < 9 else len(rows)
+        window = rows[lo:hi]
+        if not window:
+            continue
+        mean_score = sum(r[1] for r in window) / len(window)
+        print(f"  {decile + 1:>15} {window[0][0]:>9,}-{window[-1][0]:<11,} {len(window):>7,} {mean_score:>10.3f}")
+    print(f"\n  Spearman rank correlation ({label} degree vs mean score): {spearman(rows):+.4f}")
+    print("    positive => score tracks ubiquity, supporting the hypothesis")
+
+
+def main() -> None:
+    """Run the ubiquity check and print the decile table plus the correlation."""
+    args = parse_args()
+    taxa, edges, total, layout = accumulate(args.edges, args.shape)
+    label = args.shape.upper()
+    degree_of: Callable[[str], int] = (
+        (lambda term: len(taxa[term])) if args.degree == "taxa" else (lambda term: edges[term])
+    )
+
+    rows = [(degree_of(t), total[t] / edges[t], t) for t in edges if edges[t] >= args.min_edges]
+    rows.sort()
+    print(f"  layout: {layout}")
+    described = "distinct taxa" if args.degree == "taxa" else "edge count"
+    print(f"  degree measured as: {described}")
+    if rows and args.degree == "taxa":
+        # Quantifies what the edge-count approximation would have overstated.
+        counted = sum(edges[t] for _, _, t in rows)
+        distinct = sum(len(taxa[t]) for _, _, t in rows)
+        print(f"  edges per distinct taxon over these terms: {counted / max(1, distinct):.3f}x")
+    print(f"  {label} terms with >={args.min_edges} continuous-channel edges: {len(rows):,}\n")
+    if not rows:
+        raise SystemExit(f"no {label} terms cleared --min-edges {args.min_edges}; nothing to report.")
+    report(rows, label)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The ubiquity finding — PREGO's score tracks how *common* a term is rather than how well supported it is — was measured on **GO terms only**, and was being carried into habitat threshold reasoning where it had never been tested. Habitat (`biolink:location_of`, 452,051 edges) is the part of PREGO with measured enrichment, so this was the gap blocking a defensible threshold.

**It does not transfer.**

## Findings

**ENVO is U-shaped, not monotone** (Spearman +0.3016, 223 terms). The rarest three deciles score ~1.0–1.09, *above* the mid deciles (0.63–0.73); only the top two rise clearly. The GO pathology — rare, specific terms score lowest and get stripped first — does not hold for habitat. BTO is closer to monotone (+0.5967, 70 terms) and does behave like a ubiquity ranking.

**The genome channel is not flat for habitat edges.** 33.3% score-3 for ENVO (12,562/37,749), 80.5% for BTO (5,360/6,661); no value but 3 or 4 occurs. Those 17,922 rows are ~89% of the ~20k `CLAUDE.md` attributes to the channel as a whole — that figure is a whole-channel average dominated by the 44.3M `capable_of` edges. So `τ > 3` deletes **4.0% of all habitat edges** on provenance, not quality. `CLAUDE.md` corrected.

**The BTO continuous channel is not continuous above 2.0**: 23,565 edges below 2.0, 5,596 at exactly 4.0, nothing between. Every τ in [2.0, 4.0] is the same filter.

## Recommendation

**τ = 1.0 on the continuous channel, genome channel kept whole.** The knee: 7.89x → 11.59x enrichment while retaining 70.9% of distinct habitat terms and 60.6% of taxa, median term degree up only 14%. τ = 3.0 maximises measured overlap (18.79x) but keeps 8.7% of edges and 37% of taxa — on an in-sample optimum with no held-out validation, against a positive-only standard where overlap is not precision.

Flagged in the doc as **a judgement, not a measurement**: no precision/utility target exists for habitat edges, and one would move the answer. What the data settles is the shape of the trade, not the point on it.

`PREGO_MIN_CONFIDENCE` cannot express this policy — one global star threshold cannot keep the genome channel whole while filtering the continuous one — so the doc gives the downstream `awk` filter instead. This suits ingesting all habitat data and filtering per experiment.

## Changes

- `ubiquity_check.py` — `--shape {go,envo,bto}`, `--degree {taxa,edges}`. Handles the orientation flip (habitat puts the term in the *subject*) and counts distinct taxa rather than edges, since MG-RAST contributes both amplicon and metagenome studies so a pair can repeat (ENVO 1.063x).
- `habitat_threshold_check.py` (new) — coverage and specificity cost per threshold; the question a positive-only gold standard cannot answer.
- `docs/PREGO_SCORE_VALIDATION.md`, `CLAUDE.md`, `scripts/prego_validation/README.md`.

## Verification

- `--shape go --degree edges` reproduces the published run **exactly**: 3,830 terms, identical decile table, Spearman +0.2592.
- `poetry run tox` green, 927 tests.
- Measured on the current `edges.tsv` (12.17 GB, post-#722).

🤖 Generated with [Claude Code](https://claude.com/claude-code)