### PR TITLE
Make merge.yaml habitat-only PREGO, split the bakta/cog/kegg cluster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,12 +285,18 @@ Optional, for the ontology transforms:
   — gold reads `data/transformed/ontologies/ncbitaxon_nodes.tsv` and refuses
   rather than skipping the trim silently.
 
-- `PREGO_SHAPES`: `all` (default) or `habitat`. `habitat` emits only the
+- `PREGO_SHAPES`: `habitat` (default) or `all`. `habitat` emits only the
   `location_of` shapes (ENVO/BTO → taxon) — ~238k edges against 44.7M, a 55 MB
   `edges.tsv` instead of 12.2 GB. PREGO's taxon→GO edges are 99% of the source
   by volume and have no positive evidence in any of the four gold standards,
   while the habitat edges are 7.89x enriched against BacDive isolation and
   replicate at 2.01x against the independent Madin standard.
+
+  **`habitat` is the default because `merge.yaml` reads
+  `data/transformed/prego_habitat/`.** The two defaults must agree: KGX silently
+  skips a missing input, so a default transform writing `prego/` and a default
+  merge reading `prego_habitat/` produced a graph with no PREGO and no warning.
+  `all` writes `prego/` and pairs with `merge.prego-full.yaml`.
 
 - `PREGO_HABITAT_MIN_SCORE`: raw-score floor for *continuous-channel* habitat
   rows, default `1.0`, applied only when `PREGO_SHAPES=habitat`. The genome

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,9 +298,28 @@ Optional, for the ontology transforms:
   so a star threshold would delete 4% of habitat on provenance rather than
   quality. Set `0` to disable. See `docs/PREGO_SCORE_VALIDATION.md`.
 
-  Standard merges use `merge.habitat.yaml` (habitat-only PREGO) or
-  `merge.noprego.yaml` (no PREGO); `merge.yaml` keeps the full source for
-  experimental builds.
+  **`merge.yaml` now takes habitat-only PREGO**, from
+  `data/transformed/prego_habitat/`. Full PREGO — including the taxon→GO edges
+  that are 99% of the source by volume with no positive evidence in any of the
+  four gold standards — lives in `merge.prego-full.yaml`, which is experimental
+  and not for release. `merge.noprego.yaml` drops PREGO entirely.
+  `merge.habitat.yaml` was removed: once `merge.yaml` became the habitat merge it
+  was a byte-identical duplicate, and two copies of one config drift.
+
+  Merge configs, and what distinguishes them:
+
+  | config | PREGO | genome-annotation cluster |
+  |---|---|---|
+  | `merge.yaml` | habitat only | — |
+  | `merge.noprego.yaml` | none | — |
+  | `merge.prego-full.yaml` | **full** (experimental) | — |
+  | `merge_bakta.yaml` | habitat only | **bakta + cog + kegg** |
+  | `merge.minimal.yaml` | none | — |
+
+  `merge_bakta.yaml` exists because bakta is the *connector*: COG on its own is an
+  island of 5,368 edges, all internal `COG→COG_CAT→COG_GROUP` hierarchy, with
+  nothing from any other source pointing at it. Bakta emits the gene→COG and
+  gene→KEGG edges, so the three belong together or not at all.
 
   **If your goal is merge memory or graph size, reach for `merge.noprego.yaml`
   first** — it drops PREGO entirely (~76% of merge input) and needs none of this

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -192,10 +192,17 @@ class PregoTransform(Transform):
 
         :param input_dir: Raw data directory.
         :param output_dir: Transform output directory.
-        :param shapes: ``all`` (default) or ``habitat``. ``habitat`` emits only the
+        :param shapes: ``habitat`` (default) or ``all``. ``habitat`` emits only the
             ``location_of`` shapes (ENVO/BTO -> taxon), which are ~1% of PREGO by
             volume and the only part with measured, independently replicated
