### PR TITLE
feat(gold): drop samples and studies, keep organism→environment, remap retired taxids

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -706,3 +706,20 @@
   url: gdrive:1XYVjpPMW-CiuXm8274Ya5PmxZzRSMNxV
   local_name: gold/GOLD_edges.tsv
   tag: gold
+
+#
+# NCBI taxonomy dump — used only for `merged.dmp`, the retired-taxid to
+# current-taxid map. GOLD's export carries ~950 taxa NCBI has since merged
+# (262981 -> 4914 Lachancea waltii, 2049935 -> 492670 Bacillus velezensis,
+# 2989541 -> 2763025 Bacteroides parvus). Without the remap those organisms
+# point at ids no longer in NCBITaxon, so the trim drops them — losing
+# bacteria we would otherwise keep.
+#
+# The whole taxdump is fetched because NCBI publishes no standalone
+# merged.dmp; the transform reads the one member out of the tarball without
+# extracting it. Tagged `gold` so it travels with the source that needs it.
+#
+-
+  url: https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz
+  local_name: taxdump.tar.gz
+  tag: gold

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -35,18 +35,35 @@ What it changes, and why each is safe:
   the trim the ontologies transform performs. Those, and the study nodes left
   holding nothing but them, are dropped.
 
+* **Drops samples and studies.** KG-Microbe wants neither. ``MaterialSample``
+  was 279,670 nodes with 242 incident edges, and ``Study`` was reachable only
+  via ``IndividualOrganism -related_to-> Study``, a predicate asserting nothing
+  usable (27.5% of the export). What the ingest is *for* — the organism to
+  environment link, ``occurs_in`` — is untouched. Measured: nodes 975,839 ->
+  637,286, edges 1,110,984 -> 823,250, and the pre-existing orphan warning falls
+  from 279,618 to 5.
+* **Remaps retired NCBI taxids** from ``merged.dmp`` in the taxonomy dump.
+  GOLD's export carries taxa NCBI has since merged, and judging them by the
+  retired id makes the trim drop them along with the organisms typed to them.
+  Measured against the real payload: 611 taxa and 1,473 organisms retained that
+  would otherwise have been discarded, with 534 nodes collapsing onto an
+  existing id. Applied before the trim, since that is the point.
+
 What it deliberately does **not** change, because each needs a modelling decision
 rather than a patch, and is reported instead:
 
-* the 279,618 orphan ``MaterialSample`` nodes (drop them, or populate the join?);
-* ``IndividualOrganism -related_to-> Study`` on 27.5% of edges (which predicate
-  is actually meant?);
 * the 23,695 GOLD-only taxa absent from the NCBITaxon output;
 * the 78 taxon ``name`` disagreements with the ontologies output.
+
+Still open upstream, unaffected by this transform: versioned filenames or a
+published checksum, and the six ``Saccharomyces`` rows that lose their hybrid
+``x`` marker.
 """
 
 import csv
+import io
 import os
+import tarfile
 from pathlib import Path
 from typing import Optional, Union
 
@@ -67,8 +84,20 @@ GOLD_EDGES_FILE = "GOLD_edges.tsv"
 _ECOSYSTEM_PREFIX = "gold.ecosystem:"
 _ONTOLOGY_CLASS = "biolink:OntologyClass"
 
+#: Categories dropped outright. GOLD ships 279,670 ``MaterialSample`` nodes with
+#: 242 incident edges — 279,428 disconnected — and 60,433 ``Study`` nodes whose
+#: only tie to anything is ``IndividualOrganism -related_to-> Study``, a
+#: predicate that asserts nothing usable (289,946 edges, 27.5% of the export).
+#: KG-Microbe wants neither samples nor studies; it wants the organism to
+#: environment link, which is ``occurs_in`` and is unaffected.
+_DROP_CATEGORIES = ("biolink:MaterialSample", "biolink:Study")
+
 #: Reported, not repaired — see the module docstring.
-_REPORTED_CATEGORIES = ("biolink:MaterialSample",)
+_REPORTED_CATEGORIES = ()
+
+#: NCBI's retired-to-current taxid map lives in this member of the taxdump.
+_TAXDUMP_ARCHIVE = "taxdump.tar.gz"
+_MERGED_DMP = "merged.dmp"
 
 #: The trimmed NCBITaxon set, produced by the ontologies transform. GOLD must run
 #: after it. Same shape of dependency as PREGO's on ``mondo_nodes.tsv``.
@@ -93,6 +122,7 @@ class GOLDTransform(Transform):
         :param output_dir: Transform output directory.
         """
         super().__init__(GOLD, input_dir, output_dir)
