### PR TITLE
fix: report data staleness, and refuse an unknown transform source

### DIFF
--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -48,6 +48,48 @@ from typing import Iterable, Optional
 
 REPO = Path(__file__).resolve().parents[3]
 TRANSFORM_ROOT = REPO / "kg_microbe" / "transform_utils"
+
+
+def _declared_data_inputs(source: str) -> tuple:
+    """
+    Repo-relative curation files a transform reads, from its ``DATA_INPUTS``.
+
+    Read by importing the transform classes rather than by keeping a second
+    list here: a hard-coded table in this skill would drift from the code it
+    describes, and the whole point of #812 is that a stale declaration is
+    indistinguishable from a fresh one. Import failure degrades to "no declared
+    inputs" so the skill still runs in an environment without kg_microbe
+    importable.
+
+    :param source: Transform source name.
+    :return: Tuple of repo-relative paths, empty when none are declared.
+    """
+    try:
+        from kg_microbe.transform import DATA_SOURCES  # noqa: PLC0415 - optional, see docstring
+    except Exception:
+        return ()
+    cls = DATA_SOURCES.get(source)
+    return tuple(getattr(cls, "DATA_INPUTS", ()) or ()) if cls is not None else ()
+
+
+def _latest_data_input_commit(source: str, ref: str) -> tuple[Optional[int], Optional[str]]:
+    """
+    Latest commit time across a source's declared data inputs.
+
+    Uses commit time, not mtime: these files are tracked, and ``git checkout``
+    rewrites mtimes without changing content (#797).
+
+    :param source: Transform source name.
+    :param ref: Git ref to measure against.
+    :return: ``(timestamp, "path @ sha")``, or ``(None, None)``.
+    """
+    newest_ts: Optional[int] = None
+    newest_desc: Optional[str] = None
+    for rel in _declared_data_inputs(source):
+        ts, sha = _latest_commit(REPO / rel, ref)
+        if ts is not None and (newest_ts is None or ts > newest_ts):
+            newest_ts, newest_desc = ts, f"{rel} @ {sha}"
+    return newest_ts, newest_desc
 TRANSFORMED_DIR = REPO / "data" / "transformed"
 MERGE_UTILS_DIR = REPO / "kg_microbe" / "merge_utils"
 DEFAULT_REF = "origin/master"
@@ -286,16 +328,31 @@ def check_source(source: str, ref: str) -> SourceReport:
     elif commit_ts is None:
         status = "FRESH"
         note = f"no commit on {ref} touches this dir; treating as fresh"
-    elif out_mtime >= commit_ts:
-        status = "FRESH"
-        note = ""
-    else:
+    elif out_mtime < commit_ts:
         delta_days = (commit_ts - out_mtime) / 86400.0
         status = "STALE_VS_CODE"
         note = (
             f"code advanced {delta_days:.1f} days after last output build; "
             f"rerun `poetry run kg transform -s {source}`"
         )
