### PR TITLE
feat(gold): use the graph's own taxon convention, and fold organisms that add no name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,40 @@ it for any new cache of that shape.
 - Output files: Always `nodes.tsv` and `edges.tsv` per source
 - Column names: Use constants from `constants.py` (e.g., `SUBJECT_COLUMN`, `PREDICATE_COLUMN`, `OBJECT_COLUMN`)
 
+### "This named entity sits under this taxon" is always `biolink:subclass_of`
+
+Not `biolink:in_taxon`. Every source that places a named biological entity
+beneath an NCBITaxon node uses `subclass_of` / `rdfs:subClassOf`, and the node
+on the narrow end is typed `biolink:OrganismTaxon`:
+
+| source | edges |
+|---|---|
+| NCBITaxon's own hierarchy (ontologies) | 925,219 |
+| bacdive strains (`kgmicrobe.strain:`) | 251,916 |
+| gold organisms (`gold:`) | 471,702 |
+| metatraits | 186 |
+
+**This deviates from Biolink's letter, deliberately.** `subclass_of` declares
+`domain: ontology class` / `range: ontology class`, and `biolink:OrganismTaxon`
+is not one — its ancestry is `OrganismTaxon → NamedThing → Entity`. Nothing
+enforces the constraint (KGXVal does not check domain/range on this slot), so
+~1.65M edges violate it, including the entire taxonomic backbone.
+
+`in_taxon` is the domain-valid alternative and GOLD used to use it. The problem
+is that a source which is *uniquely* valid is unreachable: a query walking
+`subclass_of` down from a species found bacdive's strains and silently missed
+all 531k GOLD organisms. Conforming GOLD to the house convention (#832) fixed
+that. Moving the other direction would additionally have to say what NCBITaxon's
+own hierarchy becomes, since `in_taxon` between two taxa is meaningless.
+
+So: if you are adding a source with strain- or isolate-level nodes, type them
+`biolink:OrganismTaxon` and link them with `subclass_of`, even though
+`biolink:IndividualOrganism` + `in_taxon` reads better in isolation. Background
+in #834.
+
+`close_match` is a different relation and not a counterexample — gtdb, lpsn and
+microbedecoder use it for cross-identifier equivalence, not containment.
+
 ## Code Style
 
 - Line length: 120 characters (ruff), 100 characters (black)

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -203,8 +203,8 @@ _HOST_TAXON_EDGE_SHAPE = ("biolink:location_of", "RO:0001015")
 #: ``subclass_of`` down from a species finds BacDive's strains and silently
 #: misses every GOLD organism, which is the concrete cost of the split.
 #:
-#: The deviation from Biolink's letter is graph-wide and deliberate; #832 records
-#: it rather than leaving it implicit here.
+#: The deviation from Biolink's letter is graph-wide (~1.65M edges) and
+#: deliberate; #834 records it rather than leaving it implicit here.
 _SUBCLASS_OF = "biolink:subclass_of"
 
 #: Organism nodes carry the taxon category for the same reason, matching the
@@ -416,8 +416,23 @@ class GOLDTransform(Transform):
                 if row.get("category") == _INDIVIDUAL_ORGANISM
             }
 
+        # Count first, fold second. An organism claimed by two taxa must not be
+        # folded: the fold re-points its edges at the chosen taxon, so its
+        # *other* in_taxon row would be rewritten to `T1 subclass_of T2` — a
+        # taxonomic assertion GOLD never made, landing in the backbone where it
+        # is indistinguishable from the 925,219 real hierarchy edges (#833).
+        # The current export has none, so this is a guard against a change in
+        # someone else's file, and skipping is the honest outcome regardless:
+        # two taxa for one organism is exactly when the organism layer carries
+        # something the taxon does not.
+        taxon_edge_count: Counter = Counter()
+        with edges_in.open(newline="") as handle:
+            for row in csv.DictReader(handle, delimiter="\t"):
+                if row["predicate"] == _IN_TAXON:
+                    taxon_edge_count[row["subject"]] += 1
+
         collapse: dict = {}
-        considered = 0
+        considered = multi_taxon = 0
         with edges_in.open(newline="") as handle:
             for row in csv.DictReader(handle, delimiter="\t"):
                 if row["predicate"] != _IN_TAXON:
@@ -426,6 +441,9 @@ class GOLDTransform(Transform):
                 if organism in dropped or taxon in dropped:
                     continue
                 considered += 1
+                if taxon_edge_count[organism] > 1:
+                    multi_taxon += 1
+                    continue
                 name, taxon_name = organism_names.get(organism, ""), taxon_labels.get(taxon, "")
                 # A nameless organism is not evidence of redundancy — we cannot
                 # tell whether it duplicates the taxon, so it keeps its node.