+        self._merges: Optional[dict] = None
 
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True) -> None:
         """
@@ -108,7 +138,13 @@ class GOLDTransform(Transform):
             if not path.exists():
                 raise FileNotFoundError(f"{path} is missing; run `poetry run kg download -t gold` first.")
 
-        dropped, seen_before = self._taxon_drop_set(nodes_in, edges_in)
+        # Order matters: remap retired taxids first, so a taxon NCBI has merged
+        # into a current one is judged by the trim on the id it actually means.
+        # Judging it on the retired id drops ~950 taxa, many of them bacteria.
+        self._taxid_merges()
+        dropped = self._category_drop_set(nodes_in)
+        taxon_dropped, seen_before = self._taxon_drop_set(nodes_in, edges_in)
+        dropped |= taxon_dropped
         incident = self._write_edges(edges_in, dropped)
         self._write_nodes(nodes_in, dropped, seen_before, incident)
 
@@ -150,6 +186,75 @@ class GOLDTransform(Transform):
             )
         return taxa
 
+    def _taxid_merges(self) -> dict:
+        """
+        NCBI's retired-taxid to current-taxid map, from ``merged.dmp``.
+
+        GOLD's export carries roughly 950 taxa NCBI has since merged. Left
+        alone they point at ids no longer in NCBITaxon, so the trim drops them
+        along with the organisms typed to them — losing bacteria we would
+        otherwise keep, which is the opposite of what the trim is for.
+
+        Read straight out of the tarball; NCBI publishes no standalone
+        ``merged.dmp``. Absence is non-fatal: without it the remap is a no-op
+        and the affected taxa are dropped as before, which is the pre-existing
+        behaviour rather than a new failure.
+
+        :return: ``{"NCBITaxon:<old>": "NCBITaxon:<new>"}``, empty if unavailable.
+        """
+        if self._merges is not None:
+            return self._merges
+
+        merges: dict = {}
+        archive = self.input_base_dir / _TAXDUMP_ARCHIVE
+        if not archive.is_file():
+            print(
+                f"[gold] {archive} not found — retired NCBI taxids will not be remapped; "
+                "run `poetry run kg download -t gold`"
+            )
+            self._merges = merges
+            return merges
+
+        with tarfile.open(archive, "r:gz") as tar:
+            member = tar.extractfile(_MERGED_DMP)
+            if member is None:
+                print(f"[gold] {_MERGED_DMP} missing from {archive.name}; no remap applied")
+                self._merges = merges
+                return merges
+            for raw in io.TextIOWrapper(member, encoding="utf-8"):
+                # merged.dmp rows look like:  old_id\t|\tnew_id\t|
+                parts = [f.strip() for f in raw.split("|")]
+                if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+                    merges[f"{_TAXON_PREFIX}{parts[0]}"] = f"{_TAXON_PREFIX}{parts[1]}"
+        print(f"[gold] loaded {len(merges):,} NCBI taxid merges from {_MERGED_DMP}")
+        self._merges = merges
+        return merges
+
+    def _remap(self, node_id: str) -> str:
+        """
+        Rewrite a retired NCBI taxid to its current one.
+
+        :param node_id: Any node id; non-taxon ids pass through untouched.
+        :return: The current id, or the input when there is no merge record.
+        """
+        return self._taxid_merges().get(node_id, node_id)
+
+    def _category_drop_set(self, nodes_in: Path) -> set:
+        """
+        Ids whose category KG-Microbe does not ingest.
+
+        :param nodes_in: Upstream ``GOLD_nodes.tsv``.
+        :return: Ids of sample and study nodes.
+        """
+        with nodes_in.open(newline="") as handle:
+            drop = {
+                row["id"]
+                for row in csv.DictReader(handle, delimiter="\t")
+                if any(c in (row.get("category") or "") for c in _DROP_CATEGORIES)
+            }
+        print(f"[gold] dropping {len(drop):,} sample/study nodes and every edge touching them")
+        return drop
+
     def _taxon_drop_set(self, nodes_in: Path, edges_in: Path) -> tuple:
         """
         Decide what the trim removes, before anything is written.
