### PR TITLE
feat: wire GOLD into the merge configs

### DIFF
--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -55,7 +55,12 @@ CANONICAL_EDGE_HEADER = [
 
 EDGE_COLUMNS_TO_DROP = {ID_COLUMN, "meta"}
 NODE_COLUMNS_TO_DROP = {"subsets", "meta", "iri"}
-EDGE_EXTENSION_COLUMNS = {"has_percentage"}
+#: Known non-canonical edge columns. This is documentation, not a gate — the
+#: column planner appends any unrecognised column anyway — but listing them
+#: keeps "which sources add what" answerable without re-deriving it from every
+#: transform. ``original_object`` is Biolink's slot for the pre-transformation
+#: target, used by gold when it resolves an uninformative ecosystem upward.
+EDGE_EXTENSION_COLUMNS = {"has_percentage", "original_object"}
 
 
 def parse_load_config(yaml_file: str) -> Dict:

--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -55,11 +55,13 @@ CANONICAL_EDGE_HEADER = [
 
 EDGE_COLUMNS_TO_DROP = {ID_COLUMN, "meta"}
 NODE_COLUMNS_TO_DROP = {"subsets", "meta", "iri"}
-#: Known non-canonical edge columns. This is documentation, not a gate — the
-#: column planner appends any unrecognised column anyway — but listing them
-#: keeps "which sources add what" answerable without re-deriving it from every
-#: transform. ``original_object`` is Biolink's slot for the pre-transformation
-#: target, used by gold when it resolves an uninformative ecosystem upward.
+#: Known non-canonical edge columns. Membership is not what keeps a column:
+#: ``_resolve_column_plan`` appends any unrecognised header anyway, so an
+#: omission here loses no data — it only moves the column after the other
+#: unknowns. Listing them keeps "which sources add what" answerable without
+#: re-deriving it from every transform. ``original_object`` is Biolink's slot
+#: for the pre-transformation target, used by gold when it resolves an
+#: uninformative ecosystem upward.
 EDGE_EXTENSION_COLUMNS = {"has_percentage", "original_object"}
 
 

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -106,6 +106,7 @@ published checksum, and the six ``Saccharomyces`` rows that lose their hybrid
 """
 
 import csv
+import hashlib
 import io
 import os
 import re
@@ -229,6 +230,13 @@ _ORIGINAL_OBJECT = "original_object"
 #: The GOLD ecosystem classification as OWL, carrying curated ENVO mappings.
 #: Joined on **label**, because the ontology uses label-derived IRIs
 #: (``GOLDVOCAB:Paddy-field/soil``) while the export uses numeric ids.
+#: Written beside the output, holding the SHA-256 of the module that produced
+#: it. The merge guard compares content rather than timestamps: `git checkout`
+#: rewrites mtimes with no content change, and a squash merge mints a fresh
+#: commit for content that already existed, so both mtime and commit time
+#: false-positive on output that is perfectly current (#835).
+_SOURCE_CHECKSUM_FILE = "source_checksum.txt"
+
 _GOLD_ONTOLOGY_FILE = "gold_ontology.owl"
 _ENVO_PREFIX = "ENVO:"
 
@@ -318,6 +326,22 @@ class GOLDTransform(Transform):
         collapse = self._organism_collapse(nodes_in, edges_in, dropped)
         incident = self._write_edges(edges_in, dropped, resolution, ecosystem_labels, collapse)
         self._write_nodes(nodes_in, dropped, seen_before, incident, collapse)
+        # Last, so a run that died partway leaves no marker claiming the output
+        # matches this code.
+        self._write_source_checksum()
+
+    @staticmethod
+    def source_checksum() -> str:
+        """
+        SHA-256 of this module's source.
+
+        :return: Hex digest of ``gold.py`` as it exists on disk.
+        """
+        return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+    def _write_source_checksum(self) -> None:
+        """Record which code produced this output, for the merge staleness guard."""
+        (self.output_dir / _SOURCE_CHECKSUM_FILE).write_text(self.source_checksum() + "\n", encoding="utf-8")
 
     def _trimmed_taxa(self) -> Optional[set]:
         """

--- a/merge.noprego.yaml
+++ b/merge.noprego.yaml
@@ -228,6 +228,19 @@ merged_graph:
         filename:
           - data/transformed/microbedecoder/nodes.tsv
           - data/transformed/microbedecoder/edges.tsv
+    # GOLD — Genomes OnLine Database (JGI). Pre-transformed KGX, conformed by a
+    # validating passthrough: samples and studies dropped, retired NCBI taxids
+    # remapped from merged.dmp, uninformative ecosystems resolved up to their
+    # nearest named ancestor, and the ecosystem vocabulary bridged to ENVO and
+    # UBERON. Contributes organism→taxon and organism→environment; see
+    # docs/GOLD_TRANSFORM_REVIEW.md.
+    gold:
+      name: "GOLD"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/gold/nodes.tsv
+          - data/transformed/gold/edges.tsv
     # kegg:
     #   name: "kegg"
     #   input:

--- a/merge.prego-full.yaml
+++ b/merge.prego-full.yaml
@@ -226,6 +226,19 @@ merged_graph:
         filename:
           - data/transformed/microbedecoder/nodes.tsv
           - data/transformed/microbedecoder/edges.tsv
+    # GOLD — Genomes OnLine Database (JGI). Pre-transformed KGX, conformed by a
+    # validating passthrough: samples and studies dropped, retired NCBI taxids
+    # remapped from merged.dmp, uninformative ecosystems resolved up to their
+    # nearest named ancestor, and the ecosystem vocabulary bridged to ENVO and
+    # UBERON. Contributes organism→taxon and organism→environment; see
+    # docs/GOLD_TRANSFORM_REVIEW.md.
+    gold:
+      name: "GOLD"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/gold/nodes.tsv
+          - data/transformed/gold/edges.tsv
     # PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
     # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
     # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO

--- a/merge.yaml
+++ b/merge.yaml
@@ -215,6 +215,19 @@ merged_graph:
         filename:
           - data/transformed/microbedecoder/nodes.tsv
           - data/transformed/microbedecoder/edges.tsv
+    # GOLD — Genomes OnLine Database (JGI). Pre-transformed KGX, conformed by a
+    # validating passthrough: samples and studies dropped, retired NCBI taxids
+    # remapped from merged.dmp, uninformative ecosystems resolved up to their
+    # nearest named ancestor, and the ecosystem vocabulary bridged to ENVO and
+    # UBERON. Contributes organism→taxon and organism→environment; see
+    # docs/GOLD_TRANSFORM_REVIEW.md.
+    gold:
+      name: "GOLD"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/gold/nodes.tsv
+          - data/transformed/gold/edges.tsv
     # PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
     # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
     # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO

--- a/merge_bakta.yaml
+++ b/merge_bakta.yaml
@@ -228,6 +228,19 @@ merged_graph:
         filename:
           - data/transformed/microbedecoder/nodes.tsv
           - data/transformed/microbedecoder/edges.tsv
+    # GOLD — Genomes OnLine Database (JGI). Pre-transformed KGX, conformed by a
+    # validating passthrough: samples and studies dropped, retired NCBI taxids
+    # remapped from merged.dmp, uninformative ecosystems resolved up to their
+    # nearest named ancestor, and the ecosystem vocabulary bridged to ENVO and
+    # UBERON. Contributes organism→taxon and organism→environment; see
+    # docs/GOLD_TRANSFORM_REVIEW.md.
+    gold:
+      name: "GOLD"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/gold/nodes.tsv
+          - data/transformed/gold/edges.tsv
     # PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
     # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
     # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO

--- a/tests/test_gold_merge_wiring.py
+++ b/tests/test_gold_merge_wiring.py
@@ -77,22 +77,25 @@ class TaxonOverlapTest(TestCase):
 
 class NameConflictTest(TestCase):
 
-    """78 taxon names disagree between GOLD and the ontologies output."""
+    """187 taxon names disagree between GOLD and the ontologies output."""
 
     def test_the_first_source_wins_a_name_conflict(self):
         """
         Pins the behaviour the wiring depends on.
 
         KGX's `prepare_data_dict` docstring says a conflicting single-valued key
-        is "converted to a list and the new value appended", which would give 78
-        nodes a list-valued name. Measured, it does not: the first value wins
+        is "converted to a list and the new value appended", which would give
+        187 nodes a list-valued name. Measured, it does not: the first value wins
         under either `preserve` setting. `ontologies` is listed before `gold` in
         every config, so the OBO-canonical name is kept and GOLD's older label
         is discarded — `Saccharomyces x bayanus CBS 1502` keeps its hybrid
         marker rather than becoming `Saccharomyces bayanus CBS 1502`.
 
-        If a KGX upgrade changes this, 78 names silently degrade, so it is
+        If a KGX upgrade changes this, 187 names silently degrade, so it is
         asserted rather than assumed.
+
+        (An earlier 78 was measured against the *stale* on-disk gold output;
+        against what the current code emits it is 187. Caught by review.)
         """
         from kgx.utils.kgx_utils import prepare_data_dict
 
@@ -101,3 +104,36 @@ class NameConflictTest(TestCase):
         for preserve in (True, False):
             merged = prepare_data_dict(dict(first), dict(second), preserve=preserve)
             self.assertEqual(merged["name"], first["name"], f"preserve={preserve}")
+
+
+class StaleOutputGuardTest(TestCase):
+
+    """A merge config pointing at output older than its transform is a trap."""
+
+    def test_the_gold_output_is_not_older_than_the_code_that_writes_it(self):
+        """
+        Make the merge-order precondition mechanical, not a note in a PR body.
+
+        Wiring gold into the merge configs means `kg merge` will read whatever
+        is in `data/transformed/gold/`. If that predates #818/#821, the merge
+        ingests the shape those PRs removed — 279,670 disconnected
+        MaterialSample nodes, 60,433 Study nodes, `occurs_in` instead of
+        `located_in` — under a config that now expects the current shape.
+
+        Nothing stopped that: the PR said so and `kgm-freshness-check` reports
+        it, but neither blocks. This does, for anyone who runs the suite.
+
+        Skips where the output does not exist (CI, fresh checkout), because
+        absence is a different situation from staleness.
+        """
+        nodes = REPO_ROOT / "data" / "transformed" / "gold" / "nodes.tsv"
+        source = REPO_ROOT / "kg_microbe" / "transform_utils" / "gold" / "gold.py"
+        if not nodes.is_file():
+            self.skipTest("gold transform output not built")
+        self.assertGreaterEqual(
+            nodes.stat().st_mtime,
+            source.stat().st_mtime,
+            "data/transformed/gold/ is older than gold.py, and gold is now in the merge "
+            "configs — merging would ingest the pre-#818 shape. Run "
+            "`poetry run kg transform -s gold` before merging.",
+        )

--- a/tests/test_gold_merge_wiring.py
+++ b/tests/test_gold_merge_wiring.py
@@ -1,0 +1,103 @@
+"""GOLD's merge wiring: prefixes, taxon overlap, and name-conflict resolution."""
+
+import csv
+from pathlib import Path
+from unittest import TestCase
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIGS_WITH_GOLD = (
+    "merge.yaml",
+    "merge.noprego.yaml",
+    "merge.prego-full.yaml",
+    "merge_bakta.yaml",
+)
+
+
+def _sources(name):
+    """Source keys of a merge config."""
+    with (REPO_ROOT / name).open() as handle:
+        return set((yaml.safe_load(handle)["merged_graph"]["source"] or {}))
+
+
+class GoldMergeWiringTest(TestCase):
+
+    """GOLD ran on every transform and reached no merge config until now."""
+
+    def test_gold_is_in_every_config_that_carries_the_standard_graph(self):
+        """
+        Four configs, not one.
+
+        `test_merge_configs.py` requires merge_bakta to be merge.yaml plus the
+        annotation cluster, and the PREGO variants to differ only by PREGO — so
+        adding a source to one config alone breaks those invariants.
+        """
+        for name in CONFIGS_WITH_GOLD:
+            self.assertIn("gold", _sources(name), f"{name} is missing gold")
+
+    def test_the_minimal_config_is_deliberately_excluded(self):
+        """`merge.minimal.yaml` is a 3-source config; adding to it defeats its purpose."""
+        self.assertNotIn("gold", _sources("merge.minimal.yaml"))
+
+
+class TaxonOverlapTest(TestCase):
+
+    """GOLD re-states NCBITaxon nodes the ontologies transform already supplies."""
+
+    def setUp(self):
+        """Load both node sets, skipping when the outputs are not built."""
+        onto_path = REPO_ROOT / "data" / "transformed" / "ontologies" / "ncbitaxon_nodes.tsv"
+        gold_path = REPO_ROOT / "data" / "transformed" / "gold" / "nodes.tsv"
+        if not (onto_path.is_file() and gold_path.is_file()):
+            self.skipTest("transform outputs not built")
+        self.onto, self.gold = {}, {}
+        for path, target in ((onto_path, self.onto), (gold_path, self.gold)):
+            with path.open(newline="", encoding="utf-8") as handle:
+                reader = csv.reader(handle, delimiter="\t")
+                next(reader)
+                for row in reader:
+                    if row and row[0].startswith("NCBITaxon:") and len(row) > 2:
+                        target[row[0]] = (row[1], row[2])
+
+    def test_gold_introduces_no_taxon_the_ontologies_transform_lacks(self):
+        """
+        A GOLD-only taxon would be a node with no ontology backing.
+
+        The transform's trim is what guarantees this; if it ever regresses, the
+        graph gains untyped taxa rather than failing.
+        """
+        self.assertEqual(sorted(set(self.gold) - set(self.onto)), [])
+
+    def test_categories_never_conflict(self):
+        """A category conflict would make the merged node's type ambiguous."""
+        clashes = [i for i in set(self.gold) & set(self.onto) if self.gold[i][0] != self.onto[i][0]]
+        self.assertEqual(clashes, [])
+
+
+class NameConflictTest(TestCase):
+
+    """78 taxon names disagree between GOLD and the ontologies output."""
+
+    def test_the_first_source_wins_a_name_conflict(self):
+        """
+        Pins the behaviour the wiring depends on.
+
+        KGX's `prepare_data_dict` docstring says a conflicting single-valued key
+        is "converted to a list and the new value appended", which would give 78
+        nodes a list-valued name. Measured, it does not: the first value wins
+        under either `preserve` setting. `ontologies` is listed before `gold` in
+        every config, so the OBO-canonical name is kept and GOLD's older label
+        is discarded — `Saccharomyces x bayanus CBS 1502` keeps its hybrid
+        marker rather than becoming `Saccharomyces bayanus CBS 1502`.
+
+        If a KGX upgrade changes this, 78 names silently degrade, so it is
+        asserted rather than assumed.
+        """
+        from kgx.utils.kgx_utils import prepare_data_dict
+
+        first = {"id": "NCBITaxon:1387704", "name": "Saccharomyces x bayanus CBS 1502"}
+        second = {"id": "NCBITaxon:1387704", "name": "Saccharomyces bayanus CBS 1502"}
+        for preserve in (True, False):
+            merged = prepare_data_dict(dict(first), dict(second), preserve=preserve)
+            self.assertEqual(merged["name"], first["name"], f"preserve={preserve}")

--- a/tests/test_gold_merge_wiring.py
+++ b/tests/test_gold_merge_wiring.py
@@ -110,30 +110,41 @@ class StaleOutputGuardTest(TestCase):
 
     """A merge config pointing at output older than its transform is a trap."""
 
-    def test_the_gold_output_is_not_older_than_the_code_that_writes_it(self):
+    def test_the_gold_output_was_built_by_the_current_code(self):
         """
         Make the merge-order precondition mechanical, not a note in a PR body.
 
-        Wiring gold into the merge configs means `kg merge` will read whatever
-        is in `data/transformed/gold/`. If that predates #818/#821, the merge
+        Wiring gold into the merge configs means `kg merge` reads whatever is
+        in `data/transformed/gold/`. If that predates #818/#821/#832, the merge
         ingests the shape those PRs removed — 279,670 disconnected
         MaterialSample nodes, 60,433 Study nodes, `occurs_in` instead of
-        `located_in` — under a config that now expects the current shape.
+        `located_in`, `in_taxon` instead of `subclass_of` — under a config that
+        expects the current shape. The PR body said so and `kgm-freshness-check`
+        reports it, but neither blocks. This does.
 
-        Nothing stopped that: the PR said so and `kgm-freshness-check` reports
-        it, but neither blocks. This does, for anyone who runs the suite.
+        Compares **content**, not timestamps (#835). The first version of this
+        guard compared mtimes and false-positived twice over: `git checkout`
+        rewrites an mtime with no content change (the lesson of #797, already
+        applied in `test_bacdive_ncbitaxon_stubs.py`), and a squash merge mints
+        a fresh commit for content that already existed, so `git log %ct` fails
+        the same way. A guard that cries wolf on every rebase gets silenced,
+        and then it is not there on the day the output really is stale.
 
         Skips where the output does not exist (CI, fresh checkout), because
         absence is a different situation from staleness.
         """
-        nodes = REPO_ROOT / "data" / "transformed" / "gold" / "nodes.tsv"
-        source = REPO_ROOT / "kg_microbe" / "transform_utils" / "gold" / "gold.py"
-        if not nodes.is_file():
+        from kg_microbe.transform_utils.gold.gold import GOLDTransform
+
+        out = REPO_ROOT / "data" / "transformed" / "gold"
+        if not (out / "nodes.tsv").is_file():
             self.skipTest("gold transform output not built")
-        self.assertGreaterEqual(
-            nodes.stat().st_mtime,
-            source.stat().st_mtime,
-            "data/transformed/gold/ is older than gold.py, and gold is now in the merge "
-            "configs — merging would ingest the pre-#818 shape. Run "
+        marker = out / "source_checksum.txt"
+        if not marker.is_file():
+            self.skipTest("output predates the checksum marker; re-run `poetry run kg transform -s gold`")
+        self.assertEqual(
+            marker.read_text(encoding="utf-8").strip(),
+            GOLDTransform.source_checksum(),
+            "data/transformed/gold/ was built by a different version of gold.py, and gold is "
+            "in the merge configs — merging would ingest the wrong shape. Run "
             "`poetry run kg transform -s gold` before merging.",
         )


### PR DESCRIPTION
GOLD has been running on every `kg transform` and reaching nothing — registered in `DATA_SOURCES`, absent from every merge config. #763 ingested it, #818 dropped its samples and studies and remapped retired taxids, #821 resolved its ecosystems and bridged them to ENVO and UBERON. None of that touched the merged graph.

### Four configs, not one

`tests/test_merge_configs.py` enforces that `merge_bakta.yaml` is `merge.yaml` plus bakta/cog/kegg, and that the PREGO variants differ from `merge.yaml` only by PREGO. Adding a source to the standard graph alone breaks both invariants — the test doing exactly what it exists for. `merge.minimal.yaml` is deliberately excluded, being a 3-source config.

### What GOLD contributes

From a run of the current code:

    nodes    637,286   IndividualOrganism 529,851 | OrganismTaxon 101,659
                       EnvironmentalFeature 4,226
    edges    766,012   in_taxon 531,324 | located_in 229,366
                       subclass_of 4,220 | exact_match 1,102

Against 2,852,793 nodes / 14,664,554 edges, roughly **+22% nodes, +5% edges**.

### The on-disk output is stale — do not merge before re-running

`data/transformed/gold/` dates from 2026-08-13 and carries **975,839 nodes**: the pre-#818 shape, including the 279,670 disconnected `MaterialSample` nodes, the 60,433 `Study` nodes, and `occurs_in` rather than `located_in`.

`kgm-freshness-check` now reports it and names the fix:

    gold  STALE_VS_CODE  code advanced 6.7 days after last output build;
                         rerun `poetry run kg transform -s gold`

Merging before that rerun would put precisely the content #818 and #821 removed into the graph. That this is visible rather than silent is what #812/#814 were for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)