-            enrichment. Env: ``PREGO_SHAPES``.
+            enrichment, and it is what ``merge.yaml`` reads. ``all`` additionally
+            emits the taxon→GO edges and pairs with ``merge.prego-full.yaml``; it
+            is the experimental build, costing a 12.2 GB ``edges.tsv`` and a
+            three-hour merge. Defaulting to ``habitat`` keeps the default
+            transform and the default merge pointing at the same directory —
+            they disagreed, and KGX silently skips a missing input, so the
+            default pipeline produced a graph with no PREGO at all.
+            Env: ``PREGO_SHAPES``.
         :param habitat_min_score: Raw-score floor applied to *continuous-channel*
             habitat rows only, leaving the genome channel whole. Defaults to 1.0,
             the policy in ``docs/PREGO_SCORE_VALIDATION.md``; set 0 to disable.
@@ -221,7 +228,7 @@ class PregoTransform(Transform):
         validate_tau(min_confidence)
         self.min_confidence = min_confidence
         if shapes is None:
-            shapes = os.environ.get("PREGO_SHAPES", _SHAPES_ALL).strip().lower() or _SHAPES_ALL
+            shapes = os.environ.get("PREGO_SHAPES", _SHAPES_HABITAT).strip().lower() or _SHAPES_HABITAT
         if shapes not in (_SHAPES_ALL, _SHAPES_HABITAT):
             raise ValueError(f"PREGO_SHAPES must be {_SHAPES_ALL!r} or {_SHAPES_HABITAT!r}, got {shapes!r}")
         self.shapes = shapes

--- a/merge.prego-full.yaml
+++ b/merge.prego-full.yaml
@@ -1,8 +1,19 @@
 ---
-# Standard merge configuration (Bakta and COG excluded)
+# EXPERIMENTAL merge configuration — full PREGO, including its taxon->GO edges.
+#
+# This is not the standard graph. PREGO's taxon->GO edges are 99% of that source
+# by volume (44.3M of 44.7M) and have no positive evidence in any of the four
+# gold standards; only its habitat edges do. They are kept here for experiments
+# and analysis, not for release. The standard graph is merge.yaml, which takes
+# habitat-only PREGO from data/transformed/prego_habitat/.
+#
+# Cost, measured 2026-08-10: ~3 hours, 23.6 GB peak RSS, ~50 GB of swap, a
+# 56,805,952-edge graph of which ~74% is PREGO capable_of. Produce the input
+# with `PREGO_SHAPES=all poetry run kg transform -s prego` (12.2 GB edges.tsv).
+#
 # For Bakta-enabled merge, use merge_bakta.yaml instead
 #
-# Usage: poetry run kg merge -y merge.yaml
+# Usage: poetry run kg merge -y merge.prego-full.yaml
 #
 configuration:
   output_directory: data/merged
@@ -219,19 +230,13 @@ merged_graph:
     # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
     # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO
     # associated_with (via DOID→MONDO xref). See docs/PREGO_INGEST_PLAN.md.
-    # PREGO habitat only. Produce the input with:
-    #   PREGO_SHAPES=habitat poetry run kg transform -s prego
-    # which emits ~238k location_of edges instead of 44.7M, at the tau=1.0
-    # continuous-channel policy in docs/PREGO_SCORE_VALIDATION.md. PREGO's
-    # taxon->GO edges are excluded deliberately: they are 99% of the source by
-    # volume and have no positive evidence in any of the four gold standards.
     prego:
-      name: "PREGO (habitat only)"
+      name: "PREGO"
       input:
         format: tsv
         filename:
-          - data/transformed/prego_habitat/nodes.tsv
-          - data/transformed/prego_habitat/edges.tsv
+          - data/transformed/prego/nodes.tsv
+          - data/transformed/prego/edges.tsv
     # kegg:
     #   name: "kegg"
     #   input:

--- a/merge.yaml
+++ b/merge.yaml
@@ -1,5 +1,5 @@
 ---
-# Standard merge configuration (Bakta and COG excluded)
+# Standard merge configuration (Bakta, COG and KEGG excluded; habitat-only PREGO)
 # For Bakta-enabled merge, use merge_bakta.yaml instead
 #
 # Usage: poetry run kg merge -y merge.yaml