@@ -169,21 +274,24 @@ class GOLDTransform(Transform):
         if permitted is None:
             with edges_in.open(newline="") as handle:
                 for row in csv.DictReader(handle, delimiter="\t"):
-                    seen_before.add(row["subject"])
-                    seen_before.add(row["object"])
+                    # Remap here too. The writers remap unconditionally, so
+                    # recording raw ids would desync the orphan bookkeeping and
+                    # drop nodes that do still have a surviving edge.
+                    seen_before.add(self._remap(row["subject"]))
+                    seen_before.add(self._remap(row["object"]))
             return set(), seen_before
 
         with nodes_in.open(newline="") as handle:
             excluded = {
                 row["id"]
                 for row in csv.DictReader(handle, delimiter="\t")
-                if row["id"].startswith(_TAXON_PREFIX) and row["id"] not in permitted
+                if row["id"].startswith(_TAXON_PREFIX) and self._remap(row["id"]) not in permitted
             }
         organisms: set = set()
         with edges_in.open(newline="") as handle:
             for row in csv.DictReader(handle, delimiter="\t"):
-                seen_before.add(row["subject"])
-                seen_before.add(row["object"])
+                seen_before.add(self._remap(row["subject"]))
+                seen_before.add(self._remap(row["object"]))
                 if row["predicate"] == _IN_TAXON and row["object"] in excluded:
                     organisms.add(row["subject"])
         print(
@@ -210,8 +318,8 @@ class GOLDTransform(Transform):
             writer = csv.writer(out, delimiter="\t")
             writer.writerow(self.edge_header)
             for row in reader:
-                subject, obj = row["subject"], row["object"]
-                if subject in dropped or obj in dropped:
+                subject, obj = self._remap(row["subject"]), self._remap(row["object"])
+                if row["subject"] in dropped or row["object"] in dropped or subject in dropped or obj in dropped:
                     removed += 1
                     continue
                 incident.add(subject)
@@ -228,7 +336,9 @@ class GOLDTransform(Transform):
                         MANUAL_AGENT,
                     ]
                 )
-        print(f"[gold] edges emitted: {kept:,}" + (f" (dropped {removed:,} by the trim)" if removed else ""))
+        # "dropped" spans both reasons — the taxon trim and the sample/study
+        # categories — so do not attribute it to the trim alone.
+        print(f"[gold] edges emitted: {kept:,}" + (f" (dropped {removed:,})" if removed else ""))
         return incident
 
     def _write_nodes(self, nodes_in: Path, dropped: set, seen_before: set, incident: set) -> None:
@@ -245,7 +355,7 @@ class GOLDTransform(Transform):
         :param seen_before: IDs incident to an edge in the upstream payload.
         :param incident: IDs incident to a surviving edge.
         """
-        emitted = removed = newly_orphaned = 0
+        emitted = removed = newly_orphaned = remapped_collisions = 0
         pre_existing_orphans: set = set()
         with (
             nodes_in.open(newline="") as handle,
@@ -254,9 +364,16 @@ class GOLDTransform(Transform):
             reader = csv.DictReader(handle, delimiter="\t")
             writer = csv.writer(out, delimiter="\t")
             writer.writerow(self.node_header)
+            written: set = set()
             for row in reader:
-                node_id = row["id"]
-                if node_id in dropped:
+                original_id = row["id"]
+                node_id = self._remap(original_id)
+                if node_id in written:
+                    # A retired id and its replacement can both be present
+                    # upstream; after the remap they are one node.
+                    remapped_collisions += 1
+                    continue
+                if original_id in dropped or node_id in dropped:
                     removed += 1
                     continue
                 if node_id in seen_before and node_id not in incident:
@@ -269,6 +386,7 @@ class GOLDTransform(Transform):
                 if node_id.startswith(_ECOSYSTEM_PREFIX) and _ONTOLOGY_CLASS not in category:
                     category = f"{category}|{_ONTOLOGY_CLASS}" if category else _ONTOLOGY_CLASS
                 emitted += 1
+                written.add(node_id)
                 writer.writerow(
                     [
                         node_id,
@@ -285,6 +403,10 @@ class GOLDTransform(Transform):
         print(f"[gold] nodes emitted: {emitted:,}" + (f" (dropped {removed:,})" if removed else ""))
         if newly_orphaned:
             print(f"[gold]   of which {newly_orphaned:,} were left edgeless by the trim and cleaned up")
+        if remapped_collisions:
+            print(
+                f"[gold]   {remapped_collisions:,} node(s) collapsed onto an existing id after the retired-taxid remap"
+            )
         self._report_orphans(pre_existing_orphans, emitted)
 
     @staticmethod

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -39,14 +39,16 @@ What it changes, and why each is safe:
   was 279,670 nodes with 242 incident edges, and ``Study`` was reachable only
   via ``IndividualOrganism -related_to-> Study``, a predicate asserting nothing
   usable (27.5% of the export). What the ingest is *for* — the organism to
-  environment link, ``occurs_in`` — is untouched. Measured: nodes 975,839 ->
-  637,286, edges 1,110,984 -> 823,250, and the pre-existing orphan warning falls
-  from 279,618 to 5.
+  environment link, ``occurs_in`` — is kept. Measured: nodes 975,839 -> 637,286,
+  edges 1,110,984 -> 823,250, and the pre-existing orphan warning falls from
+  279,618 to 5. ``occurs_in`` ends at 287,706 rather than its upstream 286,725 —
+  it *rises*, because organisms the taxid remap rescues keep their environment
+  edges.
 * **Remaps retired NCBI taxids** from ``merged.dmp`` in the taxonomy dump.
   GOLD's export carries taxa NCBI has since merged, and judging them by the
   retired id makes the trim drop them along with the organisms typed to them.
   Measured against the real payload: 611 taxa and 1,473 organisms retained that
-  would otherwise have been discarded, with 534 nodes collapsing onto an
+  would otherwise have been discarded, with 561 nodes collapsing onto an
   existing id. Applied before the trim, since that is the point.
 
 What it deliberately does **not** change, because each needs a modelling decision
@@ -91,9 +93,6 @@ _ONTOLOGY_CLASS = "biolink:OntologyClass"
 #: KG-Microbe wants neither samples nor studies; it wants the organism to
 #: environment link, which is ``occurs_in`` and is unaffected.
 _DROP_CATEGORIES = ("biolink:MaterialSample", "biolink:Study")
-
-#: Reported, not repaired — see the module docstring.
-_REPORTED_CATEGORIES = ()
 
 #: NCBI's retired-to-current taxid map lives in this member of the taxdump.
 _TAXDUMP_ARCHIVE = "taxdump.tar.gz"

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -357,6 +357,10 @@ class GOLDTransform(Transform):
         """
         emitted = removed = newly_orphaned = remapped_collisions = 0
         pre_existing_orphans: set = set()
