### PR TITLE
ci: run QC on every PR, not only those targeting master

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -3,8 +3,11 @@ name: kg-microbe QC
 on:
   push:
     branches: [ master ]
+  # No `branches:` filter on pull_request. That filter matches the *base*, so a
+  # PR targeting anything but master got no checks at all -- and reported as
+  # mergeable with a clean status, because there was nothing to be un-clean.
+  # A stacked PR then looks *better* than a verified one. (#758)
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Closes #758. Found reviewing #754.

`.github/workflows/qc.yml` filtered its `pull_request` trigger to
`branches: [ master ]`. That filter matches the **base**, so any PR targeting
another branch received **no checks at all** — and showed a clean, mergeable
status, because a PR with zero checks has zero failures.

The failure is silent in the dangerous direction: an unverified PR looks better
than a verified one.

This bit us immediately. #756 was stacked on the #754 revert branch and
reported `state=CLEAN` with no checks; its code had never been run by CI. It
only got covered because the workflow was dispatched by hand:

```bash
gh workflow run qc.yml --ref feat/metpo-type-strain-predicate-v2
```

`push` keeps its `branches: [ master ]` filter, so this adds no runs on branch
pushes — only for PRs that currently get none.

Verified the parsed trigger: `push.branches == ['master']`, `pull_request ==
None` (every base), job matrix unchanged across 3.10/3.11/3.12. This PR is its
own test — it targets master, so QC runs on it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)