@@ -219,13 +219,20 @@ merged_graph:
     # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
     # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO
     # associated_with (via DOID→MONDO xref). See docs/PREGO_INGEST_PLAN.md.
+    # PREGO habitat only. Its taxon->GO edges are 99% of the source by volume and
+    # have no positive evidence in any of the four gold standards, so they are not
+    # part of the standard graph — see merge.prego-full.yaml for the experimental
+    # build that keeps them. Produce this input with:
+    #   PREGO_SHAPES=habitat poetry run kg transform -s prego
+    # which writes data/transformed/prego_habitat/ (~238k location_of edges at the
+    # tau=1.0 continuous-channel policy in docs/PREGO_SCORE_VALIDATION.md).
     prego:
-      name: "PREGO"
+      name: "PREGO (habitat only)"
       input:
         format: tsv
         filename:
-          - data/transformed/prego/nodes.tsv
-          - data/transformed/prego/edges.tsv
+          - data/transformed/prego_habitat/nodes.tsv
+          - data/transformed/prego_habitat/edges.tsv
     # kegg:
     #   name: "kegg"
     #   input:

--- a/merge_bakta.yaml
+++ b/merge_bakta.yaml
@@ -1,8 +1,19 @@
 ---
-# Merge configuration WITH Bakta sources enabled
-# Use this configuration when Bakta transform outputs are available:
-#   - data/transformed/bakta/cmm_bakta/nodes.tsv + edges.tsv
-#   - data/transformed/bakta/pfas_bakta/nodes.tsv + edges.tsv
+# Merge configuration WITH the genome-annotation cluster: Bakta, COG and KEGG.
+#
+# Bakta is the connector. COG and KEGG on their own are vocabularies with no
+# attachment points — in the standard graph COG is an island of 5,368 edges, all
+# internal COG->COG_CAT->COG_GROUP hierarchy, with nothing from any other source
+# pointing at it. Bakta is what emits the gene->COG and gene->KEGG edges
+# (`add_cog_annotation`, and the COG:/KEGG: branches in bakta/utils.py), so the
+# three belong together or not at all.
+#
+# Otherwise identical to merge.yaml, including habitat-only PREGO. Derived from
+# merge.yaml rather than maintained by hand: the previous version had drifted 7
+# sources behind (missing gtdb, lpsn, lpsn_api, metatraits, metatraits_gtdb,
+# microbedecoder, prego).
+#
+# Requires: poetry run kg transform -s bakta -s cog -s kegg
 #
 # Usage: poetry run kg merge -y merge_bakta.yaml
 #
@@ -84,7 +95,10 @@ merged_graph:
         filename:
           - data/transformed/ontologies/metpo_nodes.tsv
           - data/transformed/ontologies/metpo_edges.tsv
-    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, MICRO — see merge.yaml.
+    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, and MICRO —
+    # only the IDs referenced by mappings/* are imported (not the full
+    # ontologies). See kg_microbe/transform_utils/ontologies_stubs/ for
+    # the transform.
     ontologies_stubs:
       name: "ontologies_stubs"
       input:
@@ -134,6 +148,20 @@ merged_graph:
         filename:
           - data/transformed/madin_etal/nodes.tsv
           - data/transformed/madin_etal/edges.tsv
+    metatraits:
+      input:
+        name: "metatraits"
+        format: tsv
+        filename:
+          - data/transformed/metatraits/nodes.tsv
+          - data/transformed/metatraits/edges.tsv
+    metatraits_gtdb:
+      input:
+        name: "metatraits_gtdb"
+        format: tsv
+        filename:
+          - data/transformed/metatraits_gtdb/nodes.tsv
+          - data/transformed/metatraits_gtdb/edges.tsv
     bactotraits:
       input:
         name: "bactotraits"
@@ -155,20 +183,76 @@ merged_graph:
         filename:
           - data/transformed/bakta/pfas_bakta/nodes.tsv
           - data/transformed/bakta/pfas_bakta/edges.tsv
