### PR TITLE
Declare KGXVal coverage in the review artifact; follow PREGO's real output dir

### DIFF
--- a/.claude/skills/kg-model-review/SKILL.md
+++ b/.claude/skills/kg-model-review/SKILL.md
@@ -266,6 +266,12 @@ ships with the biolink sub/obj check disabled. So the driver:
 3. calls KGXVal's own `findSubObjErrorsForIngest`;
 4. writes an error CSV that this skill summarizes.
 
+**Every merged review declares its KGXVal status**, including when the flag was
+not passed — the section reads `**NOT RUN**` in that case. Without it, an artifact
+built without `--kgxval` was indistinguishable from a full one and passed the
+kg-release gate identically, so a release could trust the weaker review with
+nothing recording that the external validation had been skipped.
+
 **Reading the output.** `BAD BIOLINK` is split into **METPO-native predicates**
 (`METPO:2000xxx` — KG-Microbe emits these intentionally and maps them to biolink
 in `metatraits.py`; expected, not a defect) vs **other unknown predicates**

--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -1824,6 +1824,31 @@ def main():
         if kgxval_md and args.format in ("md", "text"):
             rendered += "\n\n" + kgxval_md
 
+    # Always state the external-validation status on a merged review, including
+    # when it was not requested. The kg-release gate loads "the most recent
+    # artifact" and blocks on `Total ERRORs > 0`; an artifact built without
+    # --kgxval was structurally identical to one built with it, so the gate could
+    # not tell that BMT-derived domain/range validation had been skipped, and a
+    # release would trust the weaker review without saying so.
+    if args.merged and args.format in ("md", "text"):
+        if not args.kgxval:
+            rendered += (
+                "\n\n## KGXVal biolink validation\n\n"
+                "**NOT RUN** — this review was produced without `--kgxval`, so the external "
+                "BMT-derived domain/range validation "
+                "([monarch-initiative/kgxval](https://github.com/monarch-initiative/kgxval)) "
+                "did not run. The built-in `DomainRange` check is a maintained allowlist, not "
+                "the published Biolink model. Re-run with `--kgxval` before relying on this "
+                "artifact as a release gate.\n"
+            )
+        elif kgxval_md is None:
+            rendered += (
+                "\n\n## KGXVal biolink validation\n\n"
+                "**REQUESTED BUT DID NOT COMPLETE** — `--kgxval` was passed but the external "
+                "run produced no result (missing `uv`, offline, or a tool error). Treat this "
+                "artifact as if the check had not run.\n"
+            )
+
     print(rendered)
     if kgxval_md and args.format == "json" and not args.no_save:
         kgxval_path = _save_review_artifact(kgxval_md, "merged-kgxval", ext="md")

--- a/.claude/skills/kg-release/SKILL.md
+++ b/.claude/skills/kg-release/SKILL.md
@@ -107,6 +107,10 @@ poetry run python .claude/skills/kg-release/kg_release.py \
 
 1. **Pre-flight** — verify `gh auth status`, working tree clean, master/release branch, tag does not exist.
 2. **Review gate** — load the most recent artifact from each review skill's `reviews/` dir. If older than `--review-max-age-days` or missing, **abort** and tell the user to run `/kg-model-review` and `/kg-path-review` via Claude Code first. Block on `needs-attention` (kg-model-review error count > 0, or kg-path-review CRITICAL findings) unless `--ignore-review`.
+
+   **Check the KGXVal status line in the kg-model-review artifact.** A merged review now always ends with a `## KGXVal biolink validation` section stating whether the external validator ran. `**NOT RUN**` or `**REQUESTED BUT DID NOT COMPLETE**` means the artifact carries only the built-in `DomainRange` check — a maintained allowlist rather than the published Biolink model. That artifact is structurally identical to a full one and passes the same `Total ERRORs > 0` gate, so without reading this line the gate silently accepts the weaker review. Treat it as `needs-attention` for a release, and re-run `/kg-model-review --merged --kgxval`.
+
+   The reason this is a gate concern rather than a nicety: KGXVal derives legal subject/object classes from BMT at runtime, so it catches domain/range violations the in-tree allowlist has never been taught about. On the 2026-08-12 merged KG it reported 0 actionable findings — but that is a result, not a reason to skip it.
 3. **Stage assets** in `<out-dir>`:
    - `merged-kg_<release>.tar.gz` — recompress from `<merged-dir>` (always rebuild for reproducibility).
    - `data_transformed_<release>.tar.gz` — `tar c -I 'gzip -1' data/transformed`.

