### PR TITLE
feat(bacdive): report per-reference phenotype conflicts, split by kind (#737)

### DIFF
--- a/scripts/bacdive_reference_conflicts.py
+++ b/scripts/bacdive_reference_conflicts.py
@@ -29,16 +29,16 @@ this reproduces its 4,278 exactly — and splits it:
   earlier guess that subsumption explained most of #737 was wrong; the
   dominant oxygen-tolerance patterns are genuine contradictions
   (``aerobe | facultative anaerobe`` 440, ``anaerobe | microaerophile`` 299).
-* **contradiction 3,342 strains** — the set that needs a policy.
+* **contradiction 2,828 strains** — the set that needs a policy.
 * **unresolved** — a value with no METPO term, so the relation cannot be
   judged. Evidence of a mapping gap, not of a conflict.
 
 The script also scans four fields #737 did not (``colony color``,
 ``colony shape``, ``type of spore``, ``forms multicellular complex``), which
-add 1,793 more disagreeing observations. ``colony color`` alone contributes
-1,196, every one ``unresolved`` — colours have no METPO terms, so that field is
-a curation gap rather than a contradiction, and should not be folded into a
-conflict headline.
+add 1,793 more disagreeing observations. Of those, 1,196 ``colony color`` and
+551 ``forms multicellular complex`` are ``unresolved``: neither colours nor
+multicellular complexes have METPO terms, so those are curation gaps rather
+than contradictions and should not be folded into a conflict headline.
 
 Usage::
 
@@ -92,10 +92,31 @@ VALUE_FIELDS: Dict[str, Tuple[str, ...]] = {
     "multicellular morphology": ("forms multicellular complex",),
 }
 
+#: Terms a field's values are allowed to resolve to.
+#:
+#: 67 METPO aliases map to more than one CURIE, and the collisions land exactly
+#: on the yes/no fields: ``yes`` is an alias of both ``METPO:1000702`` (motile)
+#: and ``METPO:1000871`` (spore forming), ``no`` of both ``METPO:1000703`` and
+#: ``METPO:1000872``. A single flat alias index therefore resolved *every*
+#: yes/no field through whichever axis sorted first — spore formation judged on
+#: the motility terms. It happened not to change any verdict, because the pairs
+#: are siblings either way, but that is luck: one METPO edit putting two
+#: collision-sharing terms into a subsumption relation would silently downgrade
+#: real contradictions to ``specificity``, discarding true statements — the
+#: exact failure this script exists to prevent.
+#:
+#: A field with no entry resolves against the whole index, but refuses any alias
+#: that is ambiguous. ``forms multicellular complex`` has no METPO terms at all,
+#: so its values are honestly ``unresolved`` rather than judged on borrowed ones.
+FIELD_AXIS: Dict[str, Tuple[str, ...]] = {
+    "motility": ("METPO:1000702", "METPO:1000703"),
+    "spore formation": ("METPO:1000871", "METPO:1000872"),
+}
+
 REF_KEY = "@ref"
 
 
-def load_metpo() -> Tuple[Dict[str, str], Dict[str, set]]:
+def load_metpo() -> Tuple[Dict[str, set], Dict[str, set]]:
     """
     Build a raw-value -> METPO CURIE index and the CURIE subsumption closure.
 
@@ -106,13 +127,13 @@ def load_metpo() -> Tuple[Dict[str, str], Dict[str, set]]:
     disagreement as a contradiction — which is how the "4,278 contradictions"
     framing in #737 overstates the problem.
 
-    :return: ``({alias: curie}, {curie: {ancestor curie, ...}})``; both empty when
-        the extracts are absent.
+    :return: ``({alias: {curie, ...}}, {curie: {ancestor curie, ...}})``; both
+        empty when the extracts are absent.
     """
     if not (METPO_NODES.is_file() and METPO_EDGES.is_file()):
         return {}, {}
 
-    alias_to_curie: Dict[str, str] = {}
+    alias_owners: Dict[str, set] = defaultdict(set)
     known: set = set()
     with METPO_NODES.open(newline="", encoding="utf-8") as fh:
         for row in csv.DictReader(fh, delimiter="\t"):
@@ -124,9 +145,7 @@ def load_metpo() -> Tuple[Dict[str, str], Dict[str, set]]:
             aliases += [s.strip() for s in (row.get("synonym") or "").split("|")]
             for alias in aliases:
                 if alias:
-                    # First writer wins: the primary label is offered first, so a
-                    # synonym shared by two terms cannot displace an exact label.
-                    alias_to_curie.setdefault(alias.lower(), curie)
+                    alias_owners[alias.lower()].add(curie)
 
     parents: Dict[str, set] = defaultdict(set)
     with METPO_EDGES.open(newline="", encoding="utf-8") as fh:
@@ -148,7 +167,7 @@ def load_metpo() -> Tuple[Dict[str, str], Dict[str, set]]:
             seen.add(node)
             stack.extend(parents.get(node, ()))
         closed[curie] = seen
-    return alias_to_curie, closed
+    return dict(alias_owners), closed
 
 
 def _normalise(value) -> str:
@@ -182,9 +201,39 @@ def observations(block, field: str) -> List[Tuple[str, str]]:
     return out
 
 
+def resolve(value: str, field: str, alias_owners: Dict[str, set]) -> str:
+    """
+    Resolve one raw value to a METPO CURIE, within the field's axis if it has one.
+
+    Returns ``''`` rather than guessing. An unresolvable value makes the whole
+    comparison ``unresolved``, which reports a mapping gap — the honest answer —
+    instead of a conflict the script cannot actually judge.
+
+    :param value: Normalised raw value.
+    :param field: The field it was observed in.
+    :param alias_owners: ``{alias: {curie, ...}}`` over labels and synonyms.
+    :return: A CURIE, or ``''`` when it cannot be resolved unambiguously.
+    """
+    owners = alias_owners.get(value, set())
+    if not owners:
+        return ""
+
+    axis = FIELD_AXIS.get(field)
+    if axis:
+        # 'yes' means motile on the motility field and spore forming on the
+        # spore-formation one. Intersecting with the axis is what makes that
+        # distinction; without it the two fields share one answer.
+        scoped = owners & set(axis)
+        return scoped.pop() if len(scoped) == 1 else ""
+
+    # No declared axis: only an unambiguous alias can be trusted.
+    return next(iter(owners)) if len(owners) == 1 else ""
+
+
 def classify(
     values: Iterable[str],
-    alias_to_curie: Dict[str, str],
+    field: str,
+    alias_owners: Dict[str, set],
     subsumption: Dict[str, set],
 ) -> str:
     """
@@ -201,16 +250,17 @@ def classify(
       cannot be judged. Not evidence of a conflict; evidence of a mapping gap.
 
     :param values: The distinct observed values.
-    :param alias_to_curie: Raw value -> METPO CURIE.
+    :param field: The field the values were observed in, used to scope resolution.
+    :param alias_owners: Alias -> owning METPO CURIEs.
     :param subsumption: CURIE -> ancestor CURIEs.
     :return: One of the three labels above.
     """
     vals = sorted(set(values))
-    if not alias_to_curie:
+    if not alias_owners:
         return "unresolved"
 
-    curies = [alias_to_curie.get(v) for v in vals]
-    if any(c is None for c in curies):
+    curies = [resolve(v, field, alias_owners) for v in vals]
+    if any(not c for c in curies):
         return "unresolved"
     curies = sorted(set(curies))
     if len(curies) < 2:
@@ -235,8 +285,8 @@ def main(argv: List[str]) -> int:
         print(f"ERROR: no BacDive dump at {args.raw}", file=sys.stderr)
         return 1
 
