### PR TITLE
microbedecoder: assert subsumption, not close_match, on the BacDive crosswalk (#687)

### DIFF
--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -79,14 +79,17 @@ from kg_microbe.transform_utils.constants import (
     PRIMARY_KNOWLEDGE_SOURCE_COLUMN,
     PRODUCES_PREDICATE,
     PROVIDED_BY_COLUMN,
+    RDFS_SUBCLASS_OF,
     RELATION_COLUMN,
     SMALL_MOLECULE_CATEGORY,
+    SUBCLASS_PREDICATE,
     SUBJECT_COLUMN,
     TRAIT_PREFIX,
     TROPHICALLY_INTERACTS_WITH,
     VPI_KNOWLEDGE_SOURCE,
 )
 from kg_microbe.transform_utils.microbedecoder.utils import (
+    BACDIVE_CROSSWALK_COLUMN,
     BACDIVE_SNAPSHOT_COLUMNS,
     CROSSWALK_COLUMNS,
     LPSN_ID_COLUMN,
@@ -348,15 +351,29 @@ class MicrobeDecoderTransform(Transform):
                         local_id = local_id[len(candidate) :]
                         break
                 object_curie = f"{prefix}{local_id}"
-                edge_writer.writerow(
-                    self._make_edge_row(
-                        subject,
-                        CLOSE_MATCH_PREDICATE,
-                        object_curie,
-                        CLOSE_MATCH_RELATION,
-                        self.knowledge_source,
+                if column == BACDIVE_CROSSWALK_COLUMN:
+                    # Strain -> name subsumption, matching what the bacdive
+                    # transform asserts for the same pair. See the note on
+                    # BACDIVE_CROSSWALK_COLUMN: close_match contradicted it.
+                    edge_writer.writerow(
+                        self._make_edge_row(
+                            object_curie,
+                            SUBCLASS_PREDICATE,
+                            subject,
+                            RDFS_SUBCLASS_OF,
+                            self.knowledge_source,
+                        )
                     )
-                )
+                else:
+                    edge_writer.writerow(
+                        self._make_edge_row(
+                            subject,
+                            CLOSE_MATCH_PREDICATE,
+                            object_curie,
+                            CLOSE_MATCH_RELATION,
+                            self.knowledge_source,
+                        )
+                    )
                 self._stats["crosswalk_edges"] += 1
 
     # ------------------------------------------------------------------

--- a/kg_microbe/transform_utils/microbedecoder/utils.py
+++ b/kg_microbe/transform_utils/microbedecoder/utils.py
@@ -41,6 +41,24 @@ CROSSWALK_COLUMNS: Tuple[Tuple[str, str, Optional[str]], ...] = (
     ("IMG_Genome_ID", "IMG:", None),
 )
 
+# The BacDive crosswalk is not an identifier equivalence like the others. Its
+# target is a *strain*, not another name for the same taxon, and the source says
+# which strain: MicrobeDecoder's strain designation equals LPSN's own
+# `nomenclatural_type` for 98.9% of the 21,247 rows that match a GSS record, and
+# shares a culture-collection number for another 1.1% — so the row means "this
+# BacDive record is the type strain of this LPSN name". That is what makes it
+# strictly 1:1 where bacdive's relation is many-to-one.
+#
+# `close_match` asserted near-identity between a name and a strain, and after
+# #680 collided head-on with bacdive's `strain -subclass_of-> lpsn` over 18,425
+# of the same pairs (#687): skos:closeMatch and proper subsumption cannot both
+# hold. Emitting the same subsumption bacdive does makes the two transforms
+# agree instead, so merge collapses the duplicates and keeps both provenances.
+#
+# The type-strain *specificity* is still unexpressed — no Biolink or METPO
+# predicate carries it — and is deferred rather than invented here.
+BACDIVE_CROSSWALK_COLUMN = "BacDive_ID"
+
 # Metabolism / fermentation column groups. Each entry drives one predicate
 # family; see :func:`iter_metabolism_columns` for the emission rules.
 #

--- a/tests/test_microbedecoder_transform.py
+++ b/tests/test_microbedecoder_transform.py
@@ -103,10 +103,15 @@ def test_empty_lpsn_row_is_skipped(microbedecoder_transform):
     """The fixture's trailing empty-LPSN_ID row must not produce any output."""
     microbedecoder_transform.run()
     edges = _read_tsv(microbedecoder_transform.output_edge_file)
-    subjects = {e["subject"] for e in edges}
-    # Every edge subject is a lpsn:<non-empty-id>; the blank row's would be
-    # `lpsn:` (no local) or empty, neither of which should appear.
-    assert all(s.startswith(LPSN_PREFIX) and len(s) > len(LPSN_PREFIX) for s in subjects)
+    # Most edges are subject-side lpsn:<non-empty-id>; the BacDive crosswalk is
+    # the exception, being strain -subclass_of-> lpsn (#687), so check whichever
+    # endpoint carries the LPSN CURIE. The blank row would give `lpsn:` with no
+    # local part, which must appear on neither side.
+    lpsn_endpoints = {
+        endpoint for edge in edges for endpoint in (edge["subject"], edge["object"]) if endpoint.startswith(LPSN_PREFIX)
+    }
+    assert lpsn_endpoints, "fixture must emit LPSN-anchored edges"
+    assert all(len(e) > len(LPSN_PREFIX) for e in lpsn_endpoints)
 
 
 # ---------------------------------------------------------------------------
@@ -114,8 +119,15 @@ def test_empty_lpsn_row_is_skipped(microbedecoder_transform):
 # ---------------------------------------------------------------------------
 
 
-def test_crosswalk_edges_use_close_match(microbedecoder_transform):
-    """Every crosswalk edge is a ``biolink:close_match`` from lpsn:<id> to the target."""
+def test_identifier_crosswalk_edges_use_close_match(microbedecoder_transform):
+    """
+    The identifier crosswalks stay ``biolink:close_match`` from lpsn:<id>.
+
+    NCBITaxon, GTDB, GOLD and IMG really are other identifiers for the same
+    taxon, so near-identity is right. BacDive is excluded — its target is a
+    *strain*, not another name, and it is asserted as subsumption instead
+    (#687); see :func:`test_bacdive_crosswalk_is_subsumption_not_close_match`.
+    """
     microbedecoder_transform.run()
     edges = _read_tsv(microbedecoder_transform.output_edge_file)
 
@@ -124,9 +136,40 @@ def test_crosswalk_edges_use_close_match(microbedecoder_transform):
     objects = {e["object"] for e in e_101}
     assert "NCBITaxon:1423" in objects
     assert "GTDB:d__Bacteria;g__Bacillus;s__Bacillus subtilis" in objects
-    assert "kgmicrobe.strain:bacdive_BAC01" in objects
     assert "GOLD:Gs0000101" in objects
     assert "IMG:3300000001" in objects
+    assert not any(o.startswith("kgmicrobe.strain:") for o in objects), (
+        "the BacDive crosswalk must not be a close_match"
+    )
+
+
+def test_bacdive_crosswalk_is_subsumption_not_close_match(microbedecoder_transform):
+    """
+    The BacDive crosswalk must not contradict what the bacdive transform asserts.
+
+    `close_match` claimed near-identity between an LPSN *name* and a BacDive
+    *strain*, while bacdive asserts `strain -subclass_of-> lpsn` over 18,425 of
+    the same pairs (#687). skos:closeMatch and proper subsumption cannot both
+    hold over one pair. Emitting the same subsumption makes the two transforms
+    agree, so merge collapses the duplicates and keeps both provenances.
+
+    The row means "this BacDive record is the type strain of this LPSN name" —
+    MicrobeDecoder's strain designation equals LPSN's own `nomenclatural_type`
+    for 98.9% of matched rows — but no predicate expresses that yet (#744).
+    """
+    microbedecoder_transform.run()
+    edges = _read_tsv(microbedecoder_transform.output_edge_file)
+
+    strain_edges = [e for e in edges if "kgmicrobe.strain:bacdive_" in (e["subject"] + e["object"])]
+    assert strain_edges, "fixture must produce BacDive crosswalk edges"
+    for edge in strain_edges:
+        assert edge["predicate"] != CLOSE_MATCH_PREDICATE, f"close_match contradicts subsumption: {edge}"
+    assert any(
+        e["subject"] == "kgmicrobe.strain:bacdive_BAC01"
+        and e["predicate"] == "biolink:subclass_of"
+        and e["object"] == f"{LPSN_PREFIX}101"
+        for e in strain_edges
+    ), strain_edges
 
 
 def test_bacdive_crosswalk_targets_the_strain_curie(microbedecoder_transform):
@@ -141,16 +184,17 @@ def test_bacdive_crosswalk_targets_the_strain_curie(microbedecoder_transform):
     """
     microbedecoder_transform.run()
     edges = _read_tsv(microbedecoder_transform.output_edge_file)
-    close_matches = [e for e in edges if e["predicate"] == CLOSE_MATCH_PREDICATE]
 
-    bacdive_objects = {e["object"] for e in close_matches if "bacdive" in e["object"].lower()}
-    assert bacdive_objects, "fixture must produce BacDive crosswalk edges"
-    for obj in bacdive_objects:
-        assert obj.startswith("kgmicrobe.strain:bacdive_"), (
-            f"BacDive crosswalk target must use the strain CURIE; got {obj!r}"
+    # The BacDive crosswalk is now subject-side subsumption, not a close_match
+    # object, so look at subjects (#687).
+    bacdive_subjects = {e["subject"] for e in edges if "bacdive" in e["subject"].lower()}
+    assert bacdive_subjects, "fixture must produce BacDive crosswalk edges"
+    for subject in bacdive_subjects:
+        assert subject.startswith("kgmicrobe.strain:bacdive_"), (
+            f"BacDive crosswalk endpoint must use the strain CURIE; got {subject!r}"
         )
-    # The bare source form must not survive anywhere.
-    assert not any(e["object"].startswith("bacdive:") for e in close_matches)
+    # The bare source form must not survive anywhere, on either side.
+    assert not any(e["object"].startswith("bacdive:") or e["subject"].startswith("bacdive:") for e in edges)
 
 
 def test_bacdive_crosswalk_normalizes_a_precuried_cell(microbedecoder_transform):
@@ -164,12 +208,13 @@ def test_bacdive_crosswalk_normalizes_a_precuried_cell(microbedecoder_transform)
     """
     microbedecoder_transform.run()
     edges = _read_tsv(microbedecoder_transform.output_edge_file)
-    objects = {
-        e["object"] for e in edges if e["subject"] == f"{LPSN_PREFIX}505" and e["predicate"] == CLOSE_MATCH_PREDICATE
+    # Subject-side since #687: the BacDive crosswalk is strain -subclass_of-> lpsn.
+    strains = {
+        e["subject"] for e in edges if e["object"] == f"{LPSN_PREFIX}505" and e["subject"].startswith("kgmicrobe.")
     }
-    assert "kgmicrobe.strain:bacdive_BAC05" in objects, f"pre-CURIE'd cell was not normalized; got {objects}"
-    for obj in objects:
-        assert obj.count(":") == 1, f"double-prefixed CURIE: {obj!r}"
+    assert "kgmicrobe.strain:bacdive_BAC05" in strains, f"pre-CURIE'd cell was not normalized; got {strains}"
+    for strain in strains:
+        assert strain.count(":") == 1, f"double-prefixed CURIE: {strain!r}"
 
 
 def test_crosswalk_edges_carry_microbedecoder_provenance(microbedecoder_transform):
@@ -382,11 +427,12 @@ def test_bacdive_only_row_still_emits_snapshot(microbedecoder_transform):
     """LPSN_ID=505 has synonym status and BacDive-only content — must not crash."""
     microbedecoder_transform.run()
     edges = _read_tsv(microbedecoder_transform.output_edge_file)
-    e_505 = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}505"]
-    # At minimum an oxygen tolerance edge + bacdive crosswalk
+    e_505 = [e for e in edges if f"{LPSN_PREFIX}505" in (e["subject"], e["object"])]
+    # At minimum an oxygen tolerance edge + the BacDive crosswalk, which is now
+    # subsumption from the strain rather than a close_match to it (#687).
     predicates = {e["predicate"] for e in e_505}
     assert HAS_PHENOTYPE_PREDICATE in predicates
-    assert CLOSE_MATCH_PREDICATE in predicates  # bacdive:BAC05
+    assert "biolink:subclass_of" in predicates, predicates
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #687. Defers the type-strain modelling to #744.

## State of the issue

**Orphans — already fixed.** `CROSSWALK_COLUMNS` emits `kgmicrobe.strain:bacdive_N`; the shipped output has **0** bare `bacdive:` targets.

**Semantic clash — live.** With the prefix fixed, the contradiction the issue predicted now exists:

| | count |
|---|---:|
| microbedecoder `lpsn:X -close_match-> strain:Y` | 19,114 |
| bacdive `strain:Y -subclass_of-> lpsn:X` | 62,096 |
| **same pair asserted both ways** | **18,425** |

## The modelling question, answered by the source

The issue said this needed a curator. It doesn't — LPSN's own GSS settles it. Comparing MicrobeDecoder's strain designation against GSS `nomenclatural_type` for the same `LPSN_ID`, over the 21,247 rows that match a GSS record:

| | rows | share |
|---|---:|---:|
| **exactly equals** `nomenclatural_type` | 21,010 | **98.9%** |
| shares ≥1 culture-collection number | 233 | 1.1% |
| no overlap | 4 | 0.0% |

So the column means **"this BacDive record is the type strain of this LPSN name"** — which is why it is strictly 1:1 where bacdive's is many-to-one (up to 1,870 strains per record).

## What this does, and what it deliberately doesn't

That rules `close_match` out — the target is a *strain*, not another name for the taxon. It does not pick a replacement, because **no predicate expresses "is the type strain of"**: BMT has neither `type of` nor `has nomenclatural type`, and METPO's `TYPE_STRAIN` is a TSV column name in the bacdive intermediate, not a predicate.

Rather than invent an ontology term mid-fix, this emits the **same subsumption bacdive already asserts**, so the two transforms agree instead of contradicting. Merge collapses the 18,425 shared pairs keeping both provenances; **689** are unique to microbedecoder and become new subsumption edges.

The type-strain specificity is **deferred to #744**, not dropped silently.

**Only the BacDive column changes.** NCBITaxon, GTDB, GOLD and IMG are genuine identifier crosswalks where `close_match` is correct — a test pins that they're untouched, and a mutation re-predicating all five fails it.

## Verification

Canary on the real 27,010-row source: 84,244 crosswalk edges, **0** close_match to a strain, **19,114** subsumption edges, 18,425 agreeing with bacdive.

Three pre-existing tests assumed the BacDive edge was subject-side `lpsn:` and were updated rather than bypassed. Two mutations checked. `poetry run tox` green, 25 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)