### PR TITLE
PREGO habitat-only emission at the transform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,23 @@ Optional, for the ontology transforms:
   actually applied to `data/transformed/prego/confidence_calibration.tsv`. The
   channel is derived from the **archive filename**, not from any column.
 
+- `PREGO_SHAPES`: `all` (default) or `habitat`. `habitat` emits only the
+  `location_of` shapes (ENVO/BTO → taxon) — ~238k edges against 44.7M, a 55 MB
+  `edges.tsv` instead of 12.2 GB. PREGO's taxon→GO edges are 99% of the source
+  by volume and have no positive evidence in any of the four gold standards,
+  while the habitat edges are 7.89x enriched against BacDive isolation and
+  replicate at 2.01x against the independent Madin standard.
+
+- `PREGO_HABITAT_MIN_SCORE`: raw-score floor for *continuous-channel* habitat
+  rows, default `1.0`, applied only when `PREGO_SHAPES=habitat`. The genome
+  channel is kept whole deliberately: its habitat scores are only ever 3 or 4,
+  so a star threshold would delete 4% of habitat on provenance rather than
+  quality. Set `0` to disable. See `docs/PREGO_SCORE_VALIDATION.md`.
+
+  Standard merges use `merge.habitat.yaml` (habitat-only PREGO) or
+  `merge.noprego.yaml` (no PREGO); `merge.yaml` keeps the full source for
+  experimental builds.
+
   **If your goal is merge memory or graph size, reach for `merge.noprego.yaml`
   first** — it drops PREGO entirely (~76% of merge input) and needs none of this
   machinery. `PREGO_MIN_CONFIDENCE` is the finer-grained alternative for when

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -101,6 +101,12 @@ from kg_microbe.utils.atomic_io import atomic_write
 # Emitted-shape selection. `habitat` keeps only the location_of shapes.
 _SHAPES_ALL = "all"
 _SHAPES_HABITAT = "habitat"
+# Habitat output lives apart from the full build so both can coexist.
+_HABITAT_OUTPUT_DIR = "prego_habitat"
+
+# Drops that are deliberate configuration rather than data-quality problems.
+# Counted in the summary, excluded from the curation report.
+_CONFIGURED_DROP_REASONS = frozenset({"non_habitat_shape", "below_habitat_min_score"})
 
 _LOCATION_OF_PREDICATE = "biolink:location_of"
 _ASSOCIATED_WITH_PREDICATE = "biolink:associated_with"
@@ -227,6 +233,16 @@ class PregoTransform(Transform):
         # it under `all` would silently thin habitat inside an otherwise
         # unfiltered run, which nothing documents and no caller asks for.
         self.habitat_min_score = habitat_min_score if shapes == _SHAPES_HABITAT else 0.0