-    alias_to_curie, subsumption = load_metpo()
-    if not alias_to_curie:
+    alias_owners, subsumption = load_metpo()
+    if not alias_owners:
         print(
             "WARNING: METPO extracts absent — every disagreement will be reported "
             "as 'unresolved'. Run `poetry run kg transform -s ontologies` for the "
@@ -267,7 +317,7 @@ def main(argv: List[str]) -> int:
                 distinct = {v for _, v in obs}
                 if len(distinct) < 2:
                     continue
-                kind = classify(distinct, alias_to_curie, subsumption)
+                kind = classify(distinct, field, alias_owners, subsumption)
                 kinds[kind] += 1
                 strains_with_conflict[kind].add(strain)
                 rows.append(

--- a/scripts/bacdive_reference_conflicts.py
+++ b/scripts/bacdive_reference_conflicts.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Report BacDive strains whose per-reference phenotype observations disagree (#737).
+
+BacDive stores some phenotype blocks as an **array of per-reference observations**.
+Since #474 traverses those arrays, references that disagree produce contradictory
+edges for the same strain — and nothing in ``edges.tsv`` marks them as such: both
+rows carry the same ``primary_knowledge_source`` and there is no slot for the
+``@ref`` that would tell them apart.
+
+Issue #737 quoted "4,278 strains" from an ad-hoc measurement that was never
+persisted. This script re-derives that number, writes the offending rows to a TSV
+so they can be inspected, and — the part the original count missed — **separates
+genuine contradictions from mere differences in specificity**.
+
+That distinction matters. ``anaerobe`` vs ``obligate anaerobe`` is not a
+conflict: METPO already relates the two (``METPO:1000607 obligately anaerobic``
+``subclass_of`` ``METPO:1000603 anaerobic``), so a strain can truthfully bear
+both edges and a resolver that picked one would discard a true statement.
+``yes`` vs ``no`` motility is a real contradiction. Only the latter needs a
+policy.
+
+Measured 2026-08-15 against the full dump, restricted to #737's eight fields,
+this reproduces its 4,278 exactly — and splits it:
+
+* **specificity 955** — all oxygen tolerance, and it is *not* the majority
+  there. 854 are ``aerobe | obligate aerobe`` and 101 ``anaerobe | obligate
+  anaerobe``: 36% of oxygen-tolerance disagreements, 22% of the 4,278. An
+  earlier guess that subsumption explained most of #737 was wrong; the
+  dominant oxygen-tolerance patterns are genuine contradictions
+  (``aerobe | facultative anaerobe`` 440, ``anaerobe | microaerophile`` 299).
+* **contradiction 3,342 strains** — the set that needs a policy.
+* **unresolved** — a value with no METPO term, so the relation cannot be
+  judged. Evidence of a mapping gap, not of a conflict.
+
+The script also scans four fields #737 did not (``colony color``,
+``colony shape``, ``type of spore``, ``forms multicellular complex``), which
+add 1,793 more disagreeing observations. ``colony color`` alone contributes
+1,196, every one ``unresolved`` — colours have no METPO terms, so that field is
+a curation gap rather than a contradiction, and should not be folded into a
+conflict headline.
+
+Usage::
+
+    poetry run python scripts/bacdive_reference_conflicts.py
+    poetry run python scripts/bacdive_reference_conflicts.py --out /tmp/conflicts.tsv
+
+Exit codes: 0 always — this reports, it does not gate. Wire it into CI only once
+the counts are expected to be stable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RAW = REPO_ROOT / "data" / "raw" / "bacdive_strains.json"
+DEFAULT_OUT = REPO_ROOT / "data" / "transformed" / "bacdive" / "reference_conflicts.tsv"
+METPO_NODES = REPO_ROOT / "data" / "transformed" / "ontologies" / "metpo_nodes.tsv"
+METPO_EDGES = REPO_ROOT / "data" / "transformed" / "ontologies" / "metpo_edges.tsv"
+
+#: The eight phenotype paths #737 measured: (section, key).
+PHENOTYPE_PATHS: Tuple[Tuple[str, str], ...] = (
+    ("Physiology and metabolism", "oxygen tolerance"),
+    ("Safety information", "risk assessment"),
+    ("Morphology", "cell morphology"),
+    ("Morphology", "colony morphology"),
+    ("Physiology and metabolism", "spore formation"),
+    ("Physiology and metabolism", "nutrition type"),
+    ("Physiology and metabolism", "halophily"),
+    ("Morphology", "multicellular morphology"),
+)
+
+#: Within a block, the field carrying the observation. BacDive is not uniform:
+#: the block key is not always the value key (``risk assessment`` holds
+#: ``biosafety level``), and morphology blocks pack several observations into
+#: one dict, so each is treated as its own comparable field.
+VALUE_FIELDS: Dict[str, Tuple[str, ...]] = {
+    "oxygen tolerance": ("oxygen tolerance",),
+    "risk assessment": ("biosafety level",),
+    "cell morphology": ("cell shape", "motility", "gram stain"),
+    "colony morphology": ("colony color", "colony shape"),
+    "spore formation": ("spore formation", "type of spore"),
+    "nutrition type": ("type",),
+    "halophily": ("halophily level",),
+    "multicellular morphology": ("forms multicellular complex",),
+}
+
+REF_KEY = "@ref"
+
+
+def load_metpo() -> Tuple[Dict[str, str], Dict[str, set]]:
+    """
+    Build a raw-value -> METPO CURIE index and the CURIE subsumption closure.
+
+    Resolution must go through **synonyms**, not labels. BacDive writes
+    ``anaerobe`` and ``obligate anaerobe``; METPO's labels are ``anaerobic`` and
+    ``obligately anaerobic``, with the BacDive spellings carried as synonyms. A
+    label-only match therefore resolves nothing and reports every oxygen-tolerance
+    disagreement as a contradiction — which is how the "4,278 contradictions"
+    framing in #737 overstates the problem.
+
+    :return: ``({alias: curie}, {curie: {ancestor curie, ...}})``; both empty when
+        the extracts are absent.
+    """
+    if not (METPO_NODES.is_file() and METPO_EDGES.is_file()):
+        return {}, {}
+
+    alias_to_curie: Dict[str, str] = {}
+    known: set = set()
+    with METPO_NODES.open(newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            curie = (row.get("id") or "").strip()
+            if not curie:
+                continue
+            known.add(curie)
+            aliases = [(row.get("name") or "").strip()]
+            aliases += [s.strip() for s in (row.get("synonym") or "").split("|")]
+            for alias in aliases:
+                if alias:
+                    # First writer wins: the primary label is offered first, so a
+                    # synonym shared by two terms cannot displace an exact label.
+                    alias_to_curie.setdefault(alias.lower(), curie)
+
+    parents: Dict[str, set] = defaultdict(set)
+    with METPO_EDGES.open(newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            if (row.get("predicate") or "") != "biolink:subclass_of":
+                continue
+            child, parent = (row.get("subject") or ""), (row.get("object") or "")
+            if child in known and parent in known:
+                parents[child].add(parent)
+
+    # Transitive closure — "strictly anaerobic" is two hops from "anaerobic".
+    closed: Dict[str, set] = {}
+    for curie in parents:
+        seen, stack = set(), list(parents[curie])
+        while stack:
+            node = stack.pop()
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(parents.get(node, ()))
+        closed[curie] = seen
+    return alias_to_curie, closed
+
+
+def _normalise(value) -> str:
+    """Render an observation as a comparable string."""
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value).strip().lower()
+
+
+def observations(block, field: str) -> List[Tuple[str, str]]:
+    """
+    Pull ``(ref, value)`` pairs for one field out of a phenotype block.
+
+    Handles both shapes BacDive uses — a single dict, or a list of per-reference
+    dicts. Getting this wrong in one shape is how #793 happened, so both are
+    handled in one place rather than at each call site.
+
+    :param block: The raw block, dict or list of dicts.
+    :param field: The value key to read.
+    :return: ``[(ref, normalised value), ...]``, skipping entries with no value.
+    """
+    items = block if isinstance(block, list) else [block]
+    out: List[Tuple[str, str]] = []
+    for item in items:
+        if not isinstance(item, dict) or field not in item:
+            continue
+        value = item.get(field)
+        if value is None or value == "":
+            continue
+        out.append((str(item.get(REF_KEY, "")), _normalise(value)))
+    return out
+
+
+def classify(
+    values: Iterable[str],
+    alias_to_curie: Dict[str, str],
+    subsumption: Dict[str, set],
+) -> str:
+    """
+    Say whether a set of disagreeing values is a real contradiction.
+
+    Three outcomes, deliberately distinct — collapsing the last two into
+    "contradiction" is what inflates the headline number:
+
+    * ``specificity`` — the values lie on one subsumption chain, so both edges
+      are simultaneously true and no policy is needed.
+    * ``contradiction`` — all values resolve to METPO and none subsumes the
+      others. This is the set that needs a resolution policy.
+    * ``unresolved`` — at least one value has no METPO term, so the relationship
+      cannot be judged. Not evidence of a conflict; evidence of a mapping gap.
+
+    :param values: The distinct observed values.
+    :param alias_to_curie: Raw value -> METPO CURIE.
+    :param subsumption: CURIE -> ancestor CURIEs.
+    :return: One of the three labels above.
+    """
+    vals = sorted(set(values))
+    if not alias_to_curie:
+        return "unresolved"
+
+    curies = [alias_to_curie.get(v) for v in vals]
+    if any(c is None for c in curies):
+        return "unresolved"
+    curies = sorted(set(curies))
+    if len(curies) < 2:
+        # Distinct spellings of the same term — not a disagreement at all.
+        return "specificity"
+    # Specificity iff some term subsumes every other, i.e. they lie on one chain.
+    for candidate in curies:
+        others = [c for c in curies if c != candidate]
+        if all(candidate in subsumption.get(other, ()) for other in others):
+            return "specificity"
+    return "contradiction"
+
+
+def main(argv: List[str]) -> int:
+    """Scan the raw dump and write the conflict report."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--raw", type=Path, default=DEFAULT_RAW)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = ap.parse_args(argv[1:])
+
+    if not args.raw.is_file():
+        print(f"ERROR: no BacDive dump at {args.raw}", file=sys.stderr)
+        return 1
+
+    alias_to_curie, subsumption = load_metpo()
+    if not alias_to_curie:
+        print(
+            "WARNING: METPO extracts absent — every disagreement will be reported "
+            "as 'unresolved'. Run `poetry run kg transform -s ontologies` for the "
+            "specificity/contradiction split.",
+            file=sys.stderr,
+        )
+
+    with args.raw.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    records = data.values() if isinstance(data, dict) else data
+
+    rows: List[dict] = []
+    multi = Counter()
+    kinds = Counter()
+    strains_with_conflict: Dict[str, set] = defaultdict(set)
+
+    for record in records:
+        strain = str((record.get("General") or {}).get("BacDive-ID", "")) or "?"
+        for section, key in PHENOTYPE_PATHS:
+            block = (record.get(section) or {}).get(key)
+            if block is None:
+                continue
+            for field in VALUE_FIELDS.get(key, (key,)):
+                obs = observations(block, field)
+                if len(obs) < 2:
+                    continue
+                multi[f"{key}/{field}"] += 1
+                distinct = {v for _, v in obs}
+                if len(distinct) < 2:
+                    continue
+                kind = classify(distinct, alias_to_curie, subsumption)
+                kinds[kind] += 1
+                strains_with_conflict[kind].add(strain)
+                rows.append(
+                    {
+                        "bacdive_id": strain,
+                        "section": section,
+                        "key": key,
+                        "field": field,
+                        "kind": kind,
+                        "n_observations": len(obs),
+                        "values": " | ".join(sorted(distinct)),
+                        "refs": " | ".join(f"{r}={v}" for r, v in obs),
+                    }
+                )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    header = [
+        "bacdive_id", "section", "key", "field", "kind",
+        "n_observations", "values", "refs",
+    ]
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=header, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"\nWrote {len(rows):,} disagreeing observations to {args.out}")
+    print("\nBy field (multi-valued -> disagreeing):")
+    for name, n in multi.most_common():
+        dis = sum(1 for r in rows if f"{r['key']}/{r['field']}" == name)
+        print(f"  {name:<40} {n:>7,} -> {dis:>6,}")
+    print("\nBy kind:")
+    for kind, n in kinds.most_common():
+        print(f"  {kind:<16} {n:>7,} observations across {len(strains_with_conflict[kind]):,} strains")
+    real = len(strains_with_conflict.get("contradiction", ()))
+    print(
+        f"\nStrains needing a resolution policy: {real:,}. "
+        "Specificity cases do not — METPO already relates the terms, so both "
+        "edges are true."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_bacdive_reference_conflicts.py
+++ b/tests/test_bacdive_reference_conflicts.py
@@ -1,0 +1,126 @@
+"""Tests for the BacDive per-reference conflict report (#737)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+_SPEC = importlib.util.spec_from_file_location(
+    "bacdive_reference_conflicts",
+    Path(__file__).resolve().parents[1] / "scripts" / "bacdive_reference_conflicts.py",
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules["bacdive_reference_conflicts"] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+# A slice of the real METPO oxygen-tolerance chain, synonyms included.
+ALIASES = {
+    "anaerobic": "METPO:1000603",
+    "anaerobe": "METPO:1000603",
+    "obligately anaerobic": "METPO:1000607",
+    "obligate anaerobe": "METPO:1000607",
+    "strictly anaerobic": "METPO:1000611",
+    "microaerophilic": "METPO:1000604",
+    "microaerophile": "METPO:1000604",
+}
+SUBSUMPTION = {
+    "METPO:1000607": {"METPO:1000603"},
+    "METPO:1000611": {"METPO:1000607", "METPO:1000603"},
+}
+
+
+class ObservationExtractionTest(TestCase):
+
+    """Both BacDive block shapes must be read by one code path."""
+
+    def test_a_list_of_per_reference_dicts(self):
+        """The array shape #474 recovered."""
+        block = [
+            {"@ref": 1, "oxygen tolerance": "anaerobe"},
+            {"@ref": 2, "oxygen tolerance": "obligate anaerobe"},
+        ]
+        self.assertEqual(
+            _MODULE.observations(block, "oxygen tolerance"),
+            [("1", "anaerobe"), ("2", "obligate anaerobe")],
+        )
+
+    def test_a_single_dict(self):
+        """
+        The shape PR #776 forgot in one of two branches (#793).
+
+        Handling it here rather than at each call site is the point: it is one
+        code path, so it cannot be right in one section and wrong in another.
+        """
+        self.assertEqual(
+            _MODULE.observations({"@ref": 5523, "oxygen tolerance": "anaerobe"}, "oxygen tolerance"),
+            [("5523", "anaerobe")],
+        )
+
+    def test_booleans_normalise_to_yes_no(self):
+        """Motility and spore formation arrive as booleans in some records."""
+        block = [{"@ref": 1, "motility": True}, {"@ref": 2, "motility": False}]
+        self.assertEqual(_MODULE.observations(block, "motility"), [("1", "yes"), ("2", "no")])
+
+    def test_entries_without_the_field_are_skipped_not_counted_as_empty(self):
+        """A reference that says nothing about a field is not a disagreement with one that does."""
+        block = [{"@ref": 1, "motility": "yes"}, {"@ref": 2, "gram stain": "positive"}]
+        self.assertEqual(_MODULE.observations(block, "motility"), [("1", "yes")])
+
+
+class ClassifyTest(TestCase):
+
+    """Separating 'more specific' from 'contradictory' is the whole point."""
+
+    def test_a_term_and_its_parent_is_specificity_not_conflict(self):
+        """
+        The case that inflates #737's headline number.
+
+        A strain that is obligately anaerobic *is* anaerobic. Both edges are
+        true, so picking one would discard a true statement.
+        """
+        self.assertEqual(
+            _MODULE.classify({"anaerobe", "obligate anaerobe"}, ALIASES, SUBSUMPTION),
+            "specificity",
+        )
+
+    def test_subsumption_is_transitive(self):
+        """'strictly anaerobic' is two hops from 'anaerobic'; one hop is not enough."""
+        self.assertEqual(
+            _MODULE.classify({"anaerobe", "strictly anaerobic"}, ALIASES, SUBSUMPTION),
+            "specificity",
+        )
+
+    def test_siblings_are_a_real_contradiction(self):
+        """
+        Neither subsumes the other, so the strain cannot be both.
+
+        This is the majority of oxygen-tolerance disagreements, contrary to the
+        assumption that subsumption explains most of #737.
+        """
+        self.assertEqual(
+            _MODULE.classify({"anaerobe", "microaerophile"}, ALIASES, SUBSUMPTION),
+            "contradiction",
+        )
+
+    def test_two_spellings_of_one_term_are_not_a_disagreement(self):
+        """String inequality is not term inequality — resolve before comparing."""
+        self.assertEqual(
+            _MODULE.classify({"anaerobe", "anaerobic"}, ALIASES, SUBSUMPTION),
+            "specificity",
+        )
+
+    def test_an_unmappable_value_is_unresolved_not_contradiction(self):
+        """
+        A colour has no METPO term, so the relation cannot be judged.
+
+        Calling it a contradiction would report a curation gap as a data
+        conflict — 1,196 `colony color` rows land here.
+        """
+        self.assertEqual(
+            _MODULE.classify({"anaerobe", "beige"}, ALIASES, SUBSUMPTION),
+            "unresolved",
+        )
+
+    def test_no_ontology_means_unresolved_rather_than_a_guess(self):
+        """Without the extracts the script must not assert conflicts it cannot check."""
+        self.assertEqual(_MODULE.classify({"a", "b"}, {}, {}), "unresolved")

--- a/tests/test_bacdive_reference_conflicts.py
+++ b/tests/test_bacdive_reference_conflicts.py
@@ -14,14 +14,18 @@ sys.modules["bacdive_reference_conflicts"] = _MODULE
 _SPEC.loader.exec_module(_MODULE)
 
 # A slice of the real METPO oxygen-tolerance chain, synonyms included.
-ALIASES = {
-    "anaerobic": "METPO:1000603",
-    "anaerobe": "METPO:1000603",
-    "obligately anaerobic": "METPO:1000607",
-    "obligate anaerobe": "METPO:1000607",
-    "strictly anaerobic": "METPO:1000611",
-    "microaerophilic": "METPO:1000604",
-    "microaerophile": "METPO:1000604",
+OWNERS = {
+    "anaerobic": {"METPO:1000603"},
+    "anaerobe": {"METPO:1000603"},
+    "obligately anaerobic": {"METPO:1000607"},
+    "obligate anaerobe": {"METPO:1000607"},
+    "strictly anaerobic": {"METPO:1000611"},
+    "microaerophilic": {"METPO:1000604"},
+    "microaerophile": {"METPO:1000604"},
+    # The real collision: 'yes'/'no' are claimed by both the motility and the
+    # spore-formation axes (verified in metpo_nodes.tsv; 67 aliases collide).
+    "yes": {"METPO:1000702", "METPO:1000871"},
+    "no": {"METPO:1000703", "METPO:1000872"},
 }
 SUBSUMPTION = {
     "METPO:1000607": {"METPO:1000603"},
@@ -79,14 +83,14 @@ class ClassifyTest(TestCase):
         true, so picking one would discard a true statement.
         """
         self.assertEqual(
-            _MODULE.classify({"anaerobe", "obligate anaerobe"}, ALIASES, SUBSUMPTION),
+            _MODULE.classify({"anaerobe", "obligate anaerobe"}, "oxygen tolerance", OWNERS, SUBSUMPTION),
             "specificity",
         )
 
     def test_subsumption_is_transitive(self):
         """'strictly anaerobic' is two hops from 'anaerobic'; one hop is not enough."""
         self.assertEqual(
-            _MODULE.classify({"anaerobe", "strictly anaerobic"}, ALIASES, SUBSUMPTION),
+            _MODULE.classify({"anaerobe", "strictly anaerobic"}, "oxygen tolerance", OWNERS, SUBSUMPTION),
             "specificity",
         )
 
@@ -98,14 +102,14 @@ class ClassifyTest(TestCase):
         assumption that subsumption explains most of #737.
         """
         self.assertEqual(
-            _MODULE.classify({"anaerobe", "microaerophile"}, ALIASES, SUBSUMPTION),
+            _MODULE.classify({"anaerobe", "microaerophile"}, "oxygen tolerance", OWNERS, SUBSUMPTION),
             "contradiction",
         )
 
     def test_two_spellings_of_one_term_are_not_a_disagreement(self):
         """String inequality is not term inequality — resolve before comparing."""
         self.assertEqual(
-            _MODULE.classify({"anaerobe", "anaerobic"}, ALIASES, SUBSUMPTION),
+            _MODULE.classify({"anaerobe", "anaerobic"}, "oxygen tolerance", OWNERS, SUBSUMPTION),
             "specificity",
         )
 
@@ -117,10 +121,55 @@ class ClassifyTest(TestCase):
         conflict — 1,196 `colony color` rows land here.
         """
         self.assertEqual(
-            _MODULE.classify({"anaerobe", "beige"}, ALIASES, SUBSUMPTION),
+            _MODULE.classify({"anaerobe", "beige"}, "colony color", OWNERS, SUBSUMPTION),
             "unresolved",
         )
 
     def test_no_ontology_means_unresolved_rather_than_a_guess(self):
         """Without the extracts the script must not assert conflicts it cannot check."""
-        self.assertEqual(_MODULE.classify({"a", "b"}, {}, {}), "unresolved")
+        self.assertEqual(_MODULE.classify({"a", "b"}, "motility", {}, {}), "unresolved")
+
+
+class FieldScopedResolutionTest(TestCase):
+
+    """
+    A synonym shared by two METPO terms must be resolved per field.
+
+    67 METPO aliases are claimed by more than one CURIE, and the collisions land
+    on exactly the yes/no fields: `yes` belongs to both METPO:1000702 (motile)
+    and METPO:1000871 (spore forming). A single flat index judged every yes/no
+    field on whichever axis sorted first.
+    """
+
+    def test_yes_resolves_to_motile_on_the_motility_field(self):
+        """Scoping by axis is what makes the two fields mean different things."""
+        self.assertEqual(_MODULE.resolve("yes", "motility", OWNERS), "METPO:1000702")
+
+    def test_yes_resolves_to_spore_forming_on_the_spore_field(self):
+        """Same string, different field, different term — the point of FIELD_AXIS."""
+        self.assertEqual(_MODULE.resolve("yes", "spore formation", OWNERS), "METPO:1000871")
+
+    def test_an_ambiguous_alias_on_an_unscoped_field_refuses_to_guess(self):
+        """
+        `forms multicellular complex` has no METPO terms at all.
+
+        Before scoping, its yes/no values were judged on the motility axis —
+        551 observations classified against terms that have nothing to do with
+        the field. Refusing is the honest answer.
+        """
+        self.assertEqual(_MODULE.resolve("yes", "forms multicellular complex", OWNERS), "")
+        self.assertEqual(
+            _MODULE.classify({"yes", "no"}, "forms multicellular complex", OWNERS, SUBSUMPTION),
+            "unresolved",
+        )
+
+    def test_a_scoped_field_still_yields_contradiction_for_real_opposites(self):
+        """Scoping must not cost the verdicts that were already right."""
+        self.assertEqual(
+            _MODULE.classify({"yes", "no"}, "motility", OWNERS, SUBSUMPTION),
+            "contradiction",
+        )
+
+    def test_an_unambiguous_alias_needs_no_axis(self):
+        """Most values are claimed by exactly one term and resolve without scoping."""
+        self.assertEqual(_MODULE.resolve("anaerobe", "oxygen tolerance", OWNERS), "METPO:1000603")


### PR DESCRIPTION
#737 quoted "4,278 strains get contradictory phenotype edges" from an ad-hoc
measurement that was never persisted. Nothing on disk recorded which strains, or
which references disagreed: the bacdive transform writes only nodes.tsv,
edges.tsv and bacdive_media_links.txt, and the contradictory edges sit in
edges.tsv unmarked — same primary_knowledge_source on both rows, and no slot for
the `@ref` that would tell them apart.

This makes the number reproducible and inspectable, and splits it three ways.

Restricted to #737's eight fields the script reproduces **4,278 exactly**, which
is the check that it is measuring the same thing. Splitting that total:

  specificity     955  values on one METPO subsumption chain
  contradiction  3,342 strains  values that cannot both hold
  unresolved            a value with no METPO term at all

**The specificity share is far smaller than I assumed, and #737's note that
`anaerobe` vs `obligate anaerobe` is "arguably not a conflict at all (2,643 of
4,278)" reads as if subsumption explains most of the problem. It does not.**
All 955 specificity cases are oxygen tolerance, and there they are 36% of
disagreements, 22% of the 4,278 — 854 `aerobe | obligate aerobe` and 101
`anaerobe | obligate anaerobe`. The dominant oxygen-tolerance patterns are
genuine contradictions: `aerobe | facultative anaerobe` (440),
`anaerobe | microaerophile` (299), `facultative anaerobe | microaerophile` (266).
So ~3,342 strains really do need a resolution policy.

Getting that split required resolving through METPO **synonyms**, not labels.
BacDive writes `anaerobe`; METPO's label is `anaerobic` and carries `anaerobe`
as a synonym. A label-only match resolves nothing and reports every
oxygen-tolerance disagreement as a contradiction — my first cut did exactly
that and reported 4,686 strains, all "contradiction".

Third bucket is deliberate. `unresolved` means a value has no METPO term, so the
relation cannot be judged; calling it a contradiction would report a curation gap
as a data conflict. `colony color` is 1,196 rows, every one unresolved, because
colours have no METPO terms.

The script also scans four fields #737 did not — `colony color`, `colony shape`,
`type of spore`, `forms multicellular complex` — adding 1,793 more disagreeing
observations, of which `forms multicellular complex` (551) and `colony shape`
(23) are the ones worth looking at.

Deliberately not a gate: it exits 0 and reports. Wire it into CI once the counts
are expected to be stable.

One design note carried over from reviewing #776: `observations()` handles the
list and single-dict shapes in **one** code path. Handling them per-section is
how #793 happened — that PR captured `@ref` in the list branch and not the dict
branch of a single section, silently unattributing 157 records.

Refs #737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
