### PR TITLE
Re-point LPSN synonym matches to the accepted name (#684)

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -479,6 +479,7 @@ class BacDiveTransform(Transform):
             )
             return {}
         name_index: Dict[str, list] = {}
+        gss_rows: Dict[str, dict] = {}
         with open(lpsn_csv, newline="") as fh:
             reader = csv.DictReader(fh)
             for row in reader:
@@ -494,11 +495,68 @@ class BacDiveTransform(Transform):
                 if not full_name:
                     continue
                 name_index.setdefault(full_name, []).append(record_no)
+                gss_rows[record_no] = row
+        accepted = self._resolve_accepted_records(gss_rows)
+        repointed = 0
+        for full_name, record_nos in name_index.items():
+            remapped = [accepted.get(no, no) for no in record_nos]
+            repointed += sum(1 for before, after in zip(record_nos, remapped, strict=True) if before != after)
+            name_index[full_name] = remapped
         logger.info(
-            "LPSN name index loaded: %d distinct names for BacDive cross-refs",
+            "LPSN name index loaded: %d distinct names for BacDive cross-refs "
+            "(%d re-pointed from a synonym to its accepted name)",
             len(name_index),
+            repointed,
         )
         return name_index
+
+    @staticmethod
+    def _resolve_accepted_records(gss_rows: Dict[str, dict]) -> Dict[str, str]:
+        """
+        Map each non-current LPSN record to the accepted name it defers to.
+
+        The GSS index previously matched on name alone, so a BacDive strain whose
+        reported species is an LPSN *synonym* was placed under the synonym's
+        record. #680 made that edge ``subclass_of`` rather than ``in_taxon``,
+        which puts a living strain in the subsumption hierarchy beneath a
+        deprecated class — 992 of 62,096 edges (#684).
+
+        Dropping those edges would lose real information: the strain genuinely is
+        that organism, LPSN has simply renamed it. ``record_lnk`` is LPSN's own
+        crosswalk to the accepted name, so the edge is re-pointed instead.
+        Measured on the shipped GSS: every ``record_lnk`` resolves to a real row,
+        7,018 synonyms reach a correct name in one hop, 250 in two, 2 in three,
+        and no chain cycles. 192 dead-end with no link and are left alone —
+        there is nothing better to point them at.
+
+        :param gss_rows: ``record_no`` to its GSS row.
+        :return: ``record_no`` to accepted ``record_no``, for those that move.
+        """
+        accepted: Dict[str, str] = {}
+        for record_no, row in gss_rows.items():
+            if _LPSN_CORRECT_NAME in (row.get("status") or ""):
+                continue
+            seen = {record_no}
+            current = row
+            # Bounded as well as cycle-guarded. The `seen` set is the real
+            # protection, but its failure mode if lost is an infinite loop rather
+            # than a wrong answer — a hang burns a CI job's whole budget and
+            # reports a timeout instead of pointing at the defect (#742). The
+            # deepest real chain in the shipped GSS is 3 hops.
+            for _ in range(_LPSN_MAX_SYNONYM_HOPS):
+                link = (current.get("record_lnk") or "").strip()
+                if not link or link in seen:
+                    # Dead-end or a cycle: keep the original rather than guess.
+                    break
+                seen.add(link)
+                target = gss_rows.get(link)
+                if target is None:
+                    break
+                if _LPSN_CORRECT_NAME in (target.get("status") or ""):
+                    accepted[record_no] = link
+                    break
+                current = target
+        return accepted
 
     @staticmethod
     def _strain_curie(bacdive_key: str) -> str:
@@ -3348,6 +3406,14 @@ class BacDiveTransform(Transform):
 # inline so this module-level helper doesn't need to import the (already
 # in-file) STRAIN_PREFIX + BACDIVE_PREFIX constants again.
 _STRAIN_BACDIVE_PREFIX = "kgmicrobe.strain:bacdive_"
+
+# LPSN GSS `status` marks the currently accepted name with this phrase; anything
+# else (synonym, illegitimate, rejected) defers to another record via record_lnk.
+_LPSN_CORRECT_NAME = "correct name"
+
+# Deepest synonym chain observed in the shipped GSS is 3 hops; the cap is a
+# backstop against a cyclic chain in a future release, not a real limit.
+_LPSN_MAX_SYNONYM_HOPS = 25
 
 
 class _StrainProvenanceWriter:

--- a/tests/test_bacdive_lpsn_crossref.py
+++ b/tests/test_bacdive_lpsn_crossref.py
@@ -374,3 +374,90 @@ def test_non_strain_edges_keep_their_bare_knowledge_source():
 
     assert captured[0][4] == "infores:bacdive", "an ontology axiom must not gain strain provenance"
     assert captured[1][4] == "infores:metpo", "a different knowledge source must pass through"