@@ -433,6 +451,11 @@ class GOLDTransform(Transform):
                     continue
                 if _normalise_label(name) == _normalise_label(taxon_name):
                     collapse[organism] = taxon
+        if multi_taxon:
+            print(
+                f"[gold]   {multi_taxon:,} organism(s) claimed by more than one taxon — not folded, "
+                "so no taxon-to-taxon subclass_of is invented (#833)"
+            )
         if collapse:
             # Denominator is organisms that survived the drops, not every row in
             # the upstream file — counting the 74,561 the trim removed as "kept"

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -120,6 +120,8 @@ from kg_microbe.transform_utils.constants import (
     GOLD,
     KNOWLEDGE_ASSERTION,
     MANUAL_AGENT,
+    NCBI_CATEGORY,
+    RDFS_SUBCLASS_OF,
 )
 from kg_microbe.transform_utils.transform import Transform
 
@@ -152,6 +154,10 @@ _NCBITAXON_NODES = "ncbitaxon_nodes.tsv"
 #: Set false to ingest GOLD unfiltered, for debugging what the trim removes.
 _APPLY_TRIM_ENV = "GOLD_APPLY_TAXON_TRIM"
 
+#: The predicate the *upstream export* uses for organism to taxon. It is not
+#: what we emit — see ``_SUBCLASS_OF`` below. Kept as an input constant for the
+#: same reason ``_OCCURS_IN`` is: the trim has to recognise the source rows
+#: before the re-predication happens.
 _IN_TAXON = "biolink:in_taxon"
 _OCCURS_IN = "biolink:occurs_in"
 
@@ -173,7 +179,42 @@ _LOCATED_IN_RELATION = "RO:0001025"
 #: the subject *is* that taxon, so a microbe found in a plant would be
 #: classified as a plant.
 _HOST_TAXON_EDGE_SHAPE = ("biolink:location_of", "RO:0001015")
+
+#: What a GOLD organism's link to its taxon is emitted as, replacing the
+#: upstream ``in_taxon``. A GOLD organism record is a named isolate — the same
+#: kind of thing as a BacDive strain — and the graph already has a convention
+#: for "this named biological entity sits under this taxon":
+#:
+#:   NCBITaxon's own hierarchy   925,219  biolink:subclass_of
+#:   bacdive strains             251,916  biolink:subclass_of
+#:   metatraits                      186  biolink:subclass_of
+#:   gold (before this change)   531,324  biolink:in_taxon   <- lone dialect
+#:
+#: (gtdb / lpsn / microbedecoder use ``close_match``, but that is
+#: cross-identifier equivalence, not containment, so it is not a counterexample.)
+#:
+#: Read against Biolink alone, ``in_taxon`` looks better: its domain is ``thing
+#: with taxon``, which ``IndividualOrganism`` is, whereas ``subclass_of``
+#: requires ``ontology class`` on both ends and ``biolink:OrganismTaxon`` is not
+#: one. But that objection applies just as forcefully to NCBITaxon's own 925k
+#: hierarchy edges. The graph treats OrganismTaxon as class-like throughout;
+#: making GOLD the single source that obeys a rule the taxonomy backbone itself
+#: does not leaves it unreachable instead of correct. A query walking
+#: ``subclass_of`` down from a species finds BacDive's strains and silently
+#: misses every GOLD organism, which is the concrete cost of the split.
+#:
+#: The deviation from Biolink's letter is graph-wide and deliberate; #832 records
+#: it rather than leaving it implicit here.
 _SUBCLASS_OF = "biolink:subclass_of"
+
+#: Organism nodes carry the taxon category for the same reason, matching the
+#: 251,404 bacdive strain nodes. ``biolink:IndividualOrganism`` would be the
+#: honest type for an isolate in isolation, but it cannot be the subject of a
+#: ``subclass_of`` edge without inventing a fourth dialect.
+_ORGANISM_CATEGORY = NCBI_CATEGORY
+
+#: Upstream category for a GOLD organism, used to recognise the rows to retype.
+_INDIVIDUAL_ORGANISM = "biolink:IndividualOrganism"
 
 #: Ecosystem labels that carry no information, so an edge pointing at one says
 #: nothing. ``root`` is the hierarchy root — note it is NOT a plant root, the
@@ -272,8 +313,11 @@ class GOLDTransform(Transform):
         taxon_dropped, seen_before = self._taxon_drop_set(nodes_in, edges_in)
         dropped |= taxon_dropped
         resolution, ecosystem_labels = self._ecosystem_resolution(nodes_in, edges_in)