-    # cog:
-    #   name: "cog"
-    #   input:
-    #     format: tsv
-    #     filename:
-    #       - data/transformed/cog/nodes.tsv
-    #       - data/transformed/cog/edges.tsv
-    # kegg:
-    #   name: "kegg"
-    #   input:
-    #     format: tsv
-    #     filename:
-    #       - data/transformed/kegg/nodes.tsv
-    #       - data/transformed/kegg/edges.tsv
+    cog:
+      name: "cog"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/cog/nodes.tsv
+          - data/transformed/cog/edges.tsv
+    gtdb:
+      name: "GTDB Taxonomy"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/gtdb/nodes.tsv
+          - data/transformed/gtdb/edges.tsv
+    # LPSN nomenclature. `lpsn` is the fast GSS/CSV base layer (taxon
+    # names, ranks, GTDB/NCBITaxon cross-refs); `lpsn_api` is the
+    # authenticated JSON-API enrichment (above-genus taxonomy, basonyms,
+    # publication DOIs/PMIDs, 16S INSDC accessions). The API enrichment
+    # nodes reference lpsn:* records minted by the GSS layer, so both are
+    # merged together.
+    lpsn:
+      name: "LPSN"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/lpsn/nodes.tsv
+          - data/transformed/lpsn/edges.tsv
+    lpsn_api:
+      name: "LPSN API"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/lpsn_api/nodes.tsv
+          - data/transformed/lpsn_api/edges.tsv
+    # MicrobeDecoder (Hackmann & Zhang, Sci Adv 2023) — Bergey / VPI /
+    # Literature / FAPROTAX curated fermentation profiles keyed on
+    # lpsn:<LPSN_ID>, plus a pre-joined LPSN ↔ GTDB ↔ NCBI ↔ GOLD ↔ IMG ↔
+    # BacDive identity crosswalk. See kg_microbe/transform_utils/microbedecoder/.
+    microbedecoder:
+      name: "MicrobeDecoder"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/microbedecoder/nodes.tsv
+          - data/transformed/microbedecoder/edges.tsv
+    # PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
+    # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
+    # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO
+    # associated_with (via DOID→MONDO xref). See docs/PREGO_INGEST_PLAN.md.
+    # PREGO habitat only. Its taxon->GO edges are 99% of the source by volume and
+    # have no positive evidence in any of the four gold standards, so they are not
+    # part of the standard graph — see merge.prego-full.yaml for the experimental
+    # build that keeps them. Produce this input with:
+    #   PREGO_SHAPES=habitat poetry run kg transform -s prego
+    # which writes data/transformed/prego_habitat/ (~238k location_of edges at the
+    # tau=1.0 continuous-channel policy in docs/PREGO_SCORE_VALIDATION.md).
+    prego:
+      name: "PREGO (habitat only)"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/prego_habitat/nodes.tsv
+          - data/transformed/prego_habitat/edges.tsv
+    kegg:
+      name: "kegg"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/kegg/nodes.tsv
+          - data/transformed/kegg/edges.tsv
     # ctd:
     #   input:
     #     name: "ctd"