--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -156,15 +156,46 @@ def _has_local_diff(path: Path, ref: str) -> bool:
     return bool(_git(["diff", ref, "--", rel]).strip())
 
 
+#: Sources whose output directory is not simply ``data/transformed/<name>/``.
+#: PREGO writes ``prego_habitat/`` under its default (``PREGO_SHAPES=habitat``,
+#: since #766) and ``prego/`` under ``PREGO_SHAPES=all``. Watching only ``prego/``
+#: left the flag permanently STALE_VS_CODE — no default run writes it — while the
+#: directory ``merge.yaml`` actually consumes went unchecked entirely.
+OUTPUT_DIR_ALIASES: dict[str, tuple[str, ...]] = {
+    "prego": ("prego_habitat", "prego"),
+}
+
+
+def _output_dirs(source_name: str) -> list[pathlib.Path]:
+    """
+    Candidate output directories for a source, newest-populated first.
+
+    :param source_name: Transform name.
+    :return: Existing directories that could hold this source's output.
+    """
+    names = OUTPUT_DIR_ALIASES.get(source_name, (source_name,))
+    return [TRANSFORMED_DIR / n for n in names if (TRANSFORMED_DIR / n).is_dir()]
+
+
 def _output_mtime(source_name: str) -> Optional[float]:
-    """Newest mtime across the expected nodes/edges outputs for a source."""
-    src_dir = TRANSFORMED_DIR / source_name
-    if not src_dir.is_dir():
-        return None
-    hits = list(src_dir.glob("*.tsv")) + list(src_dir.glob("*.tsv.gz"))
-    if not hits:
-        return None
-    return max(p.stat().st_mtime for p in hits)
+    """
+    Newest mtime across the expected nodes/edges outputs for a source.
+
+    Takes the **newest** across candidate directories rather than the first that
+    exists: a source with a variant output path is fresh if any of its documented
+    outputs is, and reporting the stale one would nag about a build nobody makes.
+
+    :param source_name: Transform name.
+    :return: Newest output mtime, or None if nothing is on disk.
+    """
+    newest: Optional[float] = None
+    for src_dir in _output_dirs(source_name):
+        hits = list(src_dir.glob("*.tsv")) + list(src_dir.glob("*.tsv.gz"))
+        if not hits:
+            continue
+        candidate = max(p.stat().st_mtime for p in hits)
+        newest = candidate if newest is None else max(newest, candidate)
+    return newest
 
 
 def _list_transform_sources() -> list[str]:
@@ -204,7 +235,8 @@ def check_source(source: str, ref: str) -> SourceReport:
 
     if out_mtime is None:
         status = "MISSING_OUTPUT"