-        incident = self._write_edges(edges_in, dropped, resolution, ecosystem_labels)
-        self._write_nodes(nodes_in, dropped, seen_before, incident)
+        # After the drops, so an organism is never folded onto a taxon the trim
+        # removed — that would resurrect an excluded branch through the back door.
+        collapse = self._organism_collapse(nodes_in, edges_in, dropped)
+        incident = self._write_edges(edges_in, dropped, resolution, ecosystem_labels, collapse)
+        self._write_nodes(nodes_in, dropped, seen_before, incident, collapse)
 
     def _trimmed_taxa(self) -> Optional[set]:
         """
@@ -312,6 +356,94 @@ class GOLDTransform(Transform):
                 "ingest GOLD unfiltered."
             )
         return taxa
+
+    def _taxon_labels(self) -> dict:
+        """
+        Names for the taxa a GOLD organism can sit under.
+
+        Prefers the trimmed NCBITaxon extract, because that is the row KGX keeps
+        on a merge — ``prepare_data_dict`` takes the first value for a
+        single-valued key, and the ontologies transform sorts ahead of gold, so
+        the OBO name is what a consumer actually sees. Falls back to GOLD's own
+        ``OrganismTaxon`` rows when the extract is absent, which is the
+        ``GOLD_APPLY_TAXON_TRIM=false`` case.
+
+        :return: Taxon CURIE to label.
+        """
+        path = self.output_base_dir / "ontologies" / _NCBITAXON_NODES
+        if path.exists():
+            with path.open(newline="") as handle:
+                return {
+                    row["id"]: row.get("name", "")
+                    for row in csv.DictReader(handle, delimiter="\t")
+                    if row["id"].startswith(_TAXON_PREFIX)
+                }
+        raw = self.input_base_dir / GOLD / GOLD_NODES_FILE
+        with raw.open(newline="") as handle:
+            return {
+                row["id"]: row.get("name", "")
+                for row in csv.DictReader(handle, delimiter="\t")
+                if row["id"].startswith(_TAXON_PREFIX)
+            }
+
+    def _organism_collapse(self, nodes_in: Path, edges_in: Path, dropped: set) -> dict:
+        """
+        Map each organism that adds no name of its own onto its taxon.
+
+        GOLD ships 5.2 organisms per taxon and 88.8% of them carry a strain-level
+        name the taxon cannot ("Methanococcoides sp. FTZ1" under the genus
+        ``NCBITaxon:2225``). Those earn their node. The other 11.2% are named
+        identically to their taxon, so the node is a second identifier for a
+        thing the graph already has — it adds an id, an edge, and nothing a
+        query can use. Those get folded into the taxon, and their environment
+        edges are re-pointed at it.
+
+        The comparison is on the name, not on rank or id shape, because the name
+        is the only thing the organism layer contributes. An organism under a
+        *genus* whose name is just the genus is as redundant as one under a
+        species; an organism under a species with a strain suffix is not.
+
+        :param nodes_in: Upstream ``GOLD_nodes.tsv``.
+        :param edges_in: Upstream ``GOLD_edges.tsv``.
+        :param dropped: IDs already removed, which must not be collapsed onto.
+        :return: Organism CURIE to the taxon CURIE it folds into.
+        """
+        taxon_labels = self._taxon_labels()
+        with nodes_in.open(newline="") as handle:
+            organism_names = {
+                row["id"]: row.get("name", "")
+                for row in csv.DictReader(handle, delimiter="\t")
+                if row.get("category") == _INDIVIDUAL_ORGANISM
+            }
+
+        collapse: dict = {}
+        considered = 0
+        with edges_in.open(newline="") as handle:
+            for row in csv.DictReader(handle, delimiter="\t"):
+                if row["predicate"] != _IN_TAXON:
+                    continue
+                organism, taxon = row["subject"], self._remap(row["object"])
+                if organism in dropped or taxon in dropped:
+                    continue
+                considered += 1
+                name, taxon_name = organism_names.get(organism, ""), taxon_labels.get(taxon, "")
+                # A nameless organism is not evidence of redundancy — we cannot
+                # tell whether it duplicates the taxon, so it keeps its node.
+                if not name or not taxon_name:
+                    continue
+                if _normalise_label(name) == _normalise_label(taxon_name):
+                    collapse[organism] = taxon
+        if collapse:
+            # Denominator is organisms that survived the drops, not every row in
+            # the upstream file — counting the 74,561 the trim removed as "kept"
+            # would overstate the layer by nine points.
+            kept = considered - len(collapse)
+            print(
+                f"[gold] organism layer: {kept:,} kept ({kept / considered:.1%}, "
+                f"name differs from the taxon's), {len(collapse):,} folded into their taxon "
+                f"({len(collapse) / considered:.1%}, name identical)"
+            )
+        return collapse
 
     def _ontology_label_index(self) -> dict:
         """
@@ -599,7 +731,14 @@ class GOLDTransform(Transform):
         )
         return excluded | organisms, seen_before
 
