### PR TITLE
Emit the reference DOI on bacdive metabolite-utilization edges

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -113,6 +113,7 @@ from kg_microbe.transform_utils.constants import (
     MEDIUM_URL_COLUMN,
     METABOLITE_CATEGORY,
     METABOLITE_CHEBI_KEY,
+    REFERENCE_KEY,
     METABOLITE_KEY,
     METABOLITE_MAPPING_FILE,
     METABOLITE_PRODUCTION,
@@ -1936,6 +1937,9 @@ class BacDiveTransform(Transform):
                     isolation_dict = value.get(ISOLATION_SAMPLING_ENV_INFO, {})
                     morphology_dict = value.get(MORPHOLOGY, {})
                     physiology_dict = value.get(PHYSIOLOGY_AND_METABOLISM, {})
+                    # @ref -> DOI for this record, so a statement can name the
+                    # paper behind it rather than only the strain record.
+                    record_reference_dois = reference_dois(value)
                     safety_dict = value.get(SAFETY_INFO, {})
                     name_tax_classification = value.get(NAME_TAX_CLASSIFICATION, {})
 
@@ -2809,6 +2813,10 @@ class BacDiveTransform(Transform):
                                                 "utilization_type": utilization_type,
                                                 "metpo_predicate": metpo_predicate,
                                                 "metpo_label": metpo_label,
+                                                # The @ref of this specific item, not of the
+                                                # record: one strain record cites several
+                                                # papers and they can disagree.
+                                                "ref": metabolite.get(REFERENCE_KEY),
                                             }
                                         )
 
@@ -2869,6 +2877,7 @@ class BacDiveTransform(Transform):
                                 knowledge_level, agent_type = self._add_edge_metadata(
                                     item["metpo_predicate"], HAS_PARTICIPANT, item["chebi_key"]
                                 )
+                                doi = record_reference_dois.get(item.get("ref"))
                                 edge_writer.writerow(
                                     [
                                         organism_id,
@@ -2878,7 +2887,8 @@ class BacDiveTransform(Transform):
                                         self.knowledge_source,
                                         knowledge_level,
                                         agent_type,
-                                    ]
+                                    ],
+                                    publication=f"doi:{doi}" if doi else None,
                                 )
 
                     if phys_and_metabolism_metabolite_production:
@@ -3367,6 +3377,42 @@ class BacDiveTransform(Transform):
 _STRAIN_BACDIVE_PREFIX = "kgmicrobe.strain:bacdive_"
 
 
