### PR TITLE
Pin the list-form knowledge source on BacDive strain edges (#688)

### DIFF
--- a/tests/test_bacdive_lpsn_crossref.py
+++ b/tests/test_bacdive_lpsn_crossref.py
@@ -257,6 +257,64 @@ def test_blank_lpsn_block_returns_none(tmp_path):
     assert x._lpsn_stats["unmatched"] == 0
 
 
+# The wrapper is positional, so the tests derive the column index the way
+# production does (`edge_header.index(...)`) rather than hardcoding it. A pin
+# that cannot notice the column moving is not pinning much (#741). Rows are
+# full width for the same reason: the wrapper's `len(row) > ks_idx` guard means
+# a short row passes without exercising the shape production writes.
+_EDGE_HEADER = [
+    "subject",
+    "predicate",
+    "object",
+    "relation",
+    "primary_knowledge_source",
+    "knowledge_level",
+    "agent_type",
+]
+
+
+def _provenance_writer():
+    """
+    Build a `_StrainProvenanceWriter` over a capturing sink.
+
+    :return: ``(captured_rows, writer, primary_knowledge_source_index)``.
+    """
+    from kg_microbe.transform_utils.bacdive.bacdive import _StrainProvenanceWriter
+
+    captured = []
+
+    class _Sink:
+
+        """Collect rows instead of writing them."""
+
+        def writerow(self, row):
+            """Record one row."""
+            captured.append(list(row))
+
+    index = _EDGE_HEADER.index("primary_knowledge_source")
+    return captured, _StrainProvenanceWriter(_Sink(), knowledge_source="infores:bacdive", ks_column_index=index), index
+
+
+def _edge_row(subject, obj, knowledge_source):
+    """
+    Build a full-width edge row, matching what the transform actually writes.
+
+    :param subject: Edge subject CURIE.
+    :param obj: Edge object CURIE.
+    :param knowledge_source: Value for the primary_knowledge_source column.
+    :return: A row with one cell per column in the real edge header.
+    """
+    return [
+        subject,
+        "biolink:subclass_of",
+        obj,
+        "rdfs:subClassOf",
+        knowledge_source,
+        "knowledge_assertion",
+        "manual_agent",
+    ]
+
+
 def test_lpsn_edge_carries_the_list_form_knowledge_source():
     """
     The LPSN cross-ref edge must carry the same list-form provenance as its siblings.

--- a/tests/test_bacdive_lpsn_crossref.py
+++ b/tests/test_bacdive_lpsn_crossref.py
@@ -255,3 +255,64 @@ def test_blank_lpsn_block_returns_none(tmp_path):
     assert x._lookup_lpsn(None) is None
     # None + empty are treated as no-op; unmatched not incremented.
     assert x._lpsn_stats["unmatched"] == 0
+
+
+def test_lpsn_edge_carries_the_list_form_knowledge_source():
+    """
+    The LPSN cross-ref edge must carry the same list-form provenance as its siblings.
+
+    #680 changed the subject from ``bacdive:NNN`` to
+    ``kgmicrobe.strain:bacdive_NNN``, which as a side effect brought all
+    62,096 of these edges under ``_StrainProvenanceWriter``. The provenance
+    flipped from ``infores:bacdive`` to ``['infores:bacdive', 'bacdive:NNN']``.
+
+    That is the wanted value — mediadive emits a byte-identical literal so KGX
+    collapses the two rows by exact-string match at merge — but it was an
+    unintended side effect, unmentioned in any commit on #680, and nothing
+    pinned it. A refactor could flip it back silently (#688).
+    """
+    from kg_microbe.transform_utils.bacdive.bacdive import _StrainProvenanceWriter
+
+    captured = []
+
+    class _Sink:
+
+        """Collect rows instead of writing them."""
+
+        def writerow(self, row):
+            """Record one row."""
+            captured.append(list(row))
+
+    writer = _StrainProvenanceWriter(_Sink(), knowledge_source="infores:bacdive", ks_column_index=4)
+    writer.writerow(
+        ["kgmicrobe.strain:bacdive_7249", "biolink:subclass_of", "lpsn:12345", "rdfs:subClassOf", "infores:bacdive"]
+    )
+
+    assert captured[0][4] == "['infores:bacdive', 'bacdive:7249']", captured[0][4]
+
+
+def test_non_strain_edges_keep_their_bare_knowledge_source():
+    """
+    The wrapper must fire only when an endpoint is a BacDive strain.
+
+    METPO ontology axioms and isolation-source edges pass through untouched;
+    rewriting those would invent strain provenance for rows that have none.
+    """
+    from kg_microbe.transform_utils.bacdive.bacdive import _StrainProvenanceWriter
+
+    captured = []
+
+    class _Sink:
+
+        """Collect rows instead of writing them."""
+
+        def writerow(self, row):
+            """Record one row."""
+            captured.append(list(row))
+
+    writer = _StrainProvenanceWriter(_Sink(), knowledge_source="infores:bacdive", ks_column_index=4)
+    writer.writerow(["METPO:1000601", "biolink:subclass_of", "METPO:1000600", "rdfs:subClassOf", "infores:bacdive"])
+    writer.writerow(["kgmicrobe.strain:bacdive_7249", "biolink:location_of", "ENVO:00002006", "RO:1", "infores:metpo"])
+
+    assert captured[0][4] == "infores:bacdive", "an ontology axiom must not gain strain provenance"
+    assert captured[1][4] == "infores:metpo", "a different knowledge source must pass through"


### PR DESCRIPTION
Closes #688.

## What this is

Not a defect fix — a **pin**. #680 changed the LPSN cross-ref subject from `bacdive:NNN` to `kgmicrobe.strain:bacdive_NNN`, which as a side effect brought all 62,096 of those edges under `_StrainProvenanceWriter`:

```
before:  infores:bacdive
after:   ['infores:bacdive', 'bacdive:NNN']
```

That is the wanted value — mediadive emits a byte-identical literal so KGX collapses the two rows by exact-string match at merge — but it was unintended, unmentioned in any commit on #680, and nothing pinned it.

Confirmed against the shipped `data/transformed/bacdive/edges.tsv`: the LPSN cross-ref edges carry exactly the same list form as their sibling strain edges.

## Tests

Two **behavioural** tests on `_StrainProvenanceWriter`, not assertions over source text, so a refactor preserving the spelling but changing behaviour still fails:

- the rewrite happens for a strain endpoint;
- it fires **only** for BacDive strain endpoints — a METPO ontology axiom and a row carrying a different knowledge source both pass through untouched. Rewriting those would invent strain provenance for rows that have none.

Both mutation-checked: disabling the rewrite fails the first, removing the prefix guard fails the second.

No production change. `poetry run tox` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)