### PR TITLE
microbedecoder: anchor on accepted LPSN names, sharing the resolver (#746)

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -487,6 +487,13 @@ class BacDiveTransform(Transform):
                 record_no = (row.get("record_no") or "").strip()
                 if not record_no:
                     continue
+                # Collected before the name check so the resolver sees every
+                # record, exactly as microbedecoder passes it. Both callers share
+                # one walk (#746); feeding it different subsets would let a chain
+                # hopping through a nameless record resolve for one transform and
+                # dead-end for the other. No GSS row is nameless today, so this
+                # is fragility rather than a live difference.
+                gss_rows[record_no] = row
                 genus = (row.get("genus_name") or "").strip()
                 sp = (row.get("sp_epithet") or "").strip()
                 subsp = (row.get("subsp_epithet") or "").strip()
@@ -496,7 +503,6 @@ class BacDiveTransform(Transform):
                 if not full_name:
                     continue
                 name_index.setdefault(full_name, []).append(record_no)
-                gss_rows[record_no] = row
         accepted = resolve_accepted_records(gss_rows)
         repointed = 0
         for full_name, record_nos in name_index.items():

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -187,6 +187,7 @@ from kg_microbe.utils.isolation_source_mapping_utils import (
     load_isolation_source_mappings,
     normalize_isolation_source_label,
 )
+from kg_microbe.utils.lpsn_utils import resolve_accepted_records
 from kg_microbe.utils.mapping_file_utils import (
     _build_metpo_tree,
     load_assay_kit_mappings,
@@ -496,7 +497,7 @@ class BacDiveTransform(Transform):
                     continue
                 name_index.setdefault(full_name, []).append(record_no)
                 gss_rows[record_no] = row
-        accepted = self._resolve_accepted_records(gss_rows)
+        accepted = resolve_accepted_records(gss_rows)
         repointed = 0
         for full_name, record_nos in name_index.items():
             remapped = [accepted.get(no, no) for no in record_nos]
@@ -509,54 +510,6 @@ class BacDiveTransform(Transform):
             repointed,
         )
         return name_index
-
-    @staticmethod
-    def _resolve_accepted_records(gss_rows: Dict[str, dict]) -> Dict[str, str]:
-        """
-        Map each non-current LPSN record to the accepted name it defers to.
-
-        The GSS index previously matched on name alone, so a BacDive strain whose
-        reported species is an LPSN *synonym* was placed under the synonym's
-        record. #680 made that edge ``subclass_of`` rather than ``in_taxon``,
-        which puts a living strain in the subsumption hierarchy beneath a
-        deprecated class — 992 of 62,096 edges (#684).
-
-        Dropping those edges would lose real information: the strain genuinely is
-        that organism, LPSN has simply renamed it. ``record_lnk`` is LPSN's own
-        crosswalk to the accepted name, so the edge is re-pointed instead.
-        Measured on the shipped GSS: every ``record_lnk`` resolves to a real row,
-        7,018 synonyms reach a correct name in one hop, 250 in two, 2 in three,
-        and no chain cycles. 192 dead-end with no link and are left alone —
-        there is nothing better to point them at.
-
-        :param gss_rows: ``record_no`` to its GSS row.
-        :return: ``record_no`` to accepted ``record_no``, for those that move.
-        """
-        accepted: Dict[str, str] = {}
-        for record_no, row in gss_rows.items():
-            if _LPSN_CORRECT_NAME in (row.get("status") or ""):
-                continue
-            seen = {record_no}
-            current = row
-            # Bounded as well as cycle-guarded. The `seen` set is the real
-            # protection, but its failure mode if lost is an infinite loop rather
-            # than a wrong answer — a hang burns a CI job's whole budget and
-            # reports a timeout instead of pointing at the defect (#742). The
-            # deepest real chain in the shipped GSS is 3 hops.
-            for _ in range(_LPSN_MAX_SYNONYM_HOPS):
-                link = (current.get("record_lnk") or "").strip()
-                if not link or link in seen:
-                    # Dead-end or a cycle: keep the original rather than guess.
-                    break
-                seen.add(link)
-                target = gss_rows.get(link)
-                if target is None:
-                    break
-                if _LPSN_CORRECT_NAME in (target.get("status") or ""):
-                    accepted[record_no] = link
-                    break
-                current = target
-        return accepted
 
     @staticmethod
     def _strain_curie(bacdive_key: str) -> str:
@@ -3406,14 +3359,6 @@ class BacDiveTransform(Transform):
 # inline so this module-level helper doesn't need to import the (already
 # in-file) STRAIN_PREFIX + BACDIVE_PREFIX constants again.
 _STRAIN_BACDIVE_PREFIX = "kgmicrobe.strain:bacdive_"
-
-# LPSN GSS `status` marks the currently accepted name with this phrase; anything
-# else (synonym, illegitimate, rejected) defers to another record via record_lnk.
-_LPSN_CORRECT_NAME = "correct name"
-
-# Deepest synonym chain observed in the shipped GSS is 3 hops; the cap is a
-# backstop against a cyclic chain in a future release, not a real limit.
-_LPSN_MAX_SYNONYM_HOPS = 25
 
 
 class _StrainProvenanceWriter:

--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -101,6 +101,7 @@ from kg_microbe.transform_utils.microbedecoder.utils import (
     split_multivalue_comma_only,
 )
 from kg_microbe.transform_utils.transform import Transform
+from kg_microbe.utils.lpsn_utils import resolve_accepted_records
 from kg_microbe.utils.pandas_utils import drop_duplicates
 
 logger = logging.getLogger(__name__)
@@ -175,10 +176,12 @@ class MicrobeDecoderTransform(Transform):
         self._stats: Dict[str, int] = {
             "rows_processed": 0,
             "crosswalk_edges": 0,
+            "lpsn_repointed": 0,
             "metabolism_edges": 0,
             "bacdive_snapshot_edges": 0,
             "unmatched_labels": 0,
         }
+        self._accepted_lpsn: Optional[Dict[str, str]] = None
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -300,7 +303,17 @@ class MicrobeDecoderTransform(Transform):
         lpsn_id = row.get(LPSN_ID_COLUMN)
         if is_empty_cell(lpsn_id):
             return
-        subject_curie = f"{LPSN_PREFIX}{str(lpsn_id).strip()}"
+        lpsn_id = str(lpsn_id).strip()
+        # Anchor on the accepted name, not whatever the source snapshot recorded.
+        # Everything this transform emits — crosswalk, metabolism, BacDive
+        # snapshot — hangs off this one CURIE, so a synonym LPSN_ID drags the
+        # whole row onto a deprecated record: 5,263 edges, 1.0% (#746). bacdive
+        # got this treatment in #684; the resolver is shared so the two agree.
+        accepted = self._accepted_lpsn_records()
+        if lpsn_id in accepted:
+            self._stats["lpsn_repointed"] += 1
+            lpsn_id = accepted[lpsn_id]
+        subject_curie = f"{LPSN_PREFIX}{lpsn_id}"
         self._stats["rows_processed"] += 1
 
         self._emit_crosswalk_edges(subject_curie, row, node_writer, edge_writer)
@@ -310,6 +323,40 @@ class MicrobeDecoderTransform(Transform):
     # ------------------------------------------------------------------
     # Crosswalk edges (novel identity mapping MicrobeDecoder pre-joins)
     # ------------------------------------------------------------------
+    def _accepted_lpsn_records(self) -> Dict[str, str]:
+        """
+        Return the LPSN synonym-to-accepted mapping, loading it once.
+
+        The GSS CSV is account-gated and not shipped, so absence is expected and
+        non-fatal — exactly as in the bacdive transform. Without it the mapping
+        is empty and every row anchors on the ID the source gave, which is the
+        behaviour before #746.
+
+        :return: ``record_no`` to accepted ``record_no``.
+        """
+        if self._accepted_lpsn is not None:
+            return self._accepted_lpsn
+        gss_csv = Path(self.input_base_dir) / "lpsn_gss.csv"
+        if not gss_csv.is_file():
+            print(
+                f"[microbedecoder] {gss_csv} not found — LPSN IDs are used as given. "
+                "Synonym IDs will anchor edges on deprecated records (#746)."
+            )
+            self._accepted_lpsn = {}
+            return self._accepted_lpsn
+        with gss_csv.open(newline="") as handle:
+            gss_rows = {
+                (r.get("record_no") or "").strip(): r
+                for r in csv.DictReader(handle)
+                if (r.get("record_no") or "").strip()
+            }
+        self._accepted_lpsn = resolve_accepted_records(gss_rows)
+        print(
+            f"[microbedecoder] LPSN: {len(self._accepted_lpsn):,} synonym records will be "
+            "re-pointed to their accepted name"
+        )
+        return self._accepted_lpsn
+
     def _emit_crosswalk_edges(
         self,
         subject: str,

--- a/kg_microbe/utils/lpsn_utils.py
+++ b/kg_microbe/utils/lpsn_utils.py
@@ -1,0 +1,74 @@
+"""
+Shared LPSN nomenclature helpers.
+
+LPSN's GSS export marks each record's nomenclatural standing in a ``status``
+column. Only rows whose status contains ``correct name`` are the currently
+accepted name; everything else — synonyms, illegitimate names, rejected names —
+defers to another record through ``record_lnk``.
+
+Two transforms anchor edges on ``lpsn:<record_no>`` and so need the same
+resolution:
+
+* **bacdive** matches a strain's reported species against GSS names (#684);
+* **microbedecoder** takes ``LPSN_ID`` straight from its source column (#746).
+
+Both were placing live strains under deprecated records. The resolver lived on
+``BacDiveTransform`` when only bacdive needed it; it holds no BacDive state, so
+it moved here rather than being duplicated.
+"""
+
+from typing import Dict
+
+#: LPSN GSS marks the currently accepted name with this phrase in ``status``.
+LPSN_CORRECT_NAME = "correct name"
+
+#: Deepest synonym chain observed in the shipped GSS is 3 hops. The cap is a
+#: backstop against a cyclic chain in a future release, not a real limit — and
+#: it matters because the failure mode of an unbounded walk is a hang rather
+#: than a wrong answer, which costs a CI job its whole budget (#742).
+LPSN_MAX_SYNONYM_HOPS = 25
+
+
+def resolve_accepted_records(gss_rows: Dict[str, dict]) -> Dict[str, str]:
+    """
+    Map each non-current LPSN record to the accepted name it defers to.
+
+    Anchoring on a synonym puts a living strain under a deprecated class, which
+    reasoners and any closure step then propagate. Dropping those edges would
+    lose real information — the organism genuinely is that taxon, LPSN has simply
+    renamed it — so ``record_lnk``, LPSN's own crosswalk, is followed instead.
+
+    Measured on the shipped GSS: every ``record_lnk`` resolves to a real row,
+    7,018 synonyms reach a correct name in one hop, 250 in two, 2 in three, and
+    no chain cycles. 192 dead-end with no link and are left alone, there being
+    nothing better to point them at.
+
+    Bounded as well as cycle-guarded: the ``seen`` set is the real protection,
+    but if it were lost the walk would hang rather than answer wrongly, so the
+    iteration count is capped too.
+
+    :param gss_rows: ``record_no`` to its parsed GSS row.
+    :return: ``record_no`` to accepted ``record_no``, for those that move. A
+        record already carrying ``correct name``, or whose chain dead-ends, is
+        absent from the mapping.
+    """
+    accepted: Dict[str, str] = {}
+    for record_no, row in gss_rows.items():
+        if LPSN_CORRECT_NAME in (row.get("status") or ""):
+            continue
+        seen = {record_no}
+        current = row
+        for _ in range(LPSN_MAX_SYNONYM_HOPS):
+            link = (current.get("record_lnk") or "").strip()
+            if not link or link in seen:
+                # Dead-end or a cycle: keep the original rather than guess.
+                break
+            seen.add(link)
+            target = gss_rows.get(link)
+            if target is None:
+                break
+            if LPSN_CORRECT_NAME in (target.get("status") or ""):
+                accepted[record_no] = link
+                break
+            current = target
+    return accepted

--- a/tests/test_lpsn_utils.py
+++ b/tests/test_lpsn_utils.py
@@ -1,0 +1,55 @@
+"""Tests for the shared LPSN accepted-name resolver."""
+
+from unittest import TestCase
+
+from kg_microbe.utils.lpsn_utils import LPSN_MAX_SYNONYM_HOPS, resolve_accepted_records
+
+_CORRECT = "VP; sp. nov.; validly published under the ICNP; correct name"
+_SYNONYM = "VP; sp. nov.; validly published under the ICNP; synonym"
+
+
+def _rows(*specs):
+    """Build a ``{record_no: gss_row}`` mapping from (no, status, link) triples."""
+    return {no: {"record_no": no, "status": status, "record_lnk": link} for no, status, link in specs}
+
+
+class ResolveAcceptedRecordsTest(TestCase):
+
+    """One resolver, shared by bacdive (#684) and microbedecoder (#746)."""
+
+    def test_a_synonym_resolves_to_its_accepted_record(self):
+        """The base case both transforms need."""
+        mapping = resolve_accepted_records(_rows(("1", _SYNONYM, "2"), ("2", _CORRECT, "")))
+        self.assertEqual(mapping, {"1": "2"})
+
+    def test_a_chain_is_followed(self):
+        """250 synonyms need two hops on the shipped GSS and 2 need three."""
+        mapping = resolve_accepted_records(_rows(("1", _SYNONYM, "2"), ("2", _SYNONYM, "3"), ("3", _CORRECT, "")))
+        self.assertEqual(mapping["1"], "3")
+
+    def test_a_correct_name_is_absent_from_the_mapping(self):
+        """Most records are already current and must not be remapped."""
+        self.assertEqual(resolve_accepted_records(_rows(("1", _CORRECT, ""))), {})
+
+    def test_a_dead_end_is_absent_rather_than_guessed(self):
+        """192 GSS rows are non-current with no link; there is nothing to point at."""
+        self.assertEqual(resolve_accepted_records(_rows(("1", _SYNONYM, ""))), {})
+
+    def test_a_cycle_terminates_and_yields_nothing(self):
+        """No cycles exist in the shipped GSS, but a future release could add one."""
+        self.assertEqual(resolve_accepted_records(_rows(("1", _SYNONYM, "2"), ("2", _SYNONYM, "1"))), {})
+
+    def test_an_unbounded_chain_cannot_hang(self):
+        """
+        The hop cap is the backstop, not the cycle guard.
+
+        An unbounded walk's failure mode is a hang, which costs a CI job its
+        whole budget and reports a timeout instead of the defect (#742).
+        """
+        long_chain = [(str(i), _SYNONYM, str(i + 1)) for i in range(LPSN_MAX_SYNONYM_HOPS + 10)]
+        mapping = resolve_accepted_records(_rows(*long_chain))
+        self.assertEqual(mapping, {}, "a chain longer than the cap resolves to nothing, without hanging")
+
+    def test_a_link_to_a_missing_record_is_survivable(self):
+        """GSS links can dangle; that must not raise."""
+        self.assertEqual(resolve_accepted_records(_rows(("1", _SYNONYM, "999"))), {})

--- a/tests/test_microbedecoder_transform.py
+++ b/tests/test_microbedecoder_transform.py
@@ -595,3 +595,57 @@ def test_mixed_encoding_csv_is_read_with_replacement(tmp_path):
     subjects = {e["subject"] for e in edges}
     assert f"{LPSN_PREFIX}777" in subjects, "the valid-UTF-8 row must be processed"
     assert f"{LPSN_PREFIX}888" in subjects, "the mixed-encoding row must be processed too"
+
+
+def test_lpsn_anchor_is_repointed_to_the_accepted_name(tmp_path, microbedecoder_transform):
+    """
+    A synonym LPSN_ID must not drag the whole row onto a deprecated record.
+
+    Everything this transform emits — crosswalk, metabolism, BacDive snapshot —
+    hangs off one `lpsn:<LPSN_ID>` anchor, so a synonym ID puts all of a row's
+    edges under a deprecated class: 5,263 edges, 1.0% of the output (#746).
+    bacdive got this in #684; the resolver is shared so the two agree.
+    """
+    import shutil
+
+    # The transform resolves database.csv from input_base_dir, so the fixture has
+    # to move with the GSS file rather than the base dir being repointed alone.
+    staged = tmp_path / "input"
+    staged.mkdir()
+    shutil.copy(FIXTURE_DIR / "database.csv", staged / "database.csv")
+    (staged / "lpsn_gss.csv").write_text(
+        "record_no,status,record_lnk\n"
+        "101,VP; sp. nov.; validly published under the ICNP; synonym,999\n"
+        "999,VP; sp. nov.; validly published under the ICNP; correct name,\n",
+        encoding="utf-8",
+    )
+    microbedecoder_transform.input_base_dir = staged
+    microbedecoder_transform._accepted_lpsn = None
+    microbedecoder_transform.run()
+
+    edges = _read_tsv(microbedecoder_transform.output_edge_file)
+    anchors = {e["object"] for e in edges if e["object"].startswith(LPSN_PREFIX)}
+    anchors |= {e["subject"] for e in edges if e["subject"].startswith(LPSN_PREFIX)}
+
+    assert f"{LPSN_PREFIX}999" in anchors, "the synonym anchor must be re-pointed to the accepted record"
+    assert f"{LPSN_PREFIX}101" not in anchors, "the synonym record must not survive as an anchor"
+
+
+def test_a_missing_gss_file_is_non_fatal(tmp_path, microbedecoder_transform):
+    """
+    The GSS CSV is account-gated and not shipped.
+
+    Absence must leave IDs as given rather than abort — the same contract the
+    bacdive transform honours.
+    """
+    import shutil
+
+    staged = tmp_path / "input_no_gss"
+    staged.mkdir()
+    shutil.copy(FIXTURE_DIR / "database.csv", staged / "database.csv")  # but no lpsn_gss.csv
+    microbedecoder_transform.input_base_dir = staged
+    microbedecoder_transform._accepted_lpsn = None
+    microbedecoder_transform.run()
+
+    edges = _read_tsv(microbedecoder_transform.output_edge_file)
+    assert edges, "the transform must still emit without the GSS file"


### PR DESCRIPTION
Closes #746.

## The problem

#684 fixed this for bacdive. microbedecoder never got it, and had **5,263 edges (1.0%)** on deprecated LPSN records — worse per-row than bacdive's case, because it anchors *everything* (crosswalk, metabolism, BacDive snapshot) on a single `lpsn:<LPSN_ID>` taken straight from the source column. One synonym ID drags an entire row's edges onto a deprecated class.

## Shared, not duplicated

`_resolve_accepted_records` held no BacDive-specific state, so it moved to `kg_microbe/utils/lpsn_utils.py`. Both transforms now call the same walk — which is the point: they anchor on the same records and should resolve them identically.

## Effect

| | before | after |
|---|---:|---:|
| edges touching a deprecated LPSN record | 5,263 | **269** (−94.9%) |
| synonym records re-pointed | — | 7,243 |

## A measurement trap worth recording

Comparing against the shipped `data/transformed/bacdive/edges.tsv` shows parent conflicts **rising 239 → 436**, which looks like a regression.

It isn't. **That file predates #684**, so bacdive's on-disk parents are not re-pointed, and the comparison pits one transform's new behaviour against another's old output. Applying #684's resolution to both sides gives **89** — down from 239, close to the 81 predicted in the issue. The full benefit needs a bacdive re-run.

## Contract preserved

A missing `lpsn_gss.csv` stays non-fatal — the GSS export is account-gated and not shipped — matching bacdive. IDs are then used as given and the run prints why.

## Verification

Canary on the real 27,010-row source. Nine tests: seven on the shared resolver (synonym, chain, correct-name, dead-end, cycle, over-length chain, dangling link) and two on the transform. Two mutation-checked. bacdive's 15 existing LPSN tests pass unchanged against the moved resolver. `poetry run tox` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)