+def reference_dois(record: dict) -> dict:
+    """Map a BacDive record's ``@ref`` ids to publication DOIs.
+
+    BacDive attaches an ``@ref`` to every individual data item and lists the corresponding
+    citations in the record's ``Reference`` section, keyed by ``@id``. That linkage is the
+    only route from a single statement to the paper behind it, and it is discarded unless
+    it is read here: ``primary_knowledge_source`` identifies the strain *record*, which
+    says nothing about which of its several references supports a given statement.
+
+    Two kinds of ``doi/url`` value are skipped. Catalogue URLs (DSMZ, StrainInfo) are not
+    publications, and BacDive's own record DOI (``10.13145/bacdive...``) points back at the
+    record we already identify -- treating either as a citation would attach confident-
+    looking provenance that leads nowhere.
+    """
+    refs = record.get("Reference")
+    if refs is None:
+        return {}
+    if isinstance(refs, dict):
+        refs = [refs]
+    out = {}
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        ref_id = ref.get("@id")
+        doi = str(ref.get("doi/url") or "").strip()
+        if ref_id is None or not doi.startswith("10."):
+            continue
+        if doi.lower().startswith("10.13145/bacdive"):
+            continue
+        try:
+            out[int(ref_id)] = doi
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
 class _StrainProvenanceWriter:
 
     """
@@ -3401,15 +3447,29 @@ class _StrainProvenanceWriter:
         self._ks = knowledge_source
         self._ks_idx = ks_column_index
 
-    def writerow(self, row):
-        """Write a single edge row, augmenting knowledge_source when the row references a BacDive strain."""
+    def writerow(self, row, publication: str = None):
+        """Write a single edge row, augmenting knowledge_source when the row references a BacDive strain.
+
+        ``publication`` is the DOI of the paper the statement came from, resolved from the
+        data item's ``@ref`` against the record's ``Reference`` section. When supplied it is
+        appended to the same list literal, so an edge carries the source, the strain record
+        *and* the citation:
+
+            ['infores:bacdive', 'bacdive:1', 'doi:10.1099/ijs.0.02862-0']
+
+        Callers that do not pass it are unaffected, so sections not yet threaded keep their
+        existing output byte for byte.
+        """
         row = list(row)
         if len(row) > self._ks_idx and row[self._ks_idx] == self._ks:
             # Look at subject (col 0) then object (col 2) for a strain CURIE.
             for endpoint in (row[0], row[2] if len(row) > 2 else None):
                 if isinstance(endpoint, str) and endpoint.startswith(_STRAIN_BACDIVE_PREFIX):
                     bacdive_id = endpoint[len(_STRAIN_BACDIVE_PREFIX) :]
-                    row[self._ks_idx] = f"['{self._ks}', 'bacdive:{bacdive_id}']"
+                    parts = [self._ks, f"bacdive:{bacdive_id}"]
+                    if publication:
+                        parts.append(publication)
+                    row[self._ks_idx] = "[" + ", ".join(f"'{p}'" for p in parts) + "]"
                     break
         self._inner.writerow(row)
 

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -507,6 +507,8 @@ MORPHOLOGY_CELL_MORPHOLOGY_COLUMN = MORPHOLOGY + "_" + CELL_MORPHOLOGY
 MORPHOLOGY_PIGMENTATION_COLUMN = MORPHOLOGY + "_" + PIGMENTATION
 API_X_COLUMN = "API_X"
 METABOLITE_CHEBI_KEY = "Chebi-ID"
+# Per-item citation pointer; resolved against the record's "Reference" section.
+REFERENCE_KEY = "@ref"
 METABOLITE_KEY = "metabolite"
 PRODUCTION_KEY = "production"
 EC_PREFIX = "EC:"

--- a/tests/test_bacdive_reference_doi.py
+++ b/tests/test_bacdive_reference_doi.py
@@ -1,0 +1,116 @@
+"""Tests for resolving BacDive ``@ref`` ids to publication DOIs."""
+
+from __future__ import annotations
+
+from kg_microbe.transform_utils.bacdive.bacdive import (
+    _StrainProvenanceWriter,
+    reference_dois,
+)
+
+
+class _DummyWriter:
+
+    """Minimal csv.writer stand-in that captures rows in memory for inspection."""
+
+    def __init__(self):
+        """Start with an empty list of captured rows."""
+        self.rows: list[list] = []
+
+    def writerow(self, row):
+        """Capture ``row`` as a plain list for later assertions."""
+        self.rows.append(list(row))
+
+
+def _writer():
+    """A provenance writer over a dummy sink, with knowledge_source at column 4."""
+    sink = _DummyWriter()
+    return sink, _StrainProvenanceWriter(
+        sink, knowledge_source="infores:bacdive", ks_column_index=4
+    )
+
+
+def _row():
+    """A strain-derived edge row of the shape the bacdive transform emits."""
+    return [
+        "kgmicrobe.strain:bacdive_1",
+        "METPO:2000002",
+        "CHEBI:17234",
+        "RO:0000057",
+        "infores:bacdive",
+        "observation",
+        "manual_agent",
+    ]
+
+
+def test_reference_dois_maps_ref_id_to_doi():
+    """A Reference entry with a real DOI is keyed by its integer ``@id``."""
+    record = {
+        "Reference": [
+            {"@id": 20215, "doi/url": "10.1099/ijsem.0.004332"},
+            {"@id": 12345, "doi/url": "10.1099/ijs.0.02862-0"},
+        ]
+    }
+    assert reference_dois(record) == {
+        20215: "10.1099/ijsem.0.004332",
+        12345: "10.1099/ijs.0.02862-0",
+    }
+
+
+def test_reference_dois_accepts_a_single_dict():
+    """Records with one reference store a dict rather than a list."""
+    record = {"Reference": {"@id": 7, "doi/url": "10.1099/ijs.0.63521-0"}}
+    assert reference_dois(record) == {7: "10.1099/ijs.0.63521-0"}
+
+
+def test_reference_dois_skips_non_publications():
+    """Catalogue URLs and BacDive's own record DOI are not citations.
+
+    Both would otherwise attach confident-looking provenance that leads back to a catalogue
+    entry or to the record already named by ``primary_knowledge_source``, rather than to a
+    paper someone can read.
+    """
+    record = {
+        "Reference": [
+            {"@id": 1, "doi/url": "https://www.dsmz.de/collection/catalogue/details/culture/DSM-1"},
+            {"@id": 2, "doi/url": "10.13145/bacdive1.20221219.7"},
+            {"@id": 3, "doi/url": "10.1099/ijs.0.02862-0"},
+        ]
+    }
+    assert reference_dois(record) == {3: "10.1099/ijs.0.02862-0"}
+
+
+def test_reference_dois_handles_missing_or_malformed():
+    """A record with no usable Reference section yields an empty map, not an error."""
+    assert reference_dois({}) == {}
+    assert reference_dois({"Reference": None}) == {}
+    assert reference_dois({"Reference": [{"@id": None, "doi/url": "10.1/x"}]}) == {}
+    assert reference_dois({"Reference": [{"@id": "not-an-int", "doi/url": "10.1/x"}]}) == {}
+
+
+def test_publication_is_appended_to_knowledge_source():
+    """A supplied DOI joins the source and strain id in the same list literal."""
+    sink, writer = _writer()
+    writer.writerow(_row(), publication="doi:10.1099/ijs.0.02862-0")
+    assert sink.rows[0][4] == (
+        "['infores:bacdive', 'bacdive:1', 'doi:10.1099/ijs.0.02862-0']"
+    )
+
+
+def test_output_is_unchanged_without_a_publication():
+    """Sections not yet threaded must emit exactly what they emitted before.
+
+    This is what makes the change safe to land one section at a time: every call site that
+    does not pass ``publication`` is byte-for-byte identical to the previous behaviour.
+    """
+    sink, writer = _writer()
+    writer.writerow(_row())
+    assert sink.rows[0][4] == "['infores:bacdive', 'bacdive:1']"
+
+
+def test_non_strain_rows_are_untouched_even_with_a_publication():
+    """Ontology-axiom edges have no strain endpoint, so nothing is rewritten."""
+    sink, writer = _writer()
+    row = ["METPO:1000001", "biolink:subclass_of", "METPO:1000002", "rdfs:subClassOf",
+           "infores:bacdive", "observation", "manual_agent"]
+    writer.writerow(row, publication="doi:10.1099/ijs.0.02862-0")
+    assert sink.rows[0][4] == "infores:bacdive"


### PR DESCRIPTION
Addresses #770.

BacDive attaches an `@ref` to every data item and lists the matching citations in each record's `Reference` section. The transform doesn't read it, so an edge can name the **strain record** it came from but never the **paper**. That linkage can't be recovered downstream, because the edge no longer records which data item produced it.

## The change

`reference_dois()` maps a record's `@ref` ids to publication DOIs; the metabolite-utilization path threads it through. Where a DOI is known the edge carries it alongside the existing provenance:

```
['infores:bacdive', 'bacdive:1', 'doi:10.1099/ijs.0.02862-0']
```

Same list-literal convention already used for the strain id, so nothing changes shape.

## Two `doi/url` kinds are skipped deliberately

Catalogue URLs (DSMZ, StrainInfo) aren't publications, and BacDive's own record DOI (`10.13145/bacdive…`) points back at the record `primary_knowledge_source` already identifies. Either would attach confident-looking provenance that leads nowhere.

## Backward compatible by construction

`_StrainProvenanceWriter.writerow` takes `publication` as an **optional keyword**, so every call site that doesn't pass one emits exactly what it emitted before. That's what makes this landable one section at a time, and there's a test asserting it rather than a claim.

## Scope

**Metabolite utilization only** — the carbon-source relations. The pattern for the rest is identical: capture the item's `@ref` where the item is read, pass the resolved DOI at the write site. I stopped at one section so the change is reviewable and the convention can be agreed before it's repeated ~8 times.

## Testing

- **51 bacdive tests pass**, including 7 new ones covering the mapping, the single-dict form, the skip rules, malformed input, the appended DOI, and unchanged output without a publication.
- Verified `reference_dois()` against the real dump: **300/300** sampled records resolve at least one paper DOI.
- The 3 collection errors elsewhere in `tests/` are a missing `parameterized` dependency and are **identical on a clean checkout** — not from this change.

## Why it matters downstream

In `kg-microbe-projects` we needed statement-level citations and had to re-parse the raw JSON in parallel, which covers **9 of ~50** referenced sections. In a BacDive-vs-assay comparison there, only **81 of 996** rows could be attributed to a paper — and the one row where two papers disagreed with each other (*Alteromonas stellipolaris* on NAG: `10.1099/ijs.0.02862-0` says "does not assimilate", `10.1099/ijs.0.63521-0` says "uses as carbon source") turned out to be the most informative row in the analysis. Without DOIs that's indistinguishable from a curation error.

Threading `@ref` through the remaining sections would make every edge attributable and let that parallel extraction be deleted.