--- a/tests/test_merge_configs.py
+++ b/tests/test_merge_configs.py
@@ -1,0 +1,147 @@
+"""
+Static checks over the shipped merge configs.
+
+`test_merge_source_subset.py` tests the ``-s`` subset plumbing against a
+synthetic config in ``tmp_path``; nothing validated the real YAMLs. Three things
+went wrong for want of that, all in one change:
+
+* **A config read a directory no transform writes.** ``merge.yaml`` was pointed at
+  ``data/transformed/prego_habitat/`` while ``PREGO_SHAPES`` still defaulted to
+  ``all``, which writes ``prego/``. KGX skips a missing input silently, so the
+  default pipeline produced a graph with no PREGO edges and no warning.
+* **A config stopped parsing.** ``merge_bakta.yaml`` was rebuilt by
+  regex-uncommenting blocks, which also uncommented ``name:``/``input:``/
+  ``filename:`` lines belonging to the MONDO and HP entries. Caught only by
+  running ``yaml.safe_load`` by hand.
+* **Two configs drifted.** ``merge_bakta.yaml`` is meant to be ``merge.yaml`` plus
+  the genome-annotation cluster; it had silently fallen seven sources behind.
+
+These run without any data on disk, so they hold in CI.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kg_microbe.transform import DATA_SOURCES
+
+REPO_ROOT = Path(__file__).parent.parent
+
+#: Output dirs that are not simply ``data/transformed/<registered source>/``.
+#: ``prego_habitat`` is written by ``PREGO_SHAPES=habitat``; the bakta subdirs are
+#: per-dataset. Anything else must correspond to a registered transform, so a
+#: typo or a renamed source cannot sit unnoticed in a shipped config.
+KNOWN_VARIANT_DIRS = {"prego_habitat", "bakta"}
+
+
+def _configs():
+    """
+    Every shipped merge config.
+
+    :return: Sorted list of ``merge*.yaml`` paths, excluding generated stats files.
+    """
+    return sorted(p for p in REPO_ROOT.glob("merge*.yaml") if "stats" not in p.name and "merged-kg" not in p.name)
+
+
+def _active_dirs(path: Path) -> set:
+    """
+    Transform output dirs a config actually reads.
+
+    Commented-out entries do not count — reading them is what made an earlier
+    audit report 22 sources where the config had 14.
+
+    :param path: Merge config path.
+    :return: Set of directory names under ``data/transformed/``.
+    """
+    dirs = set()
+    for line in path.read_text().splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        match = re.search(r"data/transformed/([a-z_]+)/", line)
+        if match:
+            dirs.add(match.group(1))
+    return dirs
+
+
+def test_at_least_one_config_is_present():
+    """A glob that silently matches nothing would make every check below vacuous."""
+    assert _configs(), "no merge*.yaml found — the other checks would pass on an empty set"
+
+
+@pytest.mark.parametrize("config", _configs(), ids=lambda p: p.name)
+def test_every_config_parses(config: Path):
+    """A config that does not parse is not a config."""
+    loaded = yaml.safe_load(config.read_text())
+    assert isinstance(loaded, dict), f"{config.name} did not parse to a mapping"
+    assert loaded.get("merged_graph", {}).get("source"), f"{config.name} declares no sources"
+
+
+@pytest.mark.parametrize("config", _configs(), ids=lambda p: p.name)
+def test_every_input_dir_is_producible(config: Path):
+    """
+    Every directory a config reads must be one some transform writes.
+
+    This is the check that would have caught the PREGO mismatch: a config reading
+    a directory nothing produces yields a silently smaller graph, because KGX
+    skips missing inputs without complaint.
+    """
+    registered = set(DATA_SOURCES) | KNOWN_VARIANT_DIRS
+    unknown = _active_dirs(config) - registered
+    assert not unknown, (
+        f"{config.name} reads {sorted(unknown)}, which no registered transform writes. "
+        f"Registered: {sorted(DATA_SOURCES)}; known variants: {sorted(KNOWN_VARIANT_DIRS)}."
+    )
+
+
+def test_the_default_merge_reads_what_the_default_transform_writes():
+    """
+    The two defaults have to agree about PREGO.
+
+    They disagreed: `merge.yaml` read `prego_habitat/` while `PREGO_SHAPES`
+    defaulted to `all`, which writes `prego/`. Nothing failed — KGX skips the
+    missing input — so `kg transform` followed by `kg merge` produced a graph with
+    no PREGO edges at all.
+    """
+    from kg_microbe.transform_utils.prego.prego import PregoTransform
+
+    default_dir = PregoTransform(input_dir=REPO_ROOT / "data" / "raw", output_dir=REPO_ROOT / "data" / "transformed")
+    merge_dirs = _active_dirs(REPO_ROOT / "merge.yaml")
+    prego_dirs = {d for d in merge_dirs if d.startswith("prego")}
+
+    assert prego_dirs == {default_dir.output_dir.name}, (
+        f"merge.yaml reads {sorted(prego_dirs)} but the default transform writes {default_dir.output_dir.name!r}"
+    )
+
+
+def test_the_bakta_config_is_the_standard_graph_plus_the_annotation_cluster():
+    """
+    `merge_bakta.yaml` is defined as `merge.yaml` plus bakta/cog/kegg.
+
+    Stated in its header and nowhere enforced, it had drifted seven sources
+    behind: no gtdb, lpsn, lpsn_api, metatraits, metatraits_gtdb, microbedecoder
+    or prego.
+    """
+    standard = _active_dirs(REPO_ROOT / "merge.yaml")
+    bakta = _active_dirs(REPO_ROOT / "merge_bakta.yaml")
+
+    assert bakta - standard == {"bakta", "cog", "kegg"}, f"unexpected extras: {sorted(bakta - standard)}"
+    assert not standard - bakta, f"merge_bakta.yaml has fallen behind merge.yaml: missing {sorted(standard - bakta)}"
+
+
+def test_the_prego_variants_differ_only_in_the_prego_source():
+    """
+    `merge.prego-full.yaml` and `merge.noprego.yaml` are `merge.yaml` ± PREGO.
+
+    Keeping that true is what stops a source added to the standard graph from
+    quietly missing out of the variants.
+    """
+    standard = _active_dirs(REPO_ROOT / "merge.yaml")
+    full = _active_dirs(REPO_ROOT / "merge.prego-full.yaml")
+    none = _active_dirs(REPO_ROOT / "merge.noprego.yaml")
+
+    assert full - standard == {"prego"}, f"prego-full extras: {sorted(full - standard)}"
+    assert standard - full == {"prego_habitat"}, f"prego-full is missing: {sorted(standard - full)}"
+    assert not none - standard, f"noprego extras: {sorted(none - standard)}"
+    assert standard - none == {"prego_habitat"}, f"noprego differs by more than PREGO: {sorted(standard - none)}"

--- a/tests/test_merge_configs.py
+++ b/tests/test_merge_configs.py
@@ -30,10 +30,10 @@ from kg_microbe.transform import DATA_SOURCES
 REPO_ROOT = Path(__file__).parent.parent
 
 #: Output dirs that are not simply ``data/transformed/<registered source>/``.
-#: ``prego_habitat`` is written by ``PREGO_SHAPES=habitat``; the bakta subdirs are
-#: per-dataset. Anything else must correspond to a registered transform, so a
-#: typo or a renamed source cannot sit unnoticed in a shipped config.
-KNOWN_VARIANT_DIRS = {"prego_habitat", "bakta"}
+#: Only ``prego_habitat``, written by ``PREGO_SHAPES=habitat``. ``bakta`` was listed
+#: here too, which changed nothing — it is a registered ``DATA_SOURCES`` key — while
+#: implying to a reader that it is not one.
+KNOWN_VARIANT_DIRS = {"prego_habitat"}
 
 
 def _configs():
@@ -52,6 +52,13 @@ def _active_dirs(path: Path) -> set:
     Commented-out entries do not count — reading them is what made an earlier
     audit report 22 sources where the config had 14.
 
+    The pattern is deliberately permissive about the characters in a directory
+    name. An earlier ``[a-z_]+`` had to be followed by ``/``, so any name holding a
+    digit, hyphen or capital matched *nothing* and became invisible — the guard
+    then passed a config pointing at an unproducible directory, which is the exact
+    thing it exists to catch. Better to over-capture and let the allowlist
+    comparison report an unknown than to silently skip it.
+
     :param path: Merge config path.
     :return: Set of directory names under ``data/transformed/``.
     """