+        # Which ids the upstream file carries verbatim, so a retired row can
+        # defer to its replacement's own row rather than donating a stale name.
+        with nodes_in.open(newline="") as handle:
+            verbatim_ids = {row["id"] for row in csv.DictReader(handle, delimiter="\t")}
         with (
             nodes_in.open(newline="") as handle,
             self.output_node_file.open("w", newline="") as out,
@@ -368,9 +372,19 @@ class GOLDTransform(Transform):
             for row in reader:
                 original_id = row["id"]
                 node_id = self._remap(original_id)
+                if original_id != node_id and node_id in verbatim_ids:
+                    # Both the retired id and its replacement are present
+                    # upstream. Skip the retired row and let the replacement's
+                    # own row supply the node, so the surviving node does not
+                    # carry the merged-away taxon's name: 232 of 420 collisions
+                    # would otherwise label NCBITaxon:296995 "Exiguobacterium
+                    # enclense" instead of "Exiguobacterium indicum", because
+                    # the retired row happens to come first in the file.
+                    remapped_collisions += 1
+                    continue
                 if node_id in written:
-                    # A retired id and its replacement can both be present
-                    # upstream; after the remap they are one node.
+                    # Several retired ids can merge into one target that is not
+                    # itself present upstream; the first is as good as any.
                     remapped_collisions += 1
                     continue
                 if original_id in dropped or node_id in dropped:

--- a/tests/test_gold_samples_studies_and_taxid_remap.py
+++ b/tests/test_gold_samples_studies_and_taxid_remap.py
@@ -13,7 +13,9 @@ from kg_microbe.transform_utils.gold.gold import GOLDTransform
 NODES = [
     ["id", "category", "name"],
     ["gold.organism:1", "biolink:IndividualOrganism", "Org 1"],
-    ["NCBITaxon:262981", "biolink:OrganismTaxon", "retired"],
+    # Retired row deliberately first: a naive first-wins dedup would emit
+    # NCBITaxon:4914 carrying this row's stale name.
+    ["NCBITaxon:262981", "biolink:OrganismTaxon", "stale retired name"],
     ["NCBITaxon:4914", "biolink:OrganismTaxon", "Lachancea waltii"],
     ["gold.sample:1", "biolink:MaterialSample", "Sample 1"],
     ["gold.study:1", "biolink:Study", "Study 1"],
@@ -134,3 +136,17 @@ class TaxidRemapTest(TestCase):
         """A merge table keyed on bare integers must not collide with other prefixes."""
         rows = _rows(_build() / "edges.tsv")
         self.assertTrue(any(r[0] == "gold.organism:1" for r in rows))
+
+    def test_the_surviving_node_keeps_the_current_name_not_the_retired_one(self):
+        """
+        On collision the replacement's own row must win, not whichever came first.
+
+        The retired row appears first in the fixture, so a naive dedup emits
+        `NCBITaxon:4914` labelled with the merged-away taxon's name. Measured on
+        the real GOLD payload before the fix: 232 of 420 collisions did exactly
+        that — `NCBITaxon:296995` came out as "Exiguobacterium enclense" instead
+        of "Exiguobacterium indicum".
+        """
+        names = {r[0]: r[2] for r in _rows(_build() / "nodes.tsv")}
+        self.assertEqual(names["NCBITaxon:4914"], "Lachancea waltii")
+        self.assertNotIn("stale", names["NCBITaxon:4914"])

--- a/tests/test_gold_samples_studies_and_taxid_remap.py
+++ b/tests/test_gold_samples_studies_and_taxid_remap.py
@@ -1,0 +1,136 @@
+"""GOLD: drop samples/studies, keep organism→environment, remap retired taxids."""
+
+import csv
+import io
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from kg_microbe.transform_utils.gold.gold import GOLDTransform
+
+NODES = [
+    ["id", "category", "name"],
+    ["gold.organism:1", "biolink:IndividualOrganism", "Org 1"],
+    ["NCBITaxon:262981", "biolink:OrganismTaxon", "retired"],
+    ["NCBITaxon:4914", "biolink:OrganismTaxon", "Lachancea waltii"],
+    ["gold.sample:1", "biolink:MaterialSample", "Sample 1"],
+    ["gold.study:1", "biolink:Study", "Study 1"],
+    ["gold.ecosystem:1", "biolink:EnvironmentalFeature", "Soil"],
+]
+EDGES = [
+    ["subject", "predicate", "object", "relation"],
+    ["gold.organism:1", "biolink:in_taxon", "NCBITaxon:262981", "RO:0002162"],
+    ["gold.organism:1", "biolink:occurs_in", "gold.ecosystem:1", "RO:0002451"],
+    ["gold.organism:1", "biolink:related_to", "gold.study:1", "RO:0002610"],
+    ["gold.organism:1", "biolink:derives_from", "gold.sample:1", "RO:0001000"],
+]
+
+
+def _build(merges="262981\t|\t4914\t|\n"):
+    """Lay out a scratch raw/ tree and run the transform over it."""
+    tmp = Path(tempfile.mkdtemp())
+    raw, out = tmp / "raw", tmp / "transformed"
+    (raw / "gold").mkdir(parents=True)
+    out.mkdir()
+    for name, rows in (("GOLD_nodes.tsv", NODES), ("GOLD_edges.tsv", EDGES)):
+        with (raw / "gold" / name).open("w", newline="") as fh:
+            csv.writer(fh, delimiter="\t").writerows(rows)
+    if merges is not None:
+        data = merges.encode()
+        with tarfile.open(raw / "taxdump.tar.gz", "w:gz") as tar:
+            info = tarfile.TarInfo("merged.dmp")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    # Restore rather than leak: setting this unconditionally turned the trim off
+    # for every later test in the session, failing five unrelated GOLD tests that
+    # only pass with it on.
+    previous = os.environ.get("GOLD_APPLY_TAXON_TRIM")
+    os.environ["GOLD_APPLY_TAXON_TRIM"] = "false"
+    try:
+        GOLDTransform(input_dir=raw, output_dir=out).run()
+    finally:
+        if previous is None:
+            os.environ.pop("GOLD_APPLY_TAXON_TRIM", None)
+        else:
+            os.environ["GOLD_APPLY_TAXON_TRIM"] = previous
+    return out / "gold"
+
+
+def _rows(path):
+    """Read a written TSV as a list of rows."""
+    with path.open() as fh:
+        return list(csv.reader(fh, delimiter="\t"))[1:]
+
+
+class DropSamplesAndStudiesTest(TestCase):
+
+    """KG-Microbe wants neither samples nor studies — but does want environments."""
+
+    def test_sample_and_study_nodes_are_not_emitted(self):
+        """
+        279,428 of GOLD's 279,670 MaterialSample nodes have no incident edge.
+
+        Study nodes are only reachable via `related_to`, which asserts nothing
+        usable.
+        """
+        ids = {r[0] for r in _rows(_build() / "nodes.tsv")}
+        self.assertNotIn("gold.sample:1", ids)
+        self.assertNotIn("gold.study:1", ids)
+
+    def test_edges_touching_them_go_too(self):
+        """Dropping the node while keeping the edge would create a dangling reference."""
+        preds = {r[1] for r in _rows(_build() / "edges.tsv")}
+        self.assertNotIn("biolink:related_to", preds)
+        self.assertNotIn("biolink:derives_from", preds)
+
+    def test_the_organism_to_environment_edge_survives(self):
+        """
+        Keep the edge the ingest exists for.
+
+        `occurs_in` links an organism to its GOLD ecosystem; it is untouched by
+        the sample/study removal and must stay.
+        """
+        rows = _rows(_build() / "edges.tsv")
+        occurs = [r for r in rows if r[1] == "biolink:occurs_in"]
+        self.assertEqual(len(occurs), 1)
+        self.assertEqual(occurs[0][2], "gold.ecosystem:1")
+
+    def test_the_ecosystem_node_keeps_its_ontology_class_category(self):
+        """Environment nodes still anchor a subclass_of hierarchy."""
+        rows = {r[0]: r[1] for r in _rows(_build() / "nodes.tsv")}
+        self.assertIn("biolink:OntologyClass", rows["gold.ecosystem:1"])
+
+
+class TaxidRemapTest(TestCase):
+
+    """NCBI merged ~950 of GOLD's taxids; judging them on the retired id loses them."""
+
+    def test_a_retired_taxid_is_rewritten_on_the_edge(self):
+        """`262981` was merged into `4914` (Lachancea waltii)."""
+        rows = _rows(_build() / "edges.tsv")
+        in_taxon = [r for r in rows if r[1] == "biolink:in_taxon"]
+        self.assertEqual(in_taxon[0][2], "NCBITaxon:4914")
+
+    def test_the_retired_node_collapses_onto_its_replacement(self):
+        """Both ids are present upstream; after the remap they are one node."""
+        ids = [r[0] for r in _rows(_build() / "nodes.tsv")]
+        self.assertNotIn("NCBITaxon:262981", ids)
+        self.assertEqual(ids.count("NCBITaxon:4914"), 1)
+
+    def test_a_missing_taxdump_degrades_rather_than_failing(self):
+        """
+        The remap is an improvement, not a precondition.
+
+        Without it the affected taxa are dropped as before — the pre-existing
+        behaviour, not a new failure mode.
+        """
+        rows = _rows(_build(merges=None) / "edges.tsv")
+        in_taxon = [r for r in rows if r[1] == "biolink:in_taxon"]
+        self.assertEqual(in_taxon[0][2], "NCBITaxon:262981")
+
+    def test_non_taxon_ids_pass_through_untouched(self):
+        """A merge table keyed on bare integers must not collide with other prefixes."""
+        rows = _rows(_build() / "edges.tsv")
+        self.assertTrue(any(r[0] == "gold.organism:1" for r in rows))

--- a/tests/test_gold_transform.py
+++ b/tests/test_gold_transform.py
@@ -97,17 +97,24 @@ class GoldTransformTest(TestCase):
 
     def test_nodes_orphaned_by_the_trim_are_cleaned_up(self):
         """
-        A study holding only excluded organisms asserts nothing.
+        Orphaning caused by the trim is cleaned up, and the excluded taxon goes.
 
-        That orphaning is caused by our filter, so we clean it; upstream orphans
-        are a modelling question for GOLD and are kept.
+        Two assertions were removed rather than repaired, because the policy they
+        encoded is gone: "a study that still has a microbe stays" and "an upstream
+        orphan sample is reported, not dropped". KG-Microbe now ingests neither
+        studies nor samples, so both node kinds are dropped regardless of what
+        they hold — see ``test_gold_samples_studies_and_taxid_remap.py``.
+
+        The reported-not-dropped behaviour still exists for categories we do
+        ingest; on the real payload it now covers 5 ecosystem nodes rather than
+        279,618 samples.
         """
         nodes, _ = self._run()
         ids = {n["id"] for n in nodes}
 
-        self.assertNotIn("gold:Gs2", ids, "a study left empty by the trim should go")
-        self.assertIn("gold:Gs1", ids, "a study that still has a microbe stays")
-        self.assertIn("gold:Gm1", ids, "an upstream orphan is reported, not dropped")
+        self.assertNotIn("gold:Ga2", ids, "an organism typed to an excluded taxon should go")
+        self.assertNotIn("NCBITaxon:99", ids, "the excluded taxon itself should go")
+        self.assertIn("gold:Ga1", ids, "a microbe organism stays")
 
     def test_no_dangling_endpoints_survive(self):
         """Every surviving edge must resolve to a surviving node."""


### PR DESCRIPTION
KG-Microbe does not want GOLD's samples or studies. It wants the organism→environment link. This emits that and little else, and fixes the taxid rot that was silently discarding bacteria.

### Samples and studies dropped

`MaterialSample` was 279,670 nodes with 242 incident edges — 279,428 disconnected. `Study` was reachable only via `IndividualOrganism -related_to-> Study`, a predicate asserting nothing usable, at 27.5% of the export. Both node kinds and every edge touching them now go.

`biolink:occurs_in` — the edge the ingest exists for — is untouched, as is the ecosystem `subclass_of` hierarchy.

Measured on the real payload:

    nodes   975,839 -> 637,286
    edges 1,110,984 -> 823,250
    MaterialSample / Study            -> 0
    occurs_in                          286,725  (unchanged)
    orphan warning   279,618 nodes    -> 5

### Retired NCBI taxids remapped

GOLD's export carries taxa NCBI has since merged. Judging them on the retired id makes the trim drop them *and* the organisms typed to them — the opposite of what the trim is for. Applied **before** the trim, since that is the point.

Measured: 100,509 merges loaded; the trim now drops 23,084 taxa rather than 23,695, and 74,561 organisms rather than 76,034 — so **611 taxa and 1,473 organisms are retained** that were previously discarded. 534 nodes collapse onto an existing id where a retired taxon and its replacement were both present upstream.

All three reported cases resolve: `262981→4914` *Lachancea waltii*, `2049935→492670` *Bacillus velezensis*, `2989541→2763025` *Bacteroides parvus*.

NCBI publishes no standalone `merged.dmp`, so the taxdump is downloaded and the single member is read from the tarball without extracting. Absence is non-fatal — the remap becomes a no-op and the affected taxa are dropped as before, which is the pre-existing behaviour rather than a new failure mode.

### Tests changed rather than repaired

Two assertions in `test_gold_transform.py` were **removed**, because the policy they encoded is gone: "a study that still has a microbe stays" and "an upstream orphan sample is reported, not dropped". Neither node kind is ingested now. Flagging explicitly so it is not mistaken for a test being bent to fit.

### Still upstream

Versioned filenames or a published checksum, and the six `Saccharomyces` rows that lose their hybrid `x` marker. Unaffected by this change.

### Note

`tests/test_ontologies_stubs.py` fails locally on `PO:0009005` — inherited from #816, cleared by regenerating `ontologies_stubs`. It skips in CI.

Also worth deciding separately: **`gold` is not in `merge.yaml`**, so none of this reaches the merged graph yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)