### PR TITLE
fix(madin_etal): correct two upstream environment ids naming the wrong term

### DIFF
--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -93,6 +93,65 @@ PARENT_DIR = Path(__file__).resolve().parent
 # quality is not a location.
 _QUALITY_CURIE_PREFIXES = ("PATO:",)
 
+#: Corrections to environments.csv, which is downloaded rather than tracked, so
+#: a fix to data/raw/ is erased by the next `kg download`.
+ENVIRONMENT_ID_CORRECTIONS_FILE = (
+    Path(__file__).resolve().parents[3] / "mappings" / "madin_environment_id_corrections.tsv"
+)
+
+
+def _apply_environment_id_corrections(envo_df: "pd.DataFrame") -> "pd.DataFrame":
+    """
+    Replace upstream ENVO_ids values that name the wrong term.
+
+    Two rows in Madin et al's environments.csv carry an id/label pair that agrees
+    with itself while matching neither the row's own key (#796):
+
+    * ``host_plant_root-associated`` -> ``NCBITaxon:1``, the root of the
+      *taxonomy*, matched on the label "root". The row describes a plant root.
+      This produced 628 merged edges asserting the root of the tree of life is
+      the ``location_of`` an organism.
+    * ``host_animal_endotherm_nasopharyngeal`` -> ``UBERON:0000065``, the whole
+      respiratory tract, so nasopharyngeal measurements were asserted about
+      trachea, bronchi and alveoli too.
+
+    Corrections are matched on the exact wrong value, not applied blindly: if
+    upstream fixes a row, the correction stops firing instead of overwriting the
+    new value with a stale one. Unapplied rows are reported so the file cannot
+    rot silently.
+
+    :param envo_df: Raw environments.csv frame.
+    :return: The frame with corrected ids and labels.
+    """
+    if not ENVIRONMENT_ID_CORRECTIONS_FILE.is_file():
+        return envo_df
+
+    corrections = pd.read_csv(ENVIRONMENT_ID_CORRECTIONS_FILE, sep="\t", comment="#", dtype=str).fillna("")
+    applied = 0
+    for _, row in corrections.iterrows():
+        target = envo_df[TYPE_COLUMN] == row["environment_type"]
+        wrong = envo_df[ENVO_ID_COLUMN].astype(str).str.strip() == row["wrong_object_id"]
+        match = target & wrong
+        hits = int(match.sum())
+        if not hits:
+            print(
+                f"  [madin_etal] environment correction not applied: "
+                f"{row['environment_type']!r} no longer carries {row['wrong_object_id']} "
+                "— upstream may have fixed it; drop the row from "
+                f"{ENVIRONMENT_ID_CORRECTIONS_FILE.name}"
+            )
+            continue
+        envo_df.loc[match, ENVO_ID_COLUMN] = row["object_id"]
+        envo_df.loc[match, ENVO_TERMS_COLUMN] = row["object_label"]
+        applied += hits
+        print(
+            f"  [madin_etal] corrected {row['environment_type']}: "
+            f"{row['wrong_object_id']} -> {row['object_id']} ({hits} row(s))"
+        )
+    if applied:
+        print(f"  [madin_etal] applied {applied} environment id correction(s)")
+    return envo_df
+
 
 def _partition_substrate_quality_curies(
     curies: List[str],
@@ -295,6 +354,7 @@ class MadinEtAlTransform(Transform):
 
         envo_cols = [TYPE_COLUMN, ENVO_TERMS_COLUMN, ENVO_ID_COLUMN]
         envo_df = pd.read_csv(self.environments_file, low_memory=False, usecols=envo_cols).drop_duplicates()
+        envo_df = _apply_environment_id_corrections(envo_df)
         envo_mapping = envo_df.set_index(TYPE_COLUMN).T.to_dict()
         traits_columns_of_interest = [
             TAX_ID_COLUMN,

--- a/kg_microbe/utils/stub_curie_collection.py
+++ b/kg_microbe/utils/stub_curie_collection.py
@@ -44,6 +44,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_MAPPING_PATHS = (
     REPO_ROOT / "mappings" / "kgmicrobe_unified_entity_mappings.sssom.tsv.gz",
     REPO_ROOT / "mappings" / "isolation_source_to_ontology.tsv",
+    # Registered so the ontologies_stubs transform emits nodes for the
+    # corrected targets. PO:0009005 is carried by no loaded ontology, so
+    # without this the correction would swap one phantom for another (#796).
+    REPO_ROOT / "mappings" / "madin_environment_id_corrections.tsv",
     REPO_ROOT / "mappings" / "ingredient_mappings.sssom.tsv",
     REPO_ROOT / "mappings" / "canonical" / "chemical_mappings.tsv",
     REPO_ROOT / "mappings" / "canonical" / "enzyme_mappings.tsv",

--- a/mappings/madin_environment_id_corrections.tsv
+++ b/mappings/madin_environment_id_corrections.tsv
@@ -1,0 +1,24 @@
+# madin_environment_id_corrections.tsv
+#
+# Corrections to the ENVO_ids column of Madin et al's environments.csv.
+#
+# WHY THIS FILE EXISTS: environments.csv is downloaded, not tracked
+# (download.yaml -> bacteria-archaea-traits/bacteria-archaea-traits), so an
+# edit to data/raw/ is erased by the next `kg download`. The correction has to
+# live in the repo and be applied at transform time.
+#
+# WHY A TSV AND NOT A DICT IN madin_etal.py: kg_microbe/utils/stub_curie_collection.py
+# scans mapping TSVs — not code — to decide which CURIEs the ontologies_stubs
+# transform must emit nodes for. PO:0009005 is not carried by any loaded
+# ontology, so a correction written in Python would silently produce an
+# untyped phantom node, which is the defect fixed for NCBITaxon in #790/#815.
+# Registering the path in DEFAULT_MAPPING_PATHS is what makes the stub appear.
+#
+# Keyed on the `Type` column of environments.csv (the habitat key), because
+# that is what identifies the row independently of the value being corrected.
+#
+# Report these upstream. Both are id/label pairs that agree with each other
+# while matching neither the row's own key (#796, reported from HabitatMech).
+environment_type	wrong_object_id	wrong_object_label	object_id	object_label	notes
+host_plant_root-associated	NCBITaxon:1	root	PO:0009005	root	NCBITaxon:1 is the root of the TAXONOMY, matched on the label "root"; the row describes a plant root. Live effect before the fix: 628 merged edges asserting `NCBITaxon:1 biolink:location_of <organism>` — the root of the tree of life as a habitat. HabitatMech drops these by refusing taxa as habitats; kg-microbe did not, so it asserted them.
+host_animal_endotherm_nasopharyngeal	UBERON:0000065	respiratory tract	UBERON:0001728	nasopharynx	The row is specifically nasopharyngeal; UBERON:0000065 is the whole respiratory tract, so bands measured in the nasopharynx (Gradients high, Structural high) were asserted about trachea, bronchi and alveoli too. 735 edges before the fix.

--- a/tests/test_madin_environment_corrections.py
+++ b/tests/test_madin_environment_corrections.py
@@ -1,0 +1,95 @@
+"""Corrections to Madin et al's downloaded environments.csv (#796)."""
+
+from pathlib import Path
+from unittest import TestCase
+
+import pandas as pd
+
+from kg_microbe.transform_utils.constants import ENVO_ID_COLUMN, ENVO_TERMS_COLUMN, TYPE_COLUMN
+from kg_microbe.transform_utils.madin_etal.madin_etal import (
+    ENVIRONMENT_ID_CORRECTIONS_FILE,
+    _apply_environment_id_corrections,
+)
+from kg_microbe.utils.stub_curie_collection import DEFAULT_MAPPING_PATHS, collect_stub_curies
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _frame(rows):
+    """Build a minimal environments.csv frame."""
+    return pd.DataFrame(
+        {
+            TYPE_COLUMN: [r[0] for r in rows],
+            ENVO_TERMS_COLUMN: [r[1] for r in rows],
+            ENVO_ID_COLUMN: [r[2] for r in rows],
+        }
+    )
+
+
+class EnvironmentCorrectionTest(TestCase):
+
+    """The two upstream rows that name the wrong term."""
+
+    def test_the_taxonomy_root_is_replaced_by_the_plant_root(self):
+        """
+        `NCBITaxon:1` is the root of the tree of life, matched on the label "root".
+
+        It produced 628 merged edges asserting the root of all life is the
+        `location_of` an organism. HabitatMech dropped these by refusing taxa as
+        habitats; kg-microbe applied no such filter and asserted them.
+        """
+        out = _apply_environment_id_corrections(_frame([("host_plant_root-associated", "root", "NCBITaxon:1")]))
+        self.assertEqual(out.iloc[0][ENVO_ID_COLUMN], "PO:0009005")
+        self.assertEqual(out.iloc[0][ENVO_TERMS_COLUMN], "root")
+
+    def test_the_whole_respiratory_tract_is_narrowed_to_the_nasopharynx(self):
+        """Nasopharyngeal measurements must not be asserted about trachea and alveoli."""
+        out = _apply_environment_id_corrections(
+            _frame([("host_animal_endotherm_nasopharyngeal", "respiratory tract", "UBERON:0000065")])
+        )
+        self.assertEqual(out.iloc[0][ENVO_ID_COLUMN], "UBERON:0001728")
+        self.assertEqual(out.iloc[0][ENVO_TERMS_COLUMN], "nasopharynx")
+
+    def test_unrelated_rows_are_untouched(self):
+        """A correction table that rewrites more than it names is worse than none."""
+        out = _apply_environment_id_corrections(_frame([("soil", "soil", "ENVO:00001998")]))
+        self.assertEqual(out.iloc[0][ENVO_ID_COLUMN], "ENVO:00001998")
+
+    def test_a_correction_does_not_fire_once_upstream_fixes_the_row(self):
+        """
+        Match on the exact wrong value, not just the row key.
+
+        Otherwise a stale correction would overwrite a *newer* upstream value
+        with an older one — turning the fix into the next bug.
+        """
+        out = _apply_environment_id_corrections(_frame([("host_plant_root-associated", "root", "PO:0009005")]))
+        self.assertEqual(out.iloc[0][ENVO_ID_COLUMN], "PO:0009005")
+
+    def test_an_unapplied_correction_is_reported(self):
+        """A table that silently stops matching is a table nobody will ever clean up."""
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _apply_environment_id_corrections(_frame([("soil", "soil", "ENVO:00001998")]))
+        self.assertIn("not applied", buf.getvalue())
+
+
+class StubRegistrationTest(TestCase):
+
+    """The corrected targets must resolve to real nodes."""
+
+    def test_the_corrections_file_is_scanned_for_stub_curies(self):
+        """
+        Registration is what makes the fix safe.
+
+        `PO:0009005` is carried by no loaded ontology, so a correction written
+        outside a scanned mapping file would swap the taxonomy-root phantom for
+        a PO phantom — the defect fixed for NCBITaxon in #815.
+        """
+        self.assertIn(ENVIRONMENT_ID_CORRECTIONS_FILE, DEFAULT_MAPPING_PATHS)
+
+    def test_the_plant_root_target_is_collected_for_stub_emission(self):
+        """End-to-end: the id reaches the set ontologies_stubs builds nodes from."""
+        self.assertIn("PO:0009005", collect_stub_curies(["PO"])["PO"])


### PR DESCRIPTION
Reported from HabitatMech (#796). Two rows of Madin et al's `environments.csv` carry an id/label pair that agrees with itself while matching neither the row's own key:

    host_plant_root-associated            NCBITaxon:1     "root"
    host_animal_endotherm_nasopharyngeal  UBERON:0000065  "respiratory tract"

`NCBITaxon:1` is the root of the **taxonomy**, matched because its label happens to be "root". The row describes a plant root.

### This is worse here than the reporter assumed

They note the effect is "dropped rather than misattributed", because they refuse to treat a taxon as a habitat. kg-microbe applies no such filter, so it asserted it: **628 edges in the merged graph of the form `NCBITaxon:1 biolink:location_of <organism>`** — the root of the tree of life as a habitat. The nasopharyngeal row contributes 735 edges attributing nasopharyngeal measurements to trachea, bronchi and alveoli.

### Two design points, both nearly got wrong

**Why a TSV rather than a dict in `madin_etal.py`.** `environments.csv` is downloaded, not tracked, so editing `data/raw/` is erased by the next `kg download`. But the correction cannot live in Python either: `stub_curie_collection.py` scans *mapping TSVs* to decide which CURIEs `ontologies_stubs` emits nodes for, and `PO:0009005` is carried by no loaded ontology. A code-only correction would have swapped the taxonomy-root phantom for a PO phantom — the defect just fixed for NCBITaxon in #815. Registering the file in `DEFAULT_MAPPING_PATHS` is what makes the target real, and a test asserts that end to end.

**Why corrections match the wrong value, not just the row key.** If upstream fixes a row, a key-only match would overwrite the *newer* correct value with our stale one. Non-matching rows are reported so the table cannot rot unnoticed.

### Note for whoever rebuilds

`tests/test_ontologies_stubs.py` fails **locally** until `poetry run kg transform -s ontologies_stubs` regenerates `po_nodes.tsv` with `PO:0009005`. It skips in CI, where `data/transformed/` does not exist, so this PR is green. Not run here because transform runs are on hold pending the MediaIngredientMech SSSOM.

Both rows should also be reported upstream to `bacteria-archaea-traits/bacteria-archaea-traits`.

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)