@@ -59,7 +66,7 @@ def _active_dirs(path: Path) -> set:
     for line in path.read_text().splitlines():
         if line.lstrip().startswith("#"):
             continue
-        match = re.search(r"data/transformed/([a-z_]+)/", line)
+        match = re.search(r"data/transformed/([^/\s]+)/", line)
         if match:
             dirs.add(match.group(1))
     return dirs
@@ -145,3 +152,20 @@ def test_the_prego_variants_differ_only_in_the_prego_source():
     assert standard - full == {"prego_habitat"}, f"prego-full is missing: {sorted(standard - full)}"
     assert not none - standard, f"noprego extras: {sorted(none - standard)}"
     assert standard - none == {"prego_habitat"}, f"noprego differs by more than PREGO: {sorted(standard - none)}"
+
+
+@pytest.mark.parametrize("odd_dir", ["kegg2", "go-terms", "Ontologies"], ids=["digit", "hyphen", "capital"])
+def test_an_oddly_named_unproducible_dir_is_caught(tmp_path, odd_dir):
+    """
+    The extractor must not go blind on names outside ``[a-z_]``.
+
+    With the original pattern each of these matched nothing, so a config reading
+    them passed the producibility check silently.
+    """
+    config = tmp_path / "merge.odd.yaml"
+    config.write_text(
+        "merged_graph:\n  source:\n    x:\n      input:\n        filename:\n"
+        f"          - data/transformed/{odd_dir}/nodes.tsv\n"
+    )
+    assert _active_dirs(config) == {odd_dir}, "the dir must be visible to the guard"
+    assert odd_dir not in set(DATA_SOURCES) | KNOWN_VARIANT_DIRS, "and recognised as unproducible"