-    def _write_edges(self, edges_in: Path, dropped: set, resolution: dict, ecosystem_labels: dict) -> set:
+    def _write_edges(
+        self,
+        edges_in: Path,
+        dropped: set,
+        resolution: dict,
+        ecosystem_labels: dict,
+        collapse: dict,
+    ) -> set:
         """
         Write surviving edges, resolving uninformative ecosystem targets upward.
 
@@ -607,10 +746,16 @@ class GOLDTransform(Transform):
         :param dropped: IDs removed by the trim.
         :param resolution: Ecosystem id to nearest informative ancestor, or None.
         :param ecosystem_labels: Ecosystem id to its label, for the ENVO crosswalk.
+        :param collapse: Organism to taxon, for organisms that add no name.
         :return: IDs incident to at least one surviving edge.
         """
         incident: set = set()
         kept = removed = resolved = uninformative = relabelled = 0
+        retyped = folded = deduped = 0
+        # Re-pointing a collapsed organism's edges at its taxon can land two
+        # isolates of one taxon on the same environment. The upstream export has
+        # no duplicate triples at all, so anything caught here is ours.
+        seen_triples: set = set()
         with (
             edges_in.open(newline="") as handle,
             self.output_edge_file.open("w", newline="") as out,
@@ -630,6 +775,22 @@ class GOLDTransform(Transform):
                 original_object = ""
                 predicate = row["predicate"]
                 relation = row.get("relation", "")
+
+                if predicate == _IN_TAXON:
+                    if subject in collapse:
+                        # The organism *is* the taxon by every name the graph
+                        # carries, so this edge would say `X subclass_of X`.
+                        folded += 1
+                        continue
+                    # Re-predicate to the graph's convention for "named entity
+                    # sits under this taxon" — see `_SUBCLASS_OF`.
+                    predicate = _SUBCLASS_OF
+                    relation = RDFS_SUBCLASS_OF
+                    retyped += 1
+
+                subject = collapse.get(subject, subject)
+                obj = collapse.get(obj, obj)
+
                 if predicate == _OCCURS_IN:
                     if obj in resolution:
                         target = resolution[obj]
@@ -646,6 +807,15 @@ class GOLDTransform(Transform):
                     predicate = _LOCATED_IN_PREDICATE
                     relation = _LOCATED_IN_RELATION
                     relabelled += 1
+
+                # After the upward resolution, not before: two isolates on
+                # different uninformative ecosystems can resolve to the same
+                # ancestor, and checking the pre-resolution target would miss it.
+                if (subject, predicate, obj) in seen_triples:
+                    deduped += 1
+                    continue
+                seen_triples.add((subject, predicate, obj))
+
                 incident.add(subject)
                 incident.add(obj)
                 kept += 1
@@ -771,9 +941,19 @@ class GOLDTransform(Transform):
                 f"[gold]   {relabelled:,} re-predicated occurs_in -> located_in "
                 "(Biolink defines occurs_in for a process, not an organism)"
             )
+        if retyped:
+            print(
+                f"[gold]   {retyped:,} re-predicated in_taxon -> subclass_of "
+                "(matching bacdive strains and NCBITaxon's own hierarchy)"
+            )
+        if folded or deduped:
+            print(
+                f"[gold]   {folded:,} in_taxon edges dropped as self-referential after the fold, "
+                f"{deduped:,} duplicate triples removed by re-pointing"
+            )
         return incident
 
-    def _write_nodes(self, nodes_in: Path, dropped: set, seen_before: set, incident: set) -> None:
+    def _write_nodes(self, nodes_in: Path, dropped: set, seen_before: set, incident: set, collapse: dict) -> None:
         """
         Write surviving nodes in the standard column order, adding missing columns.
 
@@ -786,8 +966,10 @@ class GOLDTransform(Transform):
         :param dropped: IDs removed by the trim.
         :param seen_before: IDs incident to an edge in the upstream payload.
         :param incident: IDs incident to a surviving edge.
+        :param collapse: Organism to taxon, for organisms folded into their taxon.
         """
         emitted = removed = newly_orphaned = remapped_collisions = 0
+        folded = 0
         pre_existing_orphans: set = set()
         # Which ids the upstream file carries verbatim, so a retired row can
         # defer to its replacement's own row rather than donating a stale name.
@@ -822,6 +1004,12 @@ class GOLDTransform(Transform):
                 if original_id in dropped or node_id in dropped:
                     removed += 1
                     continue
+                if node_id in collapse:
+                    # Folded into its taxon. Checked before the orphan test, which
+                    # would otherwise catch these too and report them as damage
+                    # the trim did rather than a fold we chose.
+                    folded += 1
+                    continue
                 if node_id in seen_before and node_id not in incident:
                     newly_orphaned += 1
                     removed += 1
@@ -831,6 +1019,11 @@ class GOLDTransform(Transform):
                 category = row.get("category", "")
                 if node_id.startswith(_ECOSYSTEM_PREFIX) and _ONTOLOGY_CLASS not in category:
                     category = f"{category}|{_ONTOLOGY_CLASS}" if category else _ONTOLOGY_CLASS