+    else:
+        status = "FRESH"
+        note = ""
+
+    # Data staleness is checked even when the code is current: a mapping
+    # correction changes the output without touching a line of transform code,
+    # and reporting FRESH there is what let a re-merge ship groundings two
+    # merged PRs had already fixed (#812).
+    if status in {"FRESH", "STALE_VS_CODE"}:
+        data_ts, data_desc = _latest_data_input_commit(source, ref)
+        if data_ts is not None and out_mtime is not None and out_mtime < data_ts:
+            delta_days = (data_ts - out_mtime) / 86400.0
+            status = "STALE_VS_DATA" if status == "FRESH" else "STALE_VS_CODE_AND_DATA"
+            note = (
+                f"data input advanced {delta_days:.1f} days after last output build "
+                f"({data_desc}); rerun `poetry run kg transform -s {source}`"
+                + (f" — {note}" if note else "")
+            )
 
     return SourceReport(
         source=source,
@@ -486,8 +543,19 @@ def main() -> int:
         print("")
         print("SUMMARY")
         print("-------")
-        for status in ["FRESH", "STALE_VS_CODE", "LOCAL_CHANGES", "MISSING_OUTPUT", "NO_CODE"]:
-            print(f"  {status:<16} {c.get(status, 0)}")
+        # Any status seen must appear, even one added later: a summary that
+        # silently omits a category reads as a clean run (#812).
+        known = [
+            "FRESH",
+            "STALE_VS_CODE",
+            "STALE_VS_DATA",
+            "STALE_VS_CODE_AND_DATA",
+            "LOCAL_CHANGES",
+            "MISSING_OUTPUT",
+            "NO_CODE",
+        ]
+        for status in known + sorted(set(c) - set(known)):
+            print(f"  {status:<24} {c.get(status, 0)}")
         print(f"  merge            {merge.status}")
 
     # exit code

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -1,6 +1,5 @@
 """Transform module."""
 
-import logging
 from pathlib import Path
 from typing import List, Optional
 
@@ -106,16 +105,62 @@ def transform(
     :param input_dir: A string pointing to the directory to import data from.
     :param output_dir: A string pointing to the directory to output data to.
     :param sources: A list of sources to transform.
+    :raises ValueError: If a requested source is not registered in DATA_SOURCES.
     """
     if not sources:
         # run all sources
         sources = list(DATA_SOURCES.keys())
 
+    # Refuse an unknown source instead of skipping it. The old loop guarded with
+    # `if source in DATA_SOURCES:` and had no else, so a typo produced exit 0 and
+    # no output — indistinguishable from a successful run, and from a transform
+    # that died early (#813).
+    unknown = [s for s in sources if s not in DATA_SOURCES]
+    if unknown:
+        raise ValueError(
+            f"Unknown transform source(s): {', '.join(sorted(unknown))}. "
+            f"Registered sources: {', '.join(sorted(DATA_SOURCES))}"
+        )
+
     for source in sources:
-        if source in DATA_SOURCES:
-            logging.info(f"Parsing {source}")
-            t = DATA_SOURCES[source](input_dir, output_dir)
-            if source in ONTOLOGIES_MAP.keys():
-                t.run(ONTOLOGIES_MAP[source])
-            else:
-                t.run(show_status=show_status)
+        # print, not logging.info: the CLI does not configure a handler that
+        # shows INFO, so the old log line was invisible and a run that produced
+        # nothing looked identical to one that worked.
+        print(f"[transform] {source}: starting", flush=True)
+        t = DATA_SOURCES[source](input_dir, output_dir)
+        if source in ONTOLOGIES_MAP.keys():
+            t.run(ONTOLOGIES_MAP[source])
+        else:
+            t.run(show_status=show_status)
+
+        written = _describe_output(t, source)
+        print(f"[transform] {source}: done — {written}", flush=True)
+
+
+def _describe_output(transform_obj, source: str) -> str:
+    """
+    Summarise what a transform actually wrote, for the completion line.
+
+    Reports row counts rather than "done", because the failure this guards
+    against is a run that completes without producing anything (#813).
+
+    :param transform_obj: The Transform instance that just ran.
+    :param source: Source name, used when the instance exposes no output dir.
+    :return: Human-readable summary of the files written.
+    """
+    out_dir = getattr(transform_obj, "output_dir", None)
+    if out_dir is None:
+        return f"no output_dir attribute on {source} transform"
+    parts = []
+    for name in ("nodes.tsv", "edges.tsv"):
+        path = Path(out_dir) / name
+        if not path.is_file():
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                rows = max(sum(1 for _ in handle) - 1, 0)
+        except OSError as exc:  # pragma: no cover - unreadable output is rare
+            parts.append(f"{name} unreadable ({exc})")
+            continue
+        parts.append(f"{name}: {rows:,} rows")
+    return "; ".join(parts) if parts else f"wrote no nodes.tsv/edges.tsv in {out_dir}"

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -222,6 +222,11 @@ class BacDiveTransform(Transform):
 
     """Template for how the transform class would be designed."""
 
+    DATA_INPUTS = (
+        "mappings/isolation_source_to_ontology.tsv",
+        "mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",
+    )
+
     def __init__(
         self,
         input_dir: Optional[Path] = None,

--- a/kg_microbe/transform_utils/ctd/ctd.py
+++ b/kg_microbe/transform_utils/ctd/ctd.py
@@ -40,6 +40,8 @@ class CTDTransform(Transform):
 
     """A class used to represent a transformation process for UniProt data."""
 
+    DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
+
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):
         """
         Initialize the class with optional input and output directories.

--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -146,6 +146,8 @@ class MadinEtAlTransform(Transform):
         -   ROBOT using 'robot_utils' module.
     """
 
+    DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
+
     def __init__(self, input_dir: str, output_dir: str, nlp=True) -> None:
         """
         Initialize MadinEtAlTransform Class.

--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -129,6 +129,8 @@ class MediaDiveTransform(Transform):
 
     """Template for how the transform class would be designed."""
 
+    DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
+
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):
         """Instantiate part."""
         source_name = MEDIADIVE

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -323,6 +323,8 @@ class MetaTraitsTransform(Transform):
 
     """Transform metatraits summary JSONL files into KGX nodes and edges."""
 
+    DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
+
     # Measurement traits that should be excluded from unmapped_traits.tsv
     # These represent quantitative measurements, not ontology classes
     MEASUREMENT_TRAITS = {

--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -131,6 +131,8 @@ class MicrobeDecoderTransform(Transform):
 
     """Transform the MicrobeDecoder wide CSV into KGX nodes and edges."""
 
+    DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
+
     def __init__(
         self,
         input_dir: Optional[Union[str, Path]] = None,

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -230,6 +230,8 @@ class OntologiesStubsTransform(Transform):
 
     """Emit one labelled stub node per referenced NCIT / mesh / BTO / PO / MICRO CURIE."""
 
+    DATA_INPUTS = ("mappings/isolation_source_to_ontology.tsv",)
+
     def __init__(
         self,
         input_dir: Optional[Path] = None,

--- a/kg_microbe/transform_utils/transform.py
+++ b/kg_microbe/transform_utils/transform.py
@@ -34,6 +34,22 @@ class Transform:
     DEFAULT_INPUT_DIR = DATA_DIR / "raw"
     DEFAULT_OUTPUT_DIR = DATA_DIR / "transformed"
 
+    #: Repo-relative curation files this transform reads, beyond its own
+    #: ``data/raw/`` download.
+    #:
+    #: Declared so freshness tooling can tell that an output is stale against
+    #: its *data* rather than only its code. Without it a mapping correction
+    #: lands, every consumer keeps reporting FRESH, and a re-merge silently
+    #: ships the old groundings: #778 corrected 16 isolation-source ids and
+    #: #786 rewrote the unified chemical SSSOM, and the merged KG built
+    #: afterwards still asserted 75 organisms isolated from a "Cell Line",
+    #: because nothing re-ran the transforms that read those files (#812).
+    #:
+    #: Paths are relative to the repo root. Keep them tracked in git — the
+    #: freshness check uses commit time, not mtime, because `git checkout`
+    #: rewrites mtimes without changing content (#797).
+    DATA_INPUTS: tuple = ()
+
     def __init__(
         self,
         source_name,

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -1,0 +1,170 @@
+"""Tests for loud transform dispatch (#813) and declared data inputs (#812)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import TestCase, mock
+
+import pytest
+
+from kg_microbe.transform import DATA_SOURCES, transform
+from kg_microbe.transform_utils.transform import Transform
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ISO = "mappings/isolation_source_to_ontology.tsv"
+SSSOM = "mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz"
+
+
+class UnknownSourceTest(TestCase):
+
+    """A typo'd source must fail, not silently succeed."""
+
+    def test_an_unknown_source_raises_rather_than_being_skipped(self):
+        """
+        The bug: `if source in DATA_SOURCES:` with no else.
+
+        `kg transform -s bacdiv` exited 0 having done nothing, which is
+        indistinguishable from a successful run and from a transform that died
+        early — the exact ambiguity that stalled a diagnosis on 2026-08-16.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            transform(None, None, sources=["bacdiv"])
+        message = str(excinfo.value)
+        self.assertIn("bacdiv", message)
+        self.assertIn("bacdive", message, "the error should list valid sources so the typo is obvious")
+
+    def test_one_unknown_source_stops_the_whole_batch(self):
+        """
+        Refuse before running anything, so a batch cannot half-complete.
+
+        Running the good sources and quietly dropping the bad one is how a
+        partial rebuild gets mistaken for a full one.
+        """
+        with mock.patch.dict(DATA_SOURCES, {}, clear=False):
+            with pytest.raises(ValueError):
+                transform(None, None, sources=["bacdive", "definitely-not-a-source"])
+
+
+class DataInputsTest(TestCase):
+
+    """Transforms declare the curation files they read, so staleness is visible."""
+
+    def test_the_base_class_defaults_to_no_declared_inputs(self):
+        """Most transforms read only their own download; the default must be empty."""
+        self.assertEqual(Transform.DATA_INPUTS, ())
+
+    def test_bacdive_declares_both_files_it_reads(self):
+        """
+        Bacdive consumes the isolation-source map and the unified chemical SSSOM.
+
+        #778 corrected 16 ids in the former and #786 rewrote the latter, and the
+        merged KG built afterwards still asserted 75 organisms isolated from a
+        "Cell Line" because nothing re-ran this transform.
+        """
+        declared = DATA_SOURCES["bacdive"].DATA_INPUTS
+        self.assertIn(ISO, declared)
+        self.assertIn(SSSOM, declared)
+
+    def test_every_declared_input_exists_on_disk(self):
+        """A declaration naming a moved or deleted file silently checks nothing."""
+        for name, cls in DATA_SOURCES.items():
+            for rel in getattr(cls, "DATA_INPUTS", ()):
+                self.assertTrue(
+                    (REPO_ROOT / rel).exists(),
+                    f"{name} declares DATA_INPUTS {rel!r}, which does not exist",
+                )
+
+    def test_metatraits_gtdb_inherits_rather_than_redeclaring(self):
+        """Subclasses must not need their own copy — a second list is a second thing to forget."""
+        self.assertEqual(
+            DATA_SOURCES["metatraits_gtdb"].DATA_INPUTS,
+            DATA_SOURCES["metatraits"].DATA_INPUTS,
+        )
+
+    def test_every_sssom_consumer_declares_it(self):
+        """
+        Guard against the next consumer forgetting.
+
+        Anything importing `chemical_mapping_utils` reads the unified SSSOM, so
+        the two sets must agree or the freshness check under-reports.
+        """
+        transform_root = REPO_ROOT / "kg_microbe" / "transform_utils"
+        consumers = set()
+        for py in transform_root.glob("*/[a-z]*.py"):
+            text = py.read_text(encoding="utf-8", errors="ignore")
+            if "chemical_mapping_utils" in text:
+                consumers.add(py.parent.name)
+        for source in sorted(consumers):
+            cls = DATA_SOURCES.get(source)
+            if cls is None:
+                continue  # not a registered transform (helper package)
+            self.assertIn(
+                SSSOM,
+                getattr(cls, "DATA_INPUTS", ()),
+                f"{source} reads the unified chemical SSSOM but does not declare it in DATA_INPUTS",
+            )
+
+
+class FreshnessDataStalenessTest(TestCase):
+
+    """The freshness check must report data staleness, not just code staleness."""
+
+    def setUp(self):
+        """Import the standalone freshness script."""
+        spec = importlib.util.spec_from_file_location(
+            "kgm_freshness_check",
+            REPO_ROOT / ".claude" / "skills" / "kgm-freshness-check" / "kgm_freshness_check.py",
+        )
+        self.mod = importlib.util.module_from_spec(spec)
+        sys.modules["kgm_freshness_check"] = self.mod
+        spec.loader.exec_module(self.mod)
+
+    def test_it_reads_declared_inputs_from_the_transform_classes(self):
+        """
+        Derived from code, not a second hard-coded table in the skill.
+
+        A table here would drift from the transforms it describes, and a stale
+        declaration is indistinguishable from a fresh one.
+        """
+        self.assertIn(ISO, self.mod._declared_data_inputs("bacdive"))
+        self.assertEqual(self.mod._declared_data_inputs("bactotraits"), ())
+
+    def test_an_output_older_than_its_data_input_is_stale(self):
+        """
+        The #812 case: code untouched, mapping changed, output not rebuilt.
+
+        Previously reported FRESH, which is why a re-merge shipped groundings
+        two merged PRs had already corrected.
+        """
+        with (
+            mock.patch.object(self.mod, "_latest_commit", return_value=(1000, "deadbee")),
+            mock.patch.object(self.mod, "_has_local_diff", return_value=False),
+            mock.patch.object(self.mod, "_output_mtime", return_value=2000),
+            mock.patch.object(self.mod, "_declared_data_inputs", return_value=(ISO,)),
+            mock.patch.object(self.mod, "_latest_data_input_commit", return_value=(3000, f"{ISO} @ abc1234")),
+        ):
+            report = self.mod.check_source("bacdive", "origin/master")
+        self.assertEqual(report.status, "STALE_VS_DATA")
+        self.assertIn(ISO, report.note)
+
+    def test_a_source_with_no_declared_inputs_is_unaffected(self):
+        """The check must not invent staleness for transforms that read no curation files."""
+        with (
+            mock.patch.object(self.mod, "_latest_commit", return_value=(1000, "deadbee")),
+            mock.patch.object(self.mod, "_has_local_diff", return_value=False),
+            mock.patch.object(self.mod, "_output_mtime", return_value=2000),
+            mock.patch.object(self.mod, "_latest_data_input_commit", return_value=(None, None)),
+        ):
+            report = self.mod.check_source("bactotraits", "origin/master")
+        self.assertEqual(report.status, "FRESH")
+
+    def test_stale_code_and_stale_data_are_reported_together(self):
+        """Fixing only the one you were told about would leave the other in place."""
+        with (
+            mock.patch.object(self.mod, "_latest_commit", return_value=(3000, "deadbee")),
+            mock.patch.object(self.mod, "_has_local_diff", return_value=False),
+            mock.patch.object(self.mod, "_output_mtime", return_value=2000),
+            mock.patch.object(self.mod, "_latest_data_input_commit", return_value=(4000, f"{ISO} @ abc1234")),
+        ):
+            report = self.mod.check_source("bacdive", "origin/master")
+        self.assertEqual(report.status, "STALE_VS_CODE_AND_DATA")


### PR DESCRIPTION
Two failures with one shape: tooling that reads as passing when it has not
actually checked. Both were found by the merge on 2026-08-16, which validated
perfectly — 0 errors, 0 dangling edges, every path archetype clean — while
still asserting groundings two merged PRs had corrected.

**#812 — a transform is stale against its data, not only its code.**

`kgm-freshness-check` compared each transform's code-directory commit time
against its output mtime. Nothing modelled the curation files a transform
*reads*, so:

    bacdive/edges.tsv    Aug 12   <- isolation_source_to_ontology.tsv changed Aug 15  -> FRESH
    mediadive/edges.tsv  Aug  5   <- unified chemical SSSOM changed Aug 15            -> FRESH
    madin_etal, metatraits  Aug 1                                                     -> FRESH

Consequence, measured in the shipped graph: 75 edges still asserted organisms
isolated from `NCIT:C16403` "Cell Line", 59 from `mesh:D010520` "Aggressive
Periodontitis", 28 from the wrong tick family — every defect #778 fixed, in a
graph built after #778 merged, with the freshness check reporting `0
STALE_VS_CODE`.

`Transform` now carries `DATA_INPUTS`, a tuple of repo-relative curation files,
declared on the eight consumers (`metatraits_gtdb` inherits from
`metatraits`). The skill derives its view by importing the transform classes
rather than keeping a second list — a table in the skill would drift from the
code it describes, and a stale declaration is indistinguishable from a fresh
one. Two new statuses: `STALE_VS_DATA`, and `STALE_VS_CODE_AND_DATA` so fixing
the one you were told about cannot hide the other.

Commit time, not mtime: these files are tracked, and `git checkout` rewrites
mtimes without changing content (#797).

Verified live — `metatraits_gtdb` now reports

    STALE_VS_DATA ... data input advanced 14.0 days after last output build
    (mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz @ 678a3ee)

The summary block also now prints any status it sees, including ones added
later. It had a hard-coded list of five, so a new category would have been
counted and then omitted from the report — the same class of bug again.

**#813 — an unknown source was skipped in silence.**

`for source in sources: if source in DATA_SOURCES:` had no `else`. A typo'd
`-s` value produced exit 0 and no output, indistinguishable from a successful
run *and* from a transform that died early. That ambiguity blocked a diagnosis:
`kg transform -s bacdive` exited 0 in seconds having written nothing, and
whether dispatch or the transform was at fault could not be told from outside.

Now: refuse the whole batch before running anything, listing valid sources; and
print a start line and a completion line carrying actual row counts, via
`print` rather than `logging.info`, which the CLI never configured a handler
for. A run that produces nothing now says so.

Closes #812
Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