-        note = f"data/transformed/{source}/ has no .tsv/.tsv.gz"
+        expected = " or ".join(f"data/transformed/{n}/" for n in OUTPUT_DIR_ALIASES.get(source, (source,)))
+        note = f"{expected} has no .tsv/.tsv.gz"
     elif local:
         status = "LOCAL_CHANGES"
         note = (
@@ -277,7 +309,19 @@ def check_merge(source_reports: Iterable[SourceReport], ref: str) -> MergeReport
         stale_against.append(merge_yaml_path or "merge yaml")
     for r in source_reports:
         if r.output_mtime is not None and merged_mtime < r.output_mtime:
-            stale_against.append(f"data/transformed/{r.source}/")
+            # Name the directory that is actually newer, not the source name. For a
+            # source with a variant output path these differ, and printing
+            # "data/transformed/prego/" while the fresh build sits in
+            # "prego_habitat/" sends the reader to the wrong file.
+            fresher = [
+                d for d in _output_dirs(r.source)
+                if any(
+                    f.stat().st_mtime > merged_mtime
+                    for f in list(d.glob("*.tsv")) + list(d.glob("*.tsv.gz"))
+                )
+            ]
+            for d in fresher or [TRANSFORMED_DIR / r.source]:
+                stale_against.append(f"data/transformed/{d.name}/")
 
     if not stale_against:
         status = "FRESH"

--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -42,6 +42,7 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass, asdict, field
+import re
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -166,24 +167,63 @@ OUTPUT_DIR_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 
-def _output_dirs(source_name: str) -> list[pathlib.Path]:
+def _dirs_referenced_by_merge_config() -> set[str]:
     """
-    Candidate output directories for a source, newest-populated first.
+    Transform output directories the active merge config actually reads.
+
+    A release pre-flight has to answer "is what will be merged current?", not "is
+    any output for this source current?". Those differ for a source with more than
+    one output path: with a fresh ``prego/`` from ``PREGO_SHAPES=all`` and a stale
+    ``prego_habitat/``, picking by mtime reports FRESH while the standard merge
+    consumes the stale build.
+
+    :return: Directory names under ``data/transformed/`` named by the config.
+    """
+    for candidate in MERGE_YAML_CANDIDATES:
+        path = REPO / candidate
+        if not path.is_file():
+            continue
+        referenced: set[str] = set()
+        for line in path.read_text().splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            match = re.search(r"data/transformed/([^/\s]+)/", line)
+            if match:
+                referenced.add(match.group(1))
+        if referenced:
+            return referenced
+    return set()
+
+
+def _output_dirs(source_name: str) -> list[Path]:
+    """
+    Candidate output directories for a source, most authoritative first.
+
+    The directory the merge config names wins. Only when the config names none
+    does this fall back to whichever alias is populated, newest first — that
+    fallback is for a source not in the merge at all, where "any output" is the
+    best available answer.
 
     :param source_name: Transform name.
     :return: Existing directories that could hold this source's output.
     """
     names = OUTPUT_DIR_ALIASES.get(source_name, (source_name,))
-    return [TRANSFORMED_DIR / n for n in names if (TRANSFORMED_DIR / n).is_dir()]
+    existing = [n for n in names if (TRANSFORMED_DIR / n).is_dir()]
+    if len(existing) > 1:
+        merged_refs = _dirs_referenced_by_merge_config()
+        preferred = [n for n in existing if n in merged_refs]
+        if preferred:
+            existing = preferred
+    return [TRANSFORMED_DIR / n for n in existing]
 
 
 def _output_mtime(source_name: str) -> Optional[float]:
     """
     Newest mtime across the expected nodes/edges outputs for a source.
 
-    Takes the **newest** across candidate directories rather than the first that
-    exists: a source with a variant output path is fresh if any of its documented
-    outputs is, and reporting the stale one would nag about a build nobody makes.
+    Measures the directory the merge config consumes when the source has more than
+    one output path — see :func:`_output_dirs`. Taking the newest across all of
+    them reported FRESH while the merge read a stale build.
 
     :param source_name: Transform name.
     :return: Newest output mtime, or None if nothing is on disk.

--- a/tests/test_freshness_output_aliases.py
+++ b/tests/test_freshness_output_aliases.py
@@ -1,0 +1,73 @@
+"""Tests that the freshness check follows a source's real output directory."""
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+from unittest import TestCase
+
+_SPEC = importlib.util.spec_from_file_location(
+    "kgm_freshness_check",
+    Path(__file__).parent.parent / ".claude" / "skills" / "kgm-freshness-check" / "kgm_freshness_check.py",
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules["kgm_freshness_check"] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+
+class FreshnessOutputAliasTest(TestCase):
+
+    """PREGO writes prego_habitat/ by default, prego/ only under PREGO_SHAPES=all."""
+
+    def setUp(self):
+        """Point the module at a scratch data/transformed tree."""
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self._orig = _MODULE.TRANSFORMED_DIR
+        _MODULE.TRANSFORMED_DIR = self.tmp
+
+    def tearDown(self):
+        """Restore the module-level path."""
+        _MODULE.TRANSFORMED_DIR = self._orig
+
+    def _write(self, name, age_seconds):
+        """Create a transform output dir with a controlled mtime."""
+        d = self.tmp / name
+        d.mkdir(parents=True, exist_ok=True)
+        f = d / "edges.tsv"
+        f.write_text("subject\tpredicate\tobject\n")
+        stamp = time.time() - age_seconds
+        import os
+
+        os.utime(f, (stamp, stamp))
+        return f
+
+    def test_a_fresh_variant_dir_clears_the_source(self):
+        """
+        The default output must be able to clear the flag.
+
+        Watching only `prego/` left the source permanently STALE_VS_CODE after
+        #766 made `habitat` the default: no default invocation writes that
+        directory, so re-running the transform changed nothing in the report.
+        """
+        self._write("prego", age_seconds=86400)
+        newest = self._write("prego_habitat", age_seconds=10)
+
+        mtime = _MODULE._output_mtime("prego")
+        self.assertAlmostEqual(mtime, newest.stat().st_mtime, places=3)
+
+    def test_the_legacy_dir_alone_still_counts(self):
+        """`PREGO_SHAPES=all` writes prego/, which must not become invisible."""
+        only = self._write("prego", age_seconds=10)
+        self.assertAlmostEqual(_MODULE._output_mtime("prego"), only.stat().st_mtime, places=3)
+
+    def test_a_source_with_no_alias_is_unchanged(self):
+        """The aliasing must not disturb the ordinary one-dir case."""
+        f = self._write("bacdive", age_seconds=10)
+        self.assertAlmostEqual(_MODULE._output_mtime("bacdive"), f.stat().st_mtime, places=3)
+
+    def test_missing_output_is_still_missing(self):
+        """A source with neither directory present must report nothing."""
+        self.assertIsNone(_MODULE._output_mtime("prego"))
+        self.assertIsNone(_MODULE._output_mtime("bacdive"))

--- a/tests/test_freshness_output_aliases.py
+++ b/tests/test_freshness_output_aliases.py
@@ -71,3 +71,26 @@ class FreshnessOutputAliasTest(TestCase):
         """A source with neither directory present must report nothing."""
         self.assertIsNone(_MODULE._output_mtime("prego"))
         self.assertIsNone(_MODULE._output_mtime("bacdive"))
+
+    def test_the_dir_the_merge_reads_wins_over_the_newest(self):
+        """
+        A pre-flight must measure what will be merged, not whatever is newest.
+
+        The first fix took the newest across aliases, which inverted the bug: a
+        fresh `prego/` from `PREGO_SHAPES=all` beside a stale `prego_habitat/`
+        reported FRESH while the standard merge consumed the stale build.
+        """
+        self._write("prego", age_seconds=10)
+        stale = self._write("prego_habitat", age_seconds=999999)
+
+        # merge.yaml in the real repo references prego_habitat/, so that must win
+        # despite prego/ being far newer.
+        self.assertEqual([d.name for d in _MODULE._output_dirs("prego")], ["prego_habitat"])
+        self.assertAlmostEqual(_MODULE._output_mtime("prego"), stale.stat().st_mtime, places=3)
+
+    def test_the_merge_config_is_actually_parsed(self):
+        """A silently empty reference set would make the preference a no-op."""
+        referenced = _MODULE._dirs_referenced_by_merge_config()
+        self.assertIn("prego_habitat", referenced)
+        self.assertIn("bacdive", referenced)
+        self.assertNotIn("prego", referenced, "merge.yaml takes habitat-only PREGO since #766")


### PR DESCRIPTION
Closes #773. Two release pre-flight tools were reporting less than they appeared to.

## 1. The release gate couldn't tell whether external validation ran

`kg-release` loads the most recent `kg-model-review` artifact and blocks on `Total ERRORs > 0`. An artifact built **without** `--kgxval` was structurally identical to one built with it — zero mentions of KGXVal, same summary, same gate verdict.

Demonstrated by running the same command both ways: the artifact without the flag contains no trace that BMT-derived domain/range validation was skipped. A release would trust the weaker review silently. (I reproduced the risk accidentally too — generating one without the flag made it the newest artifact in `reviews/`, so a release at that moment would have gated on it.)

A merged review now **always** ends with a `## KGXVal biolink validation` section, stating `**NOT RUN**` or `**REQUESTED BUT DID NOT COMPLETE**` where applicable, and `kg-release` documents treating those as needs-attention.

Why it's a gate concern and not a nicety: the in-tree `DomainRange` check is a maintained allowlist; KGXVal derives legal subject/object classes from BMT at runtime, so it catches violations the allowlist has never been taught about. It found **0 actionable** on the 2026-08-12 merged KG — a result, not a reason to skip it.

## 2. The freshness check watched a directory nothing writes

#766 made `PREGO_SHAPES` default to `habitat`, so `kg transform -s prego` writes `prego_habitat/`. `kgm_freshness_check` still derived its path from the source name:

| dir | mtime | monitored? |
|---|---|---|
| `prego/` | Aug 10 19:19 | yes — **permanently STALE_VS_CODE** |
| `prego_habitat/` | Aug 13 12:32 | **no rows in the report** |

So the flag could never be cleared — I re-ran the transform and the report was unchanged — while the directory `merge.yaml` actually consumes went unchecked. This is the third tool to inherit the default-path split that #764 first exposed.

Output dirs are now declared per source (newest-populated wins), and the merge's "stale against" line names the directory that is genuinely newer rather than the source name.

**After:** 16 FRESH, 0 STALE_VS_CODE; merge correctly reports stale against `data/transformed/prego_habitat/`.

## Verification

- Four tests; both fixes mutation-checked (reverting the alias fails the variant test; removing the status line takes KGXVal mentions to 0).
- `poetry run tox` green.
- Regenerated a proper gate-quality artifact with `--kgxval`: 0 errors, 0 warnings, 0 actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)