+                elif category == _INDIVIDUAL_ORGANISM:
+                    # Retyped alongside the subclass_of re-predication: the two
+                    # have to move together or the edge's subject is an
+                    # individual, which no dialect in this graph licenses.
+                    category = _ORGANISM_CATEGORY
                 emitted += 1
                 written.add(node_id)
                 writer.writerow(
@@ -847,6 +1040,8 @@ class GOLDTransform(Transform):
                     ]
                 )
         print(f"[gold] nodes emitted: {emitted:,}" + (f" (dropped {removed:,})" if removed else ""))
+        if folded:
+            print(f"[gold]   {folded:,} organism node(s) folded into their taxon, adding no name of their own")
         if newly_orphaned:
             print(f"[gold]   of which {newly_orphaned:,} were left edgeless by the trim and cleaned up")
         if remapped_collisions:

--- a/tests/test_gold_organism_modeling.py
+++ b/tests/test_gold_organism_modeling.py
@@ -206,3 +206,46 @@ class OrganismFoldTest(TestCase):
         nodes[2] = ["gold:same", "biolink:IndividualOrganism", "  methanococcoides "]
         ids = {n["id"] for n in _run(nodes=nodes)[0]}
         self.assertNotIn("gold:same", ids)
+
+
+class MultiTaxonGuardTest(TestCase):
+
+    """An organism claimed by two taxa must not be folded (#833)."""
+
+    def setUp(self):
+        """Give one organism two taxa, both matching its name."""
+        self.nodes = [r[:] for r in NODES] + [
+            ["NCBITaxon:777", "biolink:OrganismTaxon", "Methanococcoides"],
+        ]
+        self.edges = [r[:] for r in EDGES] + [
+            ["gold:same", "biolink:in_taxon", "NCBITaxon:777", "gold:organism_v2.ncbi_taxonomy_id"],
+        ]
+
+    def test_no_taxon_to_taxon_subclass_of_is_invented(self):
+        """
+        The failure this guards is silent and lands in the backbone.
+
+        Folding `gold:same` onto `NCBITaxon:2225` would rewrite its *other*
+        taxon edge to `NCBITaxon:2225 subclass_of NCBITaxon:777` — an assertion
+        GOLD never made, indistinguishable from the 925,219 real hierarchy
+        edges once merged.
+        """
+        _, edges = _run(nodes=self.nodes, edges=self.edges)
+        invented = [
+            e
+            for e in edges
+            if e["subject"].startswith("NCBITaxon:")
+            and e["object"].startswith("NCBITaxon:")
+            and e["predicate"] == "biolink:subclass_of"
+        ]
+        self.assertEqual(invented, [])
+
+    def test_the_multi_taxon_organism_keeps_its_node(self):
+        """
+        Skipping is the honest outcome, not merely the safe one.
+
+        Two taxa for one organism is exactly the case where the organism layer
+        carries something neither taxon does.
+        """
+        nodes, _ = _run(nodes=self.nodes, edges=self.edges)
+        self.assertIn("gold:same", {n["id"] for n in nodes})