+        if shapes == _SHAPES_HABITAT:
+            # Its own directory, so the two builds cannot overwrite each other and
+            # merge.habitat.yaml selects what it claims to. Sharing one path made
+            # the config a label rather than a selector: running it against a full
+            # PREGO output would silently ship a 44.7M-edge graph as "habitat only".
+            self.output_dir = self.output_base_dir / _HABITAT_OUTPUT_DIR
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            self.output_node_file = self.output_dir / "nodes.tsv"
+            self.output_edge_file = self.output_dir / "edges.tsv"
+            self.unmapped_report_file = self.output_dir / "unmapped_associations.tsv"
         print(
             f"[prego] shapes={self.shapes} min_confidence={self.min_confidence} "
             f"habitat_min_score={self.habitat_min_score}"
@@ -1060,12 +1076,23 @@ class PregoTransform(Transform):
         """
         self._stats["rows_dropped"] += 1
         self._stats["rows_dropped_by_reason"][reason] += 1
+        if reason in _CONFIGURED_DROP_REASONS:
+            # Counted, but no exemplar: this is the operator getting what they
+            # configured, not a data-quality problem to chase. Bypassing this
+            # method entirely was the first attempt and it silently broke the
+            # `dropped=` summary, which is derived here — 44.5M rows vanished
+            # from the arithmetic while still being filtered.
+            return
         bucket = self._drop_examples[reason]
         if len(bucket) >= self._MAX_EXAMPLES_PER_REASON:
             return
         key = f"{e1_type}:{e1_id}->{e2_type}:{e2_id}"
         bucket[key] += 1
 
+    # Deliberate configuration is counted in rows_dropped_by_reason but kept out
+    # of the curation report: a curator opening it in habitat mode would find the
+    # two largest entries are things nobody should act on, burying the real
+    # signals (bto_id_prefix_mismatch, doid_no_mondo_xref, empty_id).
     def _write_unmapped_report(self) -> None:
         """
         Emit ``unmapped_associations.tsv`` — the per-run curation report.

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -98,6 +98,10 @@ from kg_microbe.utils.atomic_io import atomic_write
 # Edge predicates and relations. PREGO uses only biolink predicates; the
 # RELATION_COLUMN carries an RO term where an obvious one applies, else empty.
 # ---------------------------------------------------------------------------
+# Emitted-shape selection. `habitat` keeps only the location_of shapes.
+_SHAPES_ALL = "all"
+_SHAPES_HABITAT = "habitat"
+
 _LOCATION_OF_PREDICATE = "biolink:location_of"
 _ASSOCIATED_WITH_PREDICATE = "biolink:associated_with"
 _RELATION_LOCATION_OF = "RO:0001015"  # source → location_of → organism
@@ -174,12 +178,22 @@ class PregoTransform(Transform):
         input_dir: Optional[Path] = None,
         output_dir: Optional[Path] = None,
         min_confidence: Optional[float] = None,
+        shapes: Optional[str] = None,
+        habitat_min_score: Optional[float] = None,
     ):
         """
         Instantiate; register the source name + extend the edge header with PREGO metadata.
 
         :param input_dir: Raw data directory.
         :param output_dir: Transform output directory.
+        :param shapes: ``all`` (default) or ``habitat``. ``habitat`` emits only the
+            ``location_of`` shapes (ENVO/BTO -> taxon), which are ~1% of PREGO by
+            volume and the only part with measured, independently replicated
+            enrichment. Env: ``PREGO_SHAPES``.
+        :param habitat_min_score: Raw-score floor applied to *continuous-channel*
+            habitat rows only, leaving the genome channel whole. Defaults to 1.0,
+            the policy in ``docs/PREGO_SCORE_VALIDATION.md``; set 0 to disable.
+            Env: ``PREGO_HABITAT_MIN_SCORE``.
         :param min_confidence: Star threshold in [0, 4]; rows below it are
             dropped. Defaults to the ``PREGO_MIN_CONFIDENCE`` environment
             variable, else 0.0 (emit everything, preserving current behaviour).
@@ -200,6 +214,23 @@ class PregoTransform(Transform):
             min_confidence = float(os.environ.get("PREGO_MIN_CONFIDENCE", "0") or 0)
         validate_tau(min_confidence)
         self.min_confidence = min_confidence
+        if shapes is None:
+            shapes = os.environ.get("PREGO_SHAPES", _SHAPES_ALL).strip().lower() or _SHAPES_ALL
+        if shapes not in (_SHAPES_ALL, _SHAPES_HABITAT):
+            raise ValueError(f"PREGO_SHAPES must be {_SHAPES_ALL!r} or {_SHAPES_HABITAT!r}, got {shapes!r}")
+        self.shapes = shapes
+        if habitat_min_score is None:
+            habitat_min_score = float(os.environ.get("PREGO_HABITAT_MIN_SCORE", "1.0") or 0)
+        if habitat_min_score < 0:
+            raise ValueError(f"PREGO_HABITAT_MIN_SCORE must be >= 0, got {habitat_min_score}")
+        # Only meaningful when habitat shapes are what is being emitted. Applying
+        # it under `all` would silently thin habitat inside an otherwise
+        # unfiltered run, which nothing documents and no caller asks for.
+        self.habitat_min_score = habitat_min_score if shapes == _SHAPES_HABITAT else 0.0
+        print(
+            f"[prego] shapes={self.shapes} min_confidence={self.min_confidence} "
+            f"habitat_min_score={self.habitat_min_score}"
+        )
         self._cutoffs: dict = {}
         self._payload_cache: dict = {}
         # Per-resource cutoffs actually applied, written next to the outputs
@@ -775,6 +806,14 @@ class PregoTransform(Transform):
             self._record_drop(outcome, entity1_type, entity1_id, entity2_type, entity2_id)
             return
 
+        # Shape filter, applied before anything is emitted. Habitat is ~1% of
+        # PREGO by volume, so filtering here rather than downstream is what makes
+        # the difference between a 12.2 GB edges.tsv and a ~65 MB one — and a
+        # three-hour merge and a routine one.
+        if self.shapes == _SHAPES_HABITAT and outcome not in (KEEP_ENVO_TO_TAXON, KEEP_TAXON_TO_BTO):
+            self._record_drop("non_habitat_shape", entity1_type, entity1_id, entity2_type, entity2_id)
+            return
+
         if outcome == KEEP_TAXON_TO_GO:
             # Defensive: some source rows type-tag GO (-21/-22/-23) but
             # carry a non-GO identifier (rare data-quality edge case).
@@ -785,8 +824,7 @@ class PregoTransform(Transform):
             obj = entity2_id
             predicate = CAPABLE_OF_PREDICATE
             relation = _RELATION_CAPABLE_OF
-            self._emit_node(node_writer, subject, _NCBITAXON_CATEGORY)
-            self._emit_node(node_writer, obj, go_category_for_type(entity2_type))
+            pending_nodes = ((subject, _NCBITAXON_CATEGORY), (obj, go_category_for_type(entity2_type)))
 
         elif outcome == KEEP_ENVO_TO_TAXON:
             if not entity1_id.startswith("ENVO:"):
@@ -796,8 +834,7 @@ class PregoTransform(Transform):
             obj = f"NCBITaxon:{entity2_id}"
             predicate = _LOCATION_OF_PREDICATE
             relation = _RELATION_LOCATION_OF
-            self._emit_node(node_writer, subject, _ENVO_CATEGORY)
-            self._emit_node(node_writer, obj, _NCBITAXON_CATEGORY)
+            pending_nodes = ((subject, _ENVO_CATEGORY), (obj, _NCBITAXON_CATEGORY))
 
         elif outcome == KEEP_TAXON_TO_DOID:
             mondo = doid_to_mondo.get(entity2_id)
@@ -809,8 +846,7 @@ class PregoTransform(Transform):
             obj = mondo
             predicate = _ASSOCIATED_WITH_PREDICATE
             relation = _RELATION_ASSOCIATED_WITH
-            self._emit_node(node_writer, subject, _NCBITAXON_CATEGORY)
-            self._emit_node(node_writer, obj, _MONDO_CATEGORY)
+            pending_nodes = ((subject, _NCBITAXON_CATEGORY), (obj, _MONDO_CATEGORY))
 
         else:  # KEEP_TAXON_TO_BTO
             # Some source rows type-tag BTO (-25) but carry a non-BTO
@@ -827,8 +863,7 @@ class PregoTransform(Transform):
             obj = f"NCBITaxon:{entity1_id}"
             predicate = _LOCATION_OF_PREDICATE
             relation = _RELATION_LOCATION_OF
-            self._emit_node(node_writer, subject, _BTO_CATEGORY)
-            self._emit_node(node_writer, obj, _NCBITAXON_CATEGORY)
+            pending_nodes = ((subject, _BTO_CATEGORY), (obj, _NCBITAXON_CATEGORY))
 
         # Applied last, after every eligibility check. Run earlier it attributed
         # rows to "below_min_confidence" that would have been dropped anyway,
@@ -840,6 +875,23 @@ class PregoTransform(Transform):
         ):
             self._record_drop("below_min_confidence", entity1_type, entity1_id, entity2_type, entity2_id)
             return
+
+        # Habitat score policy (docs/PREGO_SCORE_VALIDATION.md): threshold the
+        # continuous channel, keep the genome channel whole. The genome channel
+        # scores only 3 or 4 for habitat shapes, so a star threshold cannot
+        # express this — above 3 it would delete 4% of habitat outright, on
+        # provenance rather than quality.
+        if self.habitat_min_score > 0 and channel == CHANNEL_ENVIRONMENTAL:
+            if _as_float(score) < self.habitat_min_score:
+                self._record_drop("below_habitat_min_score", entity1_type, entity1_id, entity2_type, entity2_id)
+                return
+
+        # Emitted only now, once the row is certain to survive. Emitting inside
+        # the shape branches wrote a node for every edge the filters below then
+        # dropped, so PREGO_MIN_CONFIDENCE left orphan nodes behind — nodes with
+        # no incident edge, which merge then carries into the graph.
+        for node_id, category in pending_nodes:
+            self._emit_node(node_writer, node_id, category)
 
         edge_writer.writerow(
             self._make_edge_row(

--- a/merge.habitat.yaml
+++ b/merge.habitat.yaml
@@ -1,0 +1,296 @@
+---
+# Standard merge configuration (Bakta and COG excluded)
+# For Bakta-enabled merge, use merge_bakta.yaml instead
+#
+# Usage: poetry run kg merge -y merge.yaml
+#
+configuration:
+  output_directory: data/merged
+  checkpoint: false
+  # Allow domain-specific categories from METPO ontology
+  # METPO:1004005 represents the "growth medium" ontology class
+  # This preserves semantic precision for microbial growth media
+  category_allowlist:
+    - "METPO:1004005"  # growth medium
+  curie_map:
+    # define non-canonical CURIE to IRI mappings (for RDF)
+  node_properties:
+    # define predicates that are to be treated as direct node properties (for RDF)
+  predicate_mappings:
+    # map non-canonical predicates to a property name (for RDF)
+  property_types:
+    # define the type for non-canonical properties for RDF export
+  preserve:
+    - primary_knowledge_source
+
+merged_graph:
+  name: kg-microbe graph
+  source:
+    ncbitaxon:
+      name: "NCBITaxon"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/ncbitaxon_nodes.tsv
+          - data/transformed/ontologies/ncbitaxon_edges.tsv
+    chebi:
+      name: "CHEBI"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/chebi_nodes.tsv
+          - data/transformed/ontologies/chebi_edges.tsv
+    envo:
+      name: "ENVO"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/envo_nodes.tsv
+          - data/transformed/ontologies/envo_edges.tsv
+    go:
+      name: "GO"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/go_nodes.tsv
+          - data/transformed/ontologies/go_edges.tsv
+    # mondo:
+    #   name: "MONDO"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/ontologies/mondo_nodes.tsv
+    #       - data/transformed/ontologies/mondo_edges.tsv
+    # hp:
+    #   name: "HP"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/ontologies/hp_nodes.tsv
+    #       - data/transformed/ontologies/hp_edges.tsv
+    ec:
+      name: "EC"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/ec_nodes.tsv
+          - data/transformed/ontologies/ec_edges.tsv
+    metpo:
+      name: "METPO"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/metpo_nodes.tsv
+          - data/transformed/ontologies/metpo_edges.tsv
+    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, and MICRO —
+    # only the IDs referenced by mappings/* are imported (not the full
+    # ontologies). See kg_microbe/transform_utils/ontologies_stubs/ for
+    # the transform.
+    ontologies_stubs:
+      name: "ontologies_stubs"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies_stubs/ncit_nodes.tsv
+          - data/transformed/ontologies_stubs/ncit_edges.tsv
+          - data/transformed/ontologies_stubs/mesh_nodes.tsv
+          - data/transformed/ontologies_stubs/mesh_edges.tsv
+          - data/transformed/ontologies_stubs/bto_nodes.tsv
+          - data/transformed/ontologies_stubs/po_nodes.tsv
+          - data/transformed/ontologies_stubs/po_edges.tsv
+          - data/transformed/ontologies_stubs/micro_nodes.tsv
+          - data/transformed/ontologies_stubs/micro_edges.tsv
+    bacdive:
+      name: "bacdive"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/bacdive/nodes.tsv
+          - data/transformed/bacdive/edges.tsv
+    mediadive:
+      name: "mediadive"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/mediadive/nodes.tsv
+          - data/transformed/mediadive/edges.tsv
+    rhea_mappings:
+      name: "rhea_mappings"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/rhea_mappings/nodes.tsv
+          - data/transformed/rhea_mappings/edges.tsv
+    upa:
+      input:
+        name: "upa"
+        format: tsv
+        filename:
+          - data/transformed/ontologies/upa_nodes.tsv
+          - data/transformed/ontologies/upa_edges.tsv
+    madin_etal:
+      input:
+        name: "madin_etal"
+        format: tsv
+        filename:
+          - data/transformed/madin_etal/nodes.tsv
+          - data/transformed/madin_etal/edges.tsv
+    metatraits:
+      input:
+        name: "metatraits"
+        format: tsv
+        filename:
+          - data/transformed/metatraits/nodes.tsv
+          - data/transformed/metatraits/edges.tsv
+    metatraits_gtdb:
+      input:
+        name: "metatraits_gtdb"
+        format: tsv
+        filename:
+          - data/transformed/metatraits_gtdb/nodes.tsv
+          - data/transformed/metatraits_gtdb/edges.tsv
+    bactotraits:
+      input:
+        name: "bactotraits"
+        format: tsv
+        filename:
+          - data/transformed/bactotraits/nodes.tsv
+          - data/transformed/bactotraits/edges.tsv
+    # bakta_cmm:
+    #   name: "bakta_cmm"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/bakta/cmm_bakta/nodes.tsv
+    #       - data/transformed/bakta/cmm_bakta/edges.tsv
+    # bakta_pfas:
+    #   name: "bakta_pfas"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/bakta/pfas_bakta/nodes.tsv
+    #       - data/transformed/bakta/pfas_bakta/edges.tsv
+    # cog:
+    #   name: "cog"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/cog/nodes.tsv
+    #       - data/transformed/cog/edges.tsv
+    gtdb:
+      name: "GTDB Taxonomy"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/gtdb/nodes.tsv
+          - data/transformed/gtdb/edges.tsv
+    # LPSN nomenclature. `lpsn` is the fast GSS/CSV base layer (taxon
+    # names, ranks, GTDB/NCBITaxon cross-refs); `lpsn_api` is the
+    # authenticated JSON-API enrichment (above-genus taxonomy, basonyms,
+    # publication DOIs/PMIDs, 16S INSDC accessions). The API enrichment
+    # nodes reference lpsn:* records minted by the GSS layer, so both are
+    # merged together.
+    lpsn:
+      name: "LPSN"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/lpsn/nodes.tsv
+          - data/transformed/lpsn/edges.tsv
+    lpsn_api:
+      name: "LPSN API"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/lpsn_api/nodes.tsv
+          - data/transformed/lpsn_api/edges.tsv
+    # MicrobeDecoder (Hackmann & Zhang, Sci Adv 2023) — Bergey / VPI /
+    # Literature / FAPROTAX curated fermentation profiles keyed on
+    # lpsn:<LPSN_ID>, plus a pre-joined LPSN ↔ GTDB ↔ NCBI ↔ GOLD ↔ IMG ↔
+    # BacDive identity crosswalk. See kg_microbe/transform_utils/microbedecoder/.
+    microbedecoder:
+      name: "MicrobeDecoder"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/microbedecoder/nodes.tsv
+          - data/transformed/microbedecoder/edges.tsv
+    # PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
+    # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
+    # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO
+    # associated_with (via DOID→MONDO xref). See docs/PREGO_INGEST_PLAN.md.
+    # PREGO habitat only. Produce the input with:
+    #   PREGO_SHAPES=habitat poetry run kg transform -s prego
+    # which emits ~238k location_of edges instead of 44.7M, at the tau=1.0
+    # continuous-channel policy in docs/PREGO_SCORE_VALIDATION.md. PREGO's
+    # taxon->GO edges are excluded deliberately: they are 99% of the source by
+    # volume and have no positive evidence in any of the four gold standards.
+    prego:
+      name: "PREGO (habitat only)"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/prego/nodes.tsv
+          - data/transformed/prego/edges.tsv
+    # kegg:
+    #   name: "kegg"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/kegg/nodes.tsv
+    #       - data/transformed/kegg/edges.tsv
+    # ctd:
+    #   input:
+    #     name: "ctd"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/ctd/nodes.tsv
+    #       - data/transformed/ctd/edges.tsv
+    # disbiome:
+    #   input:
+    #     name: "disbiome"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/disbiome/nodes.tsv
+    #       - data/transformed/disbiome/edges.tsv
+    # wallen_etal:
+    #   input:
+    #     name: "wallen_etal"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/wallen_etal/nodes.tsv
+    #       - data/transformed/wallen_etal/edges.tsv
+    # Not feasible using kgx merge process
+    # uniprot_functional_microbes:
+    #   input:
+    #     name: "uniprot_functional_microbes"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/uniprot_functional_microbes/nodes.tsv
+    #       - data/transformed/uniprot_functional_microbes/edges.tsv
+    # uniprot_human:
+    #   input:
+    #     name: "uniprot_human"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/uniprot_human/nodes.tsv
+    #       - data/transformed/uniprot_human/edges.tsv
+  operations:
+    - name: kgx.graph_operations.summarize_graph.generate_graph_stats
+      args:
+        graph_name: kg-microbe graph
+        filename: merged_graph_stats.yaml
+        node_facet_properties:
+          - provided_by
+        edge_facet_properties:
+          - provided_by
+          - source
+  destination:
+    merged-kg-tsv:
+      format: tsv
+      compression: tar.gz
+      filename: merged-kg
+#    merged-kg-nt:
+#      format: nt
+#      compression: gz
+#      filename: kg_microbe.nt.gz

--- a/merge.habitat.yaml
+++ b/merge.habitat.yaml
@@ -230,8 +230,8 @@ merged_graph:
       input:
         format: tsv
         filename:
-          - data/transformed/prego/nodes.tsv
-          - data/transformed/prego/edges.tsv
+          - data/transformed/prego_habitat/nodes.tsv
+          - data/transformed/prego_habitat/edges.tsv
     # kegg:
     #   name: "kegg"
     #   input:

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -1377,3 +1377,99 @@ def test_emitted_edges_carry_populated_metadata(prego_input_dir: Path, prego_out
     # would only test the HEADER — `e` is a DictReader dict — and would pass
     # with every cell empty, which is the failure this is meant to exclude.
     assert all(e["prego_evidence"] for e in edges), "prego_evidence values must be populated"
+
+
+# ---------------------------------------------------------------------------
+# Shape selection: habitat-only emission (PREGO_SHAPES)
+# ---------------------------------------------------------------------------
+
+
+def test_habitat_shapes_emit_only_location_of(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    PREGO is ~99% taxon->GO by volume, and that part has no positive evidence.
+
+    Filtering in the transform rather than downstream is the difference between
+    a 12.2 GB edges.tsv and a ~65 MB one, and between a three-hour merge and a
+    routine one. Filtering downstream also cannot fix nodes.tsv.
+    """
+    transform = PregoTransform(
+        input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitat", habitat_min_score=0
+    )
+    transform.run()
+    edges = _read_tsv(transform.output_edge_file)
+
+    assert edges, "habitat mode must still emit something"
+    predicates = {e["predicate"] for e in edges}
+    assert predicates == {"biolink:location_of"}, predicates
+    assert not any(e["predicate"] == CAPABLE_OF_PREDICATE for e in edges)
+
+
+def test_habitat_mode_leaves_no_orphan_nodes(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    Every emitted node must be incident to an emitted edge.
+
+    Node emission used to happen inside the shape branches, before the filters
+    below could reject the row, so a dropped edge still wrote its nodes. In
+    habitat mode that would have written a GO node for all ~44M taxon->GO rows.
+    """
+    transform = PregoTransform(
+        input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitat", habitat_min_score=0
+    )
+    transform.run()
+    nodes = {n["id"] for n in _read_tsv(transform.output_node_file)}
+    incident = set()
+    for edge in _read_tsv(transform.output_edge_file):
+        incident.add(edge["subject"])
+        incident.add(edge["object"])
+
+    assert nodes, "habitat mode must still emit nodes"
+    assert not (nodes - incident), f"orphan nodes emitted: {sorted(nodes - incident)[:5]}"
+    assert not any(n.startswith("GO:") for n in nodes), "no GO nodes belong in a habitat-only build"
+
+
+def test_min_confidence_no_longer_leaves_orphan_nodes(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    The same ordering bug affected the pre-existing star threshold.
+
+    `_emit_node` ran before `keep_row`, so every edge PREGO_MIN_CONFIDENCE
+    dropped still contributed its nodes to nodes.tsv, and merge carried those
+    orphans into the graph.
+    """
+    transform = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, min_confidence=4)
+    transform.run()
+    nodes = {n["id"] for n in _read_tsv(transform.output_node_file)}
+    incident = set()
+    for edge in _read_tsv(transform.output_edge_file):
+        incident.add(edge["subject"])
+        incident.add(edge["object"])
+
+    assert not (nodes - incident), f"orphan nodes emitted: {sorted(nodes - incident)[:5]}"
+
+
+def test_habitat_min_score_thresholds_only_the_continuous_channel(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    Genome-channel habitat scores are only ever 3 or 4.
+
+    A threshold that applied to them would delete 4% of habitat outright on
+    provenance rather than quality, so the floor is continuous-channel only.
+    """
+    transform = PregoTransform(
+        input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitat", habitat_min_score=99
+    )
+    transform.run()
+    edges = _read_tsv(transform.output_edge_file)
+    channels = {e["prego_channel"] for e in edges}
+
+    assert CHANNEL_ENVIRONMENTAL not in channels, "an unreachable floor must empty the continuous channel"
+    assert channels, "the genome channel must survive any continuous-channel floor"
+    assert channels <= {CHANNEL_GENOMES, CHANNEL_LITERATURE}, channels
+
+
+def test_shapes_defaults_to_all_and_rejects_nonsense(prego_input_dir: Path, prego_output_dir: Path):
+    """Unfiltered stays the default, and a typo must fail loudly rather than silently emit everything."""
+    default = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    assert default.shapes == "all"
+    assert default.habitat_min_score == 0.0, "the habitat floor must not apply to an unfiltered run"
+
+    with pytest.raises(ValueError, match="PREGO_SHAPES"):
+        PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitats")

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -1473,3 +1473,46 @@ def test_shapes_defaults_to_all_and_rejects_nonsense(prego_input_dir: Path, preg
 
     with pytest.raises(ValueError, match="PREGO_SHAPES"):
         PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitats")
+
+
+def test_habitat_mode_writes_to_its_own_directory(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    The two builds must not overwrite each other.
+
+    Sharing one output path made merge.habitat.yaml a label rather than a
+    selector: pointed at a full PREGO output it would ship a 44.7M-edge graph
+    as "habitat only", with nothing to catch the mislabelling.
+    """
+    full = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    habitat = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitat")
+
+    assert habitat.output_dir != full.output_dir
+    assert habitat.output_dir.name == "prego_habitat"
+    assert habitat.output_edge_file != full.output_edge_file
+    assert habitat.unmapped_report_file != full.unmapped_report_file
+
+    habitat.run()
+    full.run()
+    assert habitat.output_edge_file.exists() and full.output_edge_file.exists()
+    habitat_predicates = {e["predicate"] for e in _read_tsv(habitat.output_edge_file)}
+    assert habitat_predicates == {"biolink:location_of"}, "the habitat build must survive a later full run"
+
+
+def test_deliberate_filters_stay_out_of_the_curation_report(prego_input_dir: Path, prego_output_dir: Path):
+    """
+    The report is for data-quality problems a curator should act on.
+
+    Recording the shape and score filters there put the two largest entries in
+    front of a curator as things nobody should act on, burying the real signals.
+    They remain counted in the run summary.
+    """
+    transform = PregoTransform(
+        input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitat", habitat_min_score=1.0
+    )
+    transform.run()
+    reasons = {r["reason"] for r in _read_tsv(transform.unmapped_report_file)}
+
+    assert "non_habitat_shape" not in reasons, reasons
+    assert "below_habitat_min_score" not in reasons, reasons
+    counted = transform._stats["rows_dropped_by_reason"]
+    assert counted.get("non_habitat_shape", 0) > 0, "but it must still be counted in the summary"


### PR DESCRIPTION
PREGO is experimental and won't be part of standard merges except, perhaps, habitat only. This adds that mode where it has to live — in the transform.

## Why not downstream

An `awk` over `edges.tsv` cannot fix `nodes.tsv`. A downstream filter leaves the ~30k GO nodes referenced only by the removed `capable_of` edges, shipping orphans. Filtering at emit time is also where it pays: habitat is ~1% of PREGO by volume, so it's the difference between a **12.2 GB `edges.tsv` and a 55 MB one**, and between a three-hour merge and a routine one.

## What's added

`PREGO_SHAPES=all|habitat` and `PREGO_HABITAT_MIN_SCORE` (default 1.0), implementing the policy from #724: threshold the continuous channel, keep the genome channel whole. A star threshold can't express that — genome habitat scores are only ever 3 or 4, so `τ > 3` deletes 4% of habitat on provenance rather than quality. The floor applies only under `shapes=habitat`, so unfiltered runs are unchanged.

Habitat writes to `data/transformed/prego_habitat/`, and `merge.habitat.yaml` reads from there.

## Pre-existing bug fixed

`_emit_node` ran inside the shape branches, **before** the `min_confidence` check — so every edge `PREGO_MIN_CONFIDENCE` dropped still wrote its nodes. That knob has been producing orphan nodes all along. Emission is now deferred until the row is certain to survive.

## Canary on the real 13.2 GB of archives

| | |
|---|---|
| rows read | 102,808,230 |
| edges emitted | **237,745** (envo_to_taxon 217,954 + taxon_to_bto 19,791) |
| nodes | 22,116 — **0 orphans, 0 GO nodes** |
| dropped | 102,570,485 — reconciles exactly |
| runtime | 3m26s |
| `edges.tsv` | 55 MB vs 12.2 GB |

## Review findings, fixed in-branch

- **#734** — `merge.habitat.yaml` selected nothing (one-line diff from `merge.yaml`, same input path), so it could ship a full graph labelled "habitat only", and the two builds overwrote each other.
- **#735** — the deliberate filters polluted the curation report. The first fix for this broke the `dropped=` summary by 44.5M rows; caught by re-canarying rather than by the tests.

`poetry run tox` green, 72 tests in this file, four mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)