+
+
+def _gss_row(record_no, genus, sp, status, link=""):
+    """Build one GSS CSV row."""
+    return {
+        "genus_name": genus,
+        "sp_epithet": sp,
+        "subsp_epithet": "",
+        "status": status,
+        "record_no": record_no,
+        "record_lnk": link,
+    }
+
+
+_CORRECT = "VP; sp. nov.; validly published under the ICNP; correct name"
+_SYNONYM = "VP; sp. nov.; validly published under the ICNP; synonym"
+
+
+def test_a_synonym_match_is_repointed_to_its_accepted_name(tmp_path):
+    """
+    A strain reported under an LPSN synonym must land under the accepted name.
+
+    #680 made this edge `subclass_of`, so a synonym target places a living strain
+    in the subsumption hierarchy beneath a deprecated class — 992 of 62,096 edges
+    (#684). Dropping them would lose real information: the strain genuinely is
+    that organism, LPSN has simply renamed it. `record_lnk` is LPSN's own
+    crosswalk, so the edge is re-pointed instead.
+    """
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            _gss_row("772466", "Abiotrophia", "adiacens", _SYNONYM, link="776611"),
+            _gss_row("776611", "Granulicatella", "adiacens", _CORRECT),
+        ],
+    )
+    index = _bare_transform(csv_path)._load_lpsn_name_index()
+
+    assert index["Abiotrophia adiacens"] == ["776611"], "the synonym must resolve to the accepted record"
+    assert index["Granulicatella adiacens"] == ["776611"]
+
+
+def test_a_synonym_chain_is_followed_to_the_accepted_name(tmp_path):
+    """Chains occur: 250 synonyms need two hops on the shipped GSS and 2 need three."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            _gss_row("1", "Aaa", "one", _SYNONYM, link="2"),
+            _gss_row("2", "Bbb", "two", _SYNONYM, link="3"),
+            _gss_row("3", "Ccc", "three", _CORRECT),
+        ],
+    )
+    assert _bare_transform(csv_path)._load_lpsn_name_index()["Aaa one"] == ["3"]
+
+
+def test_a_dead_end_synonym_keeps_its_own_record(tmp_path):
+    """
+    192 GSS rows are non-current with no `record_lnk`.
+
+    There is nothing better to point them at, so they are left alone rather than
+    dropped — losing the edge would be worse than an imperfect target.
+    """
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(csv_path, [_gss_row("9", "Ddd", "four", _SYNONYM)])
+    assert _bare_transform(csv_path)._load_lpsn_name_index()["Ddd four"] == ["9"]
+
+
+def test_a_cyclic_synonym_chain_terminates(tmp_path):
+    """No cycles exist in the shipped GSS, but a future release could introduce one."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(
+        csv_path,
+        [
+            _gss_row("1", "Aaa", "one", _SYNONYM, link="2"),
+            _gss_row("2", "Bbb", "two", _SYNONYM, link="1"),
+        ],
+    )
+    index = _bare_transform(csv_path)._load_lpsn_name_index()
+    assert index["Aaa one"] == ["1"], "a cycle must leave the record untouched, not hang"
+
+
+def test_correct_names_are_left_alone(tmp_path):
+    """The common case must be untouched: 26,866 of 34,301 rows are already current."""
+    csv_path = tmp_path / "lpsn_gss.csv"
+    _write_gss(csv_path, [_gss_row("100", "Escherichia", "coli", _CORRECT)])
+    assert _bare_transform(csv_path)._load_lpsn_name_index()["Escherichia coli"] == ["100"]


### PR DESCRIPTION
Closes #684.

## The problem

`_load_lpsn_name_index` matched on name alone, so a strain whose BacDive-reported species is an LPSN **synonym** was placed under the synonym's record. #680 made that edge `subclass_of` rather than `in_taxon`, which puts a living strain in the subsumption hierarchy **beneath a deprecated class** — 992 of 62,096 edges, propagated by reasoners and any closure step.

## Drop or re-point — measuring decided it

The issue offered both and suggested asking a curator. The data answered:

- `record_lnk` is **LPSN's own crosswalk** to the accepted name
- all **7,270** links resolve to a real GSS row
- **96.2%** land directly on a correct-name row

Dropping would lose real information — the strain genuinely *is* that organism, LPSN has simply renamed it. So this follows the source's mapping rather than deleting edges. That isn't a curator judgement; it's what LPSN asserts.

Chains are walked transitively: **7,018** synonyms reach a correct name in one hop, **250** in two, **2** in three, and nothing in the shipped GSS cycles. **192** dead-end with no link and keep their own record — there is nothing better to point at.

## Effect on the real GSS

| | before | after |
|---|---:|---:|
| index entries resolving to a deprecated record | 7,225 | **49** |

Example: `Abiotrophia adiacens` `lpsn:772466` → `lpsn:776611` `Granulicatella adiacens`.

## Review round 1 — #742, fixed

Mutation testing found the walk's cycle guard was its **only** protection, and removing it **hangs rather than fails**. A hang burns a CI job's entire budget and reports a timeout instead of pointing at the defect; it also bit me directly — the kill pre-empted my restore step and left a mutated file on disk.

The walk is now bounded as well as cycle-guarded, so the behaviour survives losing either. Verified: with the `seen` set removed, the cyclic case completes in 2s instead of hanging.

## Tests

Five, covering re-point, multi-hop chain, dead-end, cycle, and the untouched correct-name case (26,866 of 34,301 rows). Mutation-checked: disabling re-pointing and truncating the chain walk each fail.

`poetry run tox` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)