### PR TITLE
Surface corrections that lose a rank tie to a raw column (#723)

### DIFF
--- a/scripts/consolidate_chemical_mappings.py
+++ b/scripts/consolidate_chemical_mappings.py
@@ -612,6 +612,32 @@ def best_primary(candidates) -> str:
     return best
 
 
+def corrected_column_primary(kg_node_id, mim_id, chebi_id, culturemech_term, cas_curie) -> str:
+    """
+    Return the primary that would be chosen if corrected columns outranked raw ones.
+
+    Same candidates and same ranking as the production call, only the order
+    differs: ``kg_microbe_node_id`` and ``mim_id`` are the columns a curator
+    writes a correction into, while ``chebi_id`` and ``culturemech_term_id``
+    carry the raw upstream value. CHEBI, FOODON, UBERON, ENVO and NCIT all rank
+    100, so within that tier order alone decides, and production puts the raw
+    columns first (#723).
+
+    Comparing the two orders is what makes a silently-overruled correction
+    visible. It deliberately does not change the grounding: 30 of the 35 rows it
+    flags are unreviewed curation questions, and resolving those by column
+    position is the defect, not the fix.
+
+    :param kg_node_id: ``kg_microbe_node_id`` cell.
+    :param mim_id: ``mim_id`` cell.
+    :param chebi_id: ``chebi_id`` cell.
+    :param culturemech_term: ``culturemech_term_id`` cell.
+    :param cas_curie: CAS CURIE, last-resort candidate in both orders.
+    :return: The CURIE a corrected-first order would pick, or ``''``.
+    """
+    return best_primary([kg_node_id, mim_id, chebi_id, culturemech_term, cas_curie])
+
+
 def is_chemical_curie(curie: str) -> bool:
     """Return True if the CURIE's prefix belongs in the unified chemical file."""
     if not curie or ":" not in curie:
@@ -1198,7 +1224,10 @@ class ChemicalMappingConsolidator:
         df = pd.read_csv(filepath, sep="\t", dtype=str).fillna("")
 
         added = 0
+
         skipped = 0
+
+        diverged: list = []
         for _, row in df.iterrows():
             ingredient_name = row.get("ingredient_name", "").strip()
             cas_rn = row.get("cas_rn", "").strip()
@@ -1223,6 +1252,27 @@ class ChemicalMappingConsolidator:
                 skipped += 1
                 continue
 
+            # The corrected columns are `mim_id` and `kg_microbe_node_id`; the raw
+            # upstream ones are `chebi_id` and `culturemech_term_id`. CHEBI,
+            # FOODON, UBERON, ENVO and NCIT all rank 100, so within that tier the
+            # winner is decided purely by the order candidates are passed — and
+            # that order puts the raw columns first. A curator who corrects a
+            # grounding by writing the new id to a corrected column, while a stale
+            # value survives in a raw one, is silently overruled and their
+            # correction demoted to an xref (#723).
+            #
+            # Reordering would fix the class outright, but it also moves 30
+            # groundings nobody has reviewed — `Casein` as a CHEBI protein or a
+            # FOODON food, `Beef heart` as anatomy or food. Deciding those by
+            # column position is exactly the problem. So this reports rather than
+            # resolves: the divergence stops being silent, and the curation call
+            # stays with a curator.
+            corrected_first = corrected_column_primary(
+                kg_node_id, mim_id, chebi_id, culturemech_term, cas_curie
+            )
+            if corrected_first and corrected_first != primary_id:
+                diverged.append((ingredient_name, primary_id, corrected_first))
+
             synonyms = [ingredient_name] if ingredient_name else []
             xrefs = []
             for candidate in (cas_curie, culturemech_term, mim_id, kg_node_id, chebi_id):
@@ -1244,6 +1294,18 @@ class ChemicalMappingConsolidator:
             added += 1
 
         print(f"  Loaded {added} reviewed entries (skipped {skipped} with no supported CURIE)")
+        if diverged:
+            print(
+                f"  WARNING: {len(diverged)} rows ground to a raw upstream column while a corrected "
+                f"column names a different accepted CURIE (#723). The raw value wins on a rank tie "
+                f"purely by candidate order, so a correction written only to mim_id / "
+                f"kg_microbe_node_id is demoted to an xref. Not changed here — several are open "
+                f"curation questions. Sample:"
+            )
+            for name, chosen, corrected in diverged[:5]:
+                print(f"    {(name or '<unnamed>')[:40]:42} grounds to {chosen:22} corrected column says {corrected}")
+            if len(diverged) > 5:
+                print(f"    ... and {len(diverged) - 5} more")
 
     @staticmethod
     def _validate_sssom_file(filepath: Path) -> None:

--- a/tests/test_corrected_column_divergence.py
+++ b/tests/test_corrected_column_divergence.py
@@ -1,0 +1,62 @@
+"""Tests for surfacing corrections that lose a rank tie to a raw column (#723)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+_SPEC = importlib.util.spec_from_file_location(
+    "consolidate_chemical_mappings",
+    Path(__file__).parent.parent / "scripts" / "consolidate_chemical_mappings.py",
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules["consolidate_chemical_mappings"] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+
+class CorrectedColumnDivergenceTest(TestCase):
+
+    """`corrected_column_primary` must expose ties the production order hides."""
+
+    def test_a_correction_that_loses_the_tie_is_visible(self):
+        """
+        The case the issue is about.
+
+        A curator writes the corrected grounding to `mim_id`, a stale value
+        survives in `chebi_id`, both rank 100, and production picks the stale one
+        because it is passed first. The correction is demoted to an xref with no
+        signal.
+        """
+        production = _MODULE.best_primary(["CHEBI:194474", "", "CHEBI:30753", "", ""])
+        corrected = _MODULE.corrected_column_primary("", "CHEBI:30753", "CHEBI:194474", "", "")
+
+        self.assertEqual(production, "CHEBI:194474", "production keeps grounding to the raw column")
+        self.assertEqual(corrected, "CHEBI:30753", "the corrected column names a different CURIE")
+        self.assertNotEqual(production, corrected, "which is precisely what must be reported")
+
+    def test_agreement_is_not_reported(self):
+        """Only genuine divergence should reach a curator; noise would bury it."""
+        self.assertEqual(
+            _MODULE.corrected_column_primary("", "CHEBI:30753", "CHEBI:30753", "", ""),
+            _MODULE.best_primary(["CHEBI:30753", "", "CHEBI:30753", "", ""]),
+        )
+
+    def test_an_empty_corrected_column_does_not_divergence(self):
+        """Most rows have no correction at all; they must stay silent."""
+        self.assertEqual(
+            _MODULE.corrected_column_primary("", "", "CHEBI:30753", "", ""),
+            _MODULE.best_primary(["CHEBI:30753", "", "", "", ""]),
+        )
+
+    def test_ranking_still_beats_order(self):
+        """
+        Order only decides *within* a rank tier.
+
+        A higher-ranked raw value must still win over a lower-ranked corrected
+        one — this reports tie-breaks, it does not invert the ranking.
+        """
+        chebi_rank = _MODULE.prefix_rank("CHEBI:30753")
+        cas_rank = _MODULE.prefix_rank("CAS-RN:50-00-0")
+        if cas_rank >= chebi_rank:
+            self.skipTest("CAS is not ranked below CHEBI in this config")
+        self.assertEqual(_MODULE.corrected_column_primary("", "CAS-RN:50-00-0", "CHEBI:30753", "", ""), "CHEBI:30753")


### PR DESCRIPTION
Closes #723.

## What and why

`best_primary` breaks a rank tie by candidate order, and the call site passes the raw upstream columns (`chebi_id`, `culturemech_term_id`) **ahead of** the corrected ones (`mim_id`, `kg_microbe_node_id`). CHEBI, FOODON, UBERON, ENVO and NCIT all rank 100, so inside that tier order decides everything — a curator who writes a correction to a corrected column while a stale value survives in a raw one is **silently overruled**, their correction demoted to an xref.

## Report, don't resolve — the issue's own option 1

Reordering the candidates fixes the class outright and would let 5 retraction entries retire. But it moves **35** groundings, of which only 5 are known-wrong; the other **30 are unreviewed curation questions** — `Casein` as a CHEBI protein or a FOODON food, `Beef heart` as anatomy or food.

Resolving those by column position is *the defect being reported*. So this makes the divergence visible and leaves the call with a curator. **No emitted mapping changes.**

## Verification

Against the real 3,915-row `UNIFIED_INGREDIENT_MAPPING.tsv`: **exactly 35 rows flagged**, matching both the issue's count and its named examples.

| ingredient | grounds to | corrected column says |
|---|---|---|
| `Beef heart` | `UBERON:0000948` | `FOODON:00004410` |
| `4-Aminobenzoic acid` | `CHEBI:194474` | `CHEBI:30753` |
| `Fructose` | `CHEBI:28757` | `CHEBI:28645` |
| `CoSO4 x 7 H2O` | `CHEBI:91244` | `CHEBI:53470` |

The check is extracted as `corrected_column_primary` so it is unit-testable rather than buried in the loader. Four tests, mutation-checked (making the corrected order equal the production order fails them). One test pins that **ranking still beats order** — this reports tie-breaks, it does not invert the ranking.

`poetry run tox` green.

## Not addressed here

The upstream half is CultureBotAI/MediaIngredientMech#138 — each row should carry one consistent value. Even once that lands, the precedence rule stays latent for the next tool that writes a correction to only one column, so this report is worth having regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)