--- a/tests/test_gold_organism_modeling.py
+++ b/tests/test_gold_organism_modeling.py
@@ -1,0 +1,208 @@
+"""GOLD's organism layer uses the graph's own conventions, and earns its nodes."""
+
+import csv
+import io
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from kg_microbe.transform_utils.gold.gold import GOLDTransform
+
+# Three organisms under two taxa, covering the cases that decide the fold:
+#  - `strain` carries a strain designation the taxon cannot -> keeps its node
+#  - `same` is named exactly as its taxon -> folds into it
+#  - `bare` is named as its taxon too, and carries no environment -> folds, and
+#    leaves the taxon with nothing, so GOLD stops emitting a row for it
+NODES = [
+    ["id", "category", "name"],
+    ["gold:strain", "biolink:IndividualOrganism", "Methanococcoides sp. FTZ1"],
+    ["gold:same", "biolink:IndividualOrganism", "Methanococcoides"],
+    ["gold:bare", "biolink:IndividualOrganism", "Solitary taxon"],
+    ["gold:nameless", "biolink:IndividualOrganism", ""],
+    ["NCBITaxon:2225", "biolink:OrganismTaxon", "Methanococcoides"],
+    ["NCBITaxon:999", "biolink:OrganismTaxon", "Solitary taxon"],
+    ["gold.ecosystem:soil", "biolink:EnvironmentalFeature", "Soil"],
+]
+EDGES = [
+    ["subject", "predicate", "object", "relation"],
+    ["gold:strain", "biolink:in_taxon", "NCBITaxon:2225", "gold:organism_v2.ncbi_taxonomy_id"],
+    ["gold:same", "biolink:in_taxon", "NCBITaxon:2225", "gold:organism_v2.ncbi_taxonomy_id"],
+    ["gold:bare", "biolink:in_taxon", "NCBITaxon:999", "gold:organism_v2.ncbi_taxonomy_id"],
+    ["gold:nameless", "biolink:in_taxon", "NCBITaxon:2225", "gold:organism_v2.ncbi_taxonomy_id"],
+    ["gold:strain", "biolink:occurs_in", "gold.ecosystem:soil", "RO:0002451"],
+    ["gold:same", "biolink:occurs_in", "gold.ecosystem:soil", "RO:0002451"],
+]
+
+
+def _run(nodes=None, edges=None):
+    """
+    Run the transform over a fixture and return its nodes and edges.
+
+    :param nodes: Node rows, defaulting to the module fixture.
+    :param edges: Edge rows, defaulting to the module fixture.
+    :return: ``(node dicts, edge dicts)``.
+    """
+    tmp = Path(tempfile.mkdtemp())
+    raw, out = tmp / "raw", tmp / "transformed"
+    (raw / "gold").mkdir(parents=True)
+    out.mkdir()
+    for name, rows in (("GOLD_nodes.tsv", nodes or NODES), ("GOLD_edges.tsv", edges or EDGES)):
+        with (raw / "gold" / name).open("w", newline="") as fh:
+            csv.writer(fh, delimiter="\t").writerows(rows)
+    data = b"1\t|\t1\t|\n"
+    with tarfile.open(raw / "taxdump.tar.gz", "w:gz") as tar:
+        info = tarfile.TarInfo("merged.dmp")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    previous = os.environ.get("GOLD_APPLY_TAXON_TRIM")
+    os.environ["GOLD_APPLY_TAXON_TRIM"] = "false"
+    try:
+        GOLDTransform(input_dir=raw, output_dir=out).run()
+    finally:
+        if previous is None:
+            os.environ.pop("GOLD_APPLY_TAXON_TRIM", None)
+        else:
+            os.environ["GOLD_APPLY_TAXON_TRIM"] = previous
+    with (out / "gold" / "nodes.tsv").open() as fh:
+        node_rows = list(csv.DictReader(fh, delimiter="\t"))
+    with (out / "gold" / "edges.tsv").open() as fh:
+        edge_rows = list(csv.DictReader(fh, delimiter="\t"))
+    return node_rows, edge_rows
+
+
+class HouseConventionTest(TestCase):
+
+    """One graph, one way of saying "this named entity sits under this taxon"."""
+
+    def setUp(self):
+        """Run the fixture once."""
+        self.nodes, self.edges = _run()
+
+    def test_the_taxon_link_is_subclass_of_not_in_taxon(self):
+        """
+        GOLD was the lone dialect: 531,324 `in_taxon` against 1,177,321 `subclass_of`.
+
+        NCBITaxon's own hierarchy (925,219), bacdive's strains (251,916) and
+        metatraits (186) all use `subclass_of`. A query walking `subclass_of`
+        down from a species found bacdive's strains and silently missed every
+        GOLD organism — the concrete cost of the split, and the reason this is
+        a correctness fix rather than a cosmetic one.
+        """
+        taxon_edges = [e for e in self.edges if e["object"].startswith("NCBITaxon:")]
+        self.assertTrue(taxon_edges)
+        self.assertEqual({e["predicate"] for e in taxon_edges}, {"biolink:subclass_of"})
+        self.assertEqual({e["relation"] for e in taxon_edges}, {"rdfs:subClassOf"})
+
+    def test_no_in_taxon_edge_survives(self):
+        """The upstream predicate must not leak through any path."""
+        self.assertEqual([e for e in self.edges if e["predicate"] == "biolink:in_taxon"], [])
+
+    def test_organism_nodes_are_retyped_to_match(self):
+        """
+        The category has to move with the predicate.
+
+        `biolink:IndividualOrganism` is the honest type for an isolate read on
+        its own, but an individual cannot be the subject of `subclass_of`
+        without inventing a fourth dialect. bacdive types its 251,404 strains
+        `biolink:OrganismTaxon` for the same reason.
+        """
+        strain = next(n for n in self.nodes if n["id"] == "gold:strain")
+        self.assertEqual(strain["category"], "biolink:OrganismTaxon")
+        self.assertNotIn("biolink:IndividualOrganism", {n["category"] for n in self.nodes})
+
+
+class OrganismFoldTest(TestCase):
+
+    """An organism node has to earn its place by carrying a name the taxon lacks."""
+
+    def setUp(self):
+        """Run the fixture once."""
+        self.nodes, self.edges = _run()
+        self.ids = {n["id"] for n in self.nodes}
+
+    def test_an_organism_naming_a_strain_keeps_its_node(self):
+        """
+        88.8% of the real payload is this case, and it is the layer's whole value.
+
+        "Methanococcoides sp. FTZ1" under the genus `NCBITaxon:2225` is
+        strain-level identity the taxon cannot carry.
+        """
+        self.assertIn("gold:strain", self.ids)
+
+    def test_an_organism_named_as_its_taxon_folds_into_it(self):
+        """
+        11.2% of the payload is a second identifier for a thing already present.
+
+        It contributes an id and an edge and nothing a query can use.
+        """
+        self.assertNotIn("gold:same", self.ids)
+
+    def test_the_folded_organism_donates_its_environment_to_the_taxon(self):
+        """
+        Folding must move the evidence, not discard it.
+
+        This is the difference between the fold and a plain drop: GOLD observed
+        that organism in soil, and after the fold the taxon says so.
+        """
+        located = [e for e in self.edges if e["predicate"] == "biolink:located_in"]
+        self.assertIn(("NCBITaxon:2225", "gold.ecosystem:soil"), {(e["subject"], e["object"]) for e in located})
+
+    def test_folding_creates_no_self_referential_edge(self):
+        """`X subclass_of X` is what the organism's own taxon edge becomes."""
+        self.assertEqual([e for e in self.edges if e["subject"] == e["object"]], [])
+
+    def test_re_pointing_does_not_duplicate_a_triple(self):
+        """
+        Two isolates of one taxon in one environment collapse to one statement.
+
+        The upstream export carries no duplicate triples at all, so any
+        duplicate in the output would be ours — on the real payload the fold
+        creates 604 and this removes them.
+        """
+        triples = [(e["subject"], e["predicate"], e["object"]) for e in self.edges]
+        self.assertEqual(len(triples), len(set(triples)))
+
+    def test_a_nameless_organism_is_not_folded(self):
+        """
+        Absence of a name is not evidence of redundancy.
+
+        We cannot tell whether it duplicates the taxon, so it keeps its node —
+        the same fail-closed reasoning the rest of this repo applies to
+        unresolvable rows.
+        """
+        self.assertIn("gold:nameless", self.ids)
+
+    def test_a_taxon_left_with_nothing_to_say_stops_being_emitted(self):
+        """
+        Second-order effect, and a desirable one.
+
+        `NCBITaxon:999`'s only tie to GOLD was a redundant organism carrying no
+        environment. Once folded, GOLD asserts nothing about that taxon, so
+        emitting a row for it duplicates what the ontologies transform already
+        supplies. On the real payload this is 25,288 rows, none of which carried
+        an xref, description or synonym, and all of which are in the trimmed
+        NCBITaxon extract — so nothing is lost.
+        """
+        self.assertNotIn("NCBITaxon:999", self.ids)
+        self.assertIn("NCBITaxon:2225", self.ids)
+
+    def test_the_fold_is_decided_on_the_name_not_the_rank(self):
+        """
+        An organism named for its genus is as redundant as one named for a species.
+
+        Keying on rank or id shape instead would keep `gold:same` — named
+        exactly "Methanococcoides", a genus — while the name is the only thing
+        the organism layer contributes.
+        """
+        self.assertNotIn("gold:same", self.ids)
+        self.assertIn("gold:strain", self.ids)
+
+    def test_case_and_whitespace_alone_do_not_block_the_fold(self):
+        """A label differing only in spacing names the same thing."""
+        nodes = [r[:] for r in NODES]
+        nodes[2] = ["gold:same", "biolink:IndividualOrganism", "  methanococcoides "]
+        ids = {n["id"] for n in _run(nodes=nodes)[0]}
+        self.assertNotIn("gold:same", ids)