--- a/tests/test_prego_transform.py
+++ b/tests/test_prego_transform.py
@@ -34,6 +34,25 @@ from kg_microbe.transform_utils.prego.utils import (
 FIXTURE_DIR = Path(__file__).parent / "resources" / "prego"
 
 
+@pytest.fixture(autouse=True)
+def _full_emission_by_default(monkeypatch):
+    """
+    Exercise full emission unless a test says otherwise.
+
+    Nearly every test here predates shape selection and asserts on the full
+    output — taxon→GO edges, all three channels, the MONDO path. The shipped
+    default is ``habitat``, so that the default transform writes where the default
+    merge reads; a test that silently inherited that default would be asserting
+    something it was never written to check, and ~20 of them failed that way when
+    the default changed.
+
+    Setting the environment rather than passing ``shapes="all"`` at ~30 call sites
+    keeps the intent in one place and covers the multi-line constructions too.
+    Tests that care about the real default unset this.
+    """
+    monkeypatch.setenv("PREGO_SHAPES", "all")
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -94,7 +113,11 @@ def prego_output_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture()
 def prego_transform(prego_input_dir: Path, prego_output_dir: Path) -> PregoTransform:
-    """Return a ``PregoTransform`` wired to the fixture input + output dirs."""
+    """
+    Return a ``PregoTransform`` wired to the fixture input + output dirs.
+
+    Full emission, via the module-wide ``_full_emission_by_default`` fixture.
+    """
     return PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
 
 
@@ -1465,11 +1488,20 @@ def test_habitat_min_score_thresholds_only_the_continuous_channel(prego_input_di
     assert channels <= {CHANNEL_GENOMES, CHANNEL_LITERATURE}, channels
 
 
-def test_shapes_defaults_to_all_and_rejects_nonsense(prego_input_dir: Path, prego_output_dir: Path):
-    """Unfiltered stays the default, and a typo must fail loudly rather than silently emit everything."""
+def test_shapes_defaults_to_habitat_and_rejects_nonsense(prego_input_dir: Path, prego_output_dir: Path, monkeypatch):
+    """
+    The default must produce what the default merge reads.
+
+    `merge.yaml` reads data/transformed/prego_habitat/. KGX silently skips a
+    missing input, so a default transform writing prego/ against a default merge
+    reading prego_habitat/ produced a graph with no PREGO edges and no warning.
+    A typo must still fail loudly rather than silently emit everything.
+    """
+    monkeypatch.delenv("PREGO_SHAPES", raising=False)
     default = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
-    assert default.shapes == "all"
-    assert default.habitat_min_score == 0.0, "the habitat floor must not apply to an unfiltered run"
+    assert default.shapes == "habitat"
+    assert default.output_dir.name == "prego_habitat", "and must write where merge.yaml looks"
+    assert default.habitat_min_score == 1.0, "the documented tau=1.0 policy applies by default"
 
     with pytest.raises(ValueError, match="PREGO_SHAPES"):
         PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitats")
@@ -1483,7 +1515,7 @@ def test_habitat_mode_writes_to_its_own_directory(prego_input_dir: Path, prego_o
     selector: pointed at a full PREGO output it would ship a 44.7M-edge graph
     as "habitat only", with nothing to catch the mislabelling.
     """
-    full = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir)
+    full = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="all")
     habitat = PregoTransform(input_dir=prego_input_dir, output_dir=prego_output_dir, shapes="habitat")
 
     assert habitat.output_dir != full.output_dir


### PR DESCRIPTION
PREGO is experimental and not for standard merges — but `merge.yaml`, the default, still carried the full source: ~74% of a 56.8M-edge graph, a 3-hour merge, 23.6 GB peak RSS and ~50 GB of swap, all of it the taxon→GO edges with no positive evidence in any of the four gold standards.

## Config changes

| config | PREGO | bakta/cog/kegg | active sources |
|---|---|---|---:|
| `merge.yaml` | **habitat only** | — | 14 |
| `merge.prego-full.yaml` | full (**experimental**) | — | 14 |
| `merge.noprego.yaml` | none | — | 13 |
| `merge_bakta.yaml` | habitat only | **yes** | 17 |

- `merge.habitat.yaml` **removed** — once `merge.yaml` became the habitat merge the two had byte-identical source sets, and two copies of one config drift. It was a day old with nothing scripted referencing it.
- `merge_bakta.yaml` already existed but had **drifted 7 sources behind** (no `gtdb`, `lpsn`, `lpsn_api`, `metatraits`, `metatraits_gtdb`, `microbedecoder`, `prego`). Rebuilt from the current `merge.yaml`.

Its header now records *why* the three travel together: COG in the standard graph is an island of 5,368 edges, all internal `COG→COG_CAT→COG_GROUP`, with nothing from any other source pointing at it. Bakta is the connector — `add_cog_annotation`, and the `COG:`/`KEGG:` branches in `bakta/utils.py` — so COG and KEGG are vocabularies with no attachment points until bakta runs.

## Review findings, fixed in-branch

**#764 — the default pipeline silently dropped PREGO.** `PREGO_SHAPES` defaulted to `all` (writes `prego/`) while `merge.yaml` read `prego_habitat/`. KGX skips missing inputs silently, so `kg transform` → `kg merge` produced a graph with **no PREGO edges and no warning**. Masked locally because both dirs existed from canaries. `PREGO_SHAPES` now defaults to `habitat`; `all` pairs with `merge.prego-full.yaml`.

**#765 — nothing validated the real merge YAMLs**, which is why #764 was invisible. New `tests/test_merge_configs.py` adds static checks (no data on disk needed): every config parses, every input dir is producible by a registered transform, the two defaults agree, `merge_bakta.yaml` is exactly `merge.yaml` + the cluster, and the PREGO variants differ only in PREGO.

## Verification

- Each new guard verified against the failure it exists for — reverting the transform default, dropping `gtdb` from `merge_bakta.yaml`, and misspelling a transform dir each fail exactly one test.
- All six configs parse and were checked by enumerating active sources.
- 20 PREGO tests had silently inherited the old default while asserting on full emission; a module-wide fixture now makes that explicit in one place.
- `poetry run tox` green.

One process note: a first attempt built `merge_bakta.yaml` by regex-uncommenting, which also uncommented `name:`/`input:`/`filename:` lines belonging to the MONDO and HP entries and produced YAML that wouldn't parse. Rebuilt from literal blocks — and the new parse check is exactly what would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)