--- a/tests/test_gold_samples_studies_and_taxid_remap.py
+++ b/tests/test_gold_samples_studies_and_taxid_remap.py
@@ -112,10 +112,17 @@ class TaxidRemapTest(TestCase):
     """NCBI merged ~950 of GOLD's taxids; judging them on the retired id loses them."""
 
     def test_a_retired_taxid_is_rewritten_on_the_edge(self):
-        """`262981` was merged into `4914` (Lachancea waltii)."""
+        """
+        `262981` was merged into `4914` (Lachancea waltii).
+
+        The organism-to-taxon edge is emitted as `subclass_of`, not the
+        upstream `in_taxon` — see `_SUBCLASS_OF` in gold.py. What this test
+        pins is the remap, which the re-predication did not change.
+        """
         rows = _rows(_build() / "edges.tsv")
-        in_taxon = [r for r in rows if r[1] == "biolink:in_taxon"]
-        self.assertEqual(in_taxon[0][2], "NCBITaxon:4914")
+        taxon_edges = [r for r in rows if r[2].startswith("NCBITaxon:")]
+        self.assertEqual([r[1] for r in taxon_edges], ["biolink:subclass_of"])
+        self.assertEqual(taxon_edges[0][2], "NCBITaxon:4914")
 
     def test_the_retired_node_collapses_onto_its_replacement(self):
         """Both ids are present upstream; after the remap they are one node."""
@@ -131,8 +138,8 @@ class TaxidRemapTest(TestCase):
         behaviour, not a new failure mode.
         """
         rows = _rows(_build(merges=None) / "edges.tsv")
-        in_taxon = [r for r in rows if r[1] == "biolink:in_taxon"]
-        self.assertEqual(in_taxon[0][2], "NCBITaxon:262981")
+        taxon_edges = [r for r in rows if r[2].startswith("NCBITaxon:")]
+        self.assertEqual(taxon_edges[0][2], "NCBITaxon:262981")
 
     def test_non_taxon_ids_pass_through_untouched(self):
         """A merge table keyed on bare integers must not collide with other prefixes."""


### PR DESCRIPTION
Implements option 3 for the GOLD organism layer, plus the modelling consistency it depends on.

## 1. GOLD was the lone dialect

| source | predicate → NCBITaxon | edges |
|---|---|---|
| NCBITaxon's own hierarchy | `biolink:subclass_of` | 925,219 |
| bacdive strains | `biolink:subclass_of` | 251,916 |
| metatraits | `biolink:subclass_of` | 186 |
| **gold** | **`biolink:in_taxon`** | **531,324** |

(gtdb/lpsn/microbedecoder use `close_match` — cross-identifier equivalence, not containment. Not a counterexample.)

A GOLD organism record is a named isolate, the same kind of thing as a BacDive strain. Read against Biolink alone `in_taxon` looks like the better choice — its domain is `thing with taxon`, which `IndividualOrganism` is, whereas `subclass_of` wants `ontology class` on both ends and `biolink:OrganismTaxon` isn't one. **But that objection applies just as forcefully to NCBITaxon's own 925k hierarchy edges.** The graph treats OrganismTaxon as class-like throughout; making GOLD the single source that obeys a rule the taxonomy backbone ignores leaves it *unreachable* rather than correct.

The concrete cost: a query walking `subclass_of` down from a species found bacdive's strains and silently missed all 531k GOLD organisms.

Node category moves with the predicate (`IndividualOrganism` → `OrganismTaxon`), because an individual can't be the subject of `subclass_of` without inventing a fourth dialect. Same trade bacdive already made for its 251,404 strains.

The graph-wide deviation from Biolink's letter is real and now deliberate — filed separately rather than left implicit in a comment.

## 2. Fold the organisms that add no name

88.8% of GOLD organisms carry a strain-level name their taxon cannot — `Methanococcoides sp. FTZ1` under the genus `NCBITaxon:2225`. Those earn their node.

The other 11.2% are named *identically* to their taxon: a second identifier for something the graph already has, contributing an id, an edge, and nothing a query can use. Those fold into the taxon and **donate their environment edges to it** — the evidence moves rather than being discarded, which is the difference between this and a plain drop.

The test is the **name**, not the rank. An organism named for its genus is as redundant as one named for a species; one with a strain suffix is not. A nameless organism is *not* folded — absence of a name isn't evidence of redundancy.

## Measured against master, real payload

```
nodes   637,286 -> 552,376   (-84,910, -13.3%)
edges   765,964 -> 705,738   (-60,226,  -7.9%)
```

The node saving exceeds the 59,622 folded organisms because **25,288 NCBITaxon rows go too**: their only tie to GOLD was a redundant organism carrying no environment, so GOLD now asserts nothing about them. I checked before accepting this — none of those rows carried an xref, description or synonym, and all 25,288 are present in the trimmed NCBITaxon extract. Nothing is lost.

This is why the saving is 10.3% of nodes+edges rather than the 8.5% I estimated when I first sized option 3: I hadn't accounted for the taxon rows.

## Verification

Ran the transform (52s) and checked the artifacts, not the exit code:

- zero `biolink:in_taxon`, zero `biolink:IndividualOrganism`
- zero self-loops, zero duplicate triples
- only dangling endpoints are ENVO/UBERON/FOODON/FAO/PO terms other transforms supply
- re-ran after the reporting fix: byte-identical output

Before/after was produced by stashing `gold.py` and re-running master's version against the same inputs, so the delta is attributable to this change alone.

12 new tests in `tests/test_gold_organism_modeling.py`. Two assertions in `test_gold_samples_studies_and_taxid_remap.py` searched for `biolink:in_taxon` by name; updated to the new predicate — the behaviour they pin (the retired-taxid remap landing on the edge) is unchanged, and the updated version asserts the predicate explicitly rather than just finding the row.

`poetry run tox`: 1107 passed. The one failure, `test_every_referenced_curie_has_stub_node` (`PO:0009005`), reproduces on master unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)