### PR TITLE
fix: derive ontologies_stubs DATA_INPUTS from what the collector reads

### DIFF
--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -69,7 +69,13 @@ from kg_microbe.transform_utils.constants import (
 )
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.isolation_source_mapping_utils import STUB_ONTOLOGY_CATEGORY
-from kg_microbe.utils.stub_curie_collection import collect_stub_curies
+from kg_microbe.utils.stub_curie_collection import (
+    DEFAULT_MAPPING_PATHS,
+    collect_stub_curies,
+)
+from kg_microbe.utils.stub_curie_collection import (
+    REPO_ROOT as _STUB_REPO_ROOT,
+)
 
 # Stub ontologies handled by this transform. Each entry maps the canonical
 # CURIE prefix (case-sensitive — must match how the prefix appears in
@@ -230,7 +236,17 @@ class OntologiesStubsTransform(Transform):
 
     """Emit one labelled stub node per referenced NCIT / mesh / BTO / PO / MICRO CURIE."""
 
-    DATA_INPUTS = ("mappings/isolation_source_to_ontology.tsv",)
+    #: Derived from the collector's own list rather than restated, so the two
+    #: cannot drift (#839). Hand-maintaining it declared 1 of the 11 files this
+    #: transform reads, which made `kgm-freshness-check` — which consults
+    #: nothing but `DATA_INPUTS` — report the output fresh after a change to any
+    #: of the other ten. That is the #812 blind spot, and this was the last
+    #: transform still carrying it.
+    #:
+    #: Note this makes the SSSOM dependency visible: `DEFAULT_MAPPING_PATHS[0]`
+    #: is the unified mapping set, so `ontologies_stubs` is *not* independent of
+    #: an incoming MIM release, which the one-file declaration implied it was.
+    DATA_INPUTS = tuple(sorted(path.relative_to(_STUB_REPO_ROOT).as_posix() for path in DEFAULT_MAPPING_PATHS))
 
     def __init__(
         self,

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -246,7 +246,18 @@ class OntologiesStubsTransform(Transform):
     #: Note this makes the SSSOM dependency visible: `DEFAULT_MAPPING_PATHS[0]`
     #: is the unified mapping set, so `ontologies_stubs` is *not* independent of
     #: an incoming MIM release, which the one-file declaration implied it was.
-    DATA_INPUTS = tuple(sorted(path.relative_to(_STUB_REPO_ROOT).as_posix() for path in DEFAULT_MAPPING_PATHS))
+    #: Paths outside the repo are skipped rather than raising. This runs at
+    #: class-definition time, so `relative_to` raising would surface as an
+    #: ImportError from a tuple comprehension — breaking every importer, and
+    #: pointing nowhere near the entry that caused it (#841). An out-of-repo
+    #: path is not git-checkable anyway, so dropping it loses no signal.
+    DATA_INPUTS = tuple(
+        sorted(
+            path.relative_to(_STUB_REPO_ROOT).as_posix()
+            for path in DEFAULT_MAPPING_PATHS
+            if path.is_relative_to(_STUB_REPO_ROOT)
+        )
+    )
 
     def __init__(
         self,

--- a/kg_microbe/transform_utils/transform.py
+++ b/kg_microbe/transform_utils/transform.py
@@ -48,6 +48,12 @@ class Transform:
     #: Paths are relative to the repo root. Keep them tracked in git — the
     #: freshness check uses commit time, not mtime, because `git checkout`
     #: rewrites mtimes without changing content (#797).
+    #:
+    #: List **every** curation file read, not a representative one. A partial
+    #: declaration fails silently and looks identical to a complete one:
+    #: ontologies_stubs declared 1 of the 11 files it read and was reported
+    #: fresh after changes to the other ten (#839). Where the set comes from a
+    #: constant, derive this from it rather than restating it.
     DATA_INPUTS: tuple = ()
 
     def __init__(

--- a/tests/test_data_inputs_cover_reads.py
+++ b/tests/test_data_inputs_cover_reads.py
@@ -62,19 +62,35 @@ class OntologiesStubsDeclarationTest(TestCase):
             OntologiesStubsTransform.DATA_INPUTS,
         )
 
-    def test_declared_paths_are_repo_relative_and_resolvable(self):
+    def test_declared_paths_are_repo_relative_and_tracked(self):
         """
-        The checker resolves these against the repo root and asks git about them.
+        Assert the property the consumer actually uses: git-trackedness (#843).
 
-        An absolute path, or one that does not exist, silently contributes no
-        staleness signal — a declaration that looks complete but is inert.
-        `DEFAULT_MAPPING_PATHS` documents that missing files are skipped by the
-        *collector*, so absence is tolerated there; it must not be tolerated
-        here, where it would mean a typo reads as "nothing changed".
+        `_latest_data_input_commit` resolves each entry through `_latest_commit`,
+        which asks git. An untracked-but-present file returns `(None, None)` and
+        is skipped in silence, so checking `is_file()` — as the first version of
+        this test did — passes on a declaration that contributes no staleness
+        signal at all. That is #839 one layer down: complete on paper, partly
+        inert in fact.
+
+        The repo-relative assertion stays, and fails differently: `REPO / "/abs"`
+        resolves to the absolute path, so an absolute entry can *succeed* while
+        measuring a file outside the repo entirely.
         """
+        import subprocess
+
         for declared in OntologiesStubsTransform.DATA_INPUTS:
             self.assertFalse(Path(declared).is_absolute(), f"{declared} is absolute")
-            self.assertTrue((REPO / declared).is_file(), f"{declared} does not exist")
+            tracked = subprocess.run(  # noqa: S603 - fixed argv, paths from our own constant
+                ["/usr/bin/git", "ls-files", "--error-unmatch", declared],  # noqa: S607
+                cwd=REPO,
+                capture_output=True,
+            )
+            self.assertEqual(
+                tracked.returncode,
+                0,
+                f"{declared} is not tracked in git, so the freshness check silently ignores it",
+            )
 
     def test_the_collector_has_no_second_undeclared_source(self):
         """

--- a/tests/test_data_inputs_cover_reads.py
+++ b/tests/test_data_inputs_cover_reads.py
@@ -1,0 +1,92 @@
+"""A transform's declared DATA_INPUTS must cover what it actually reads (#839)."""
+
+import inspect
+from pathlib import Path
+from unittest import TestCase
+
+from kg_microbe.transform_utils.ontologies_stubs.ontologies_stubs_transform import (
+    OntologiesStubsTransform,
+)
+from kg_microbe.utils import stub_curie_collection
+from kg_microbe.utils.stub_curie_collection import DEFAULT_MAPPING_PATHS, REPO_ROOT
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+class OntologiesStubsDeclarationTest(TestCase):
+
+    """The freshness checker reads DATA_INPUTS and nothing else."""
+
+    def test_every_collected_mapping_file_is_declared(self):
+        """
+        Hand-maintaining the list declared 1 of the 11 files this transform reads.
+
+        `kgm-freshness-check` consults `DATA_INPUTS` alone, so the other ten
+        could change and the output would still be reported fresh — the #812
+        blind spot. This was the last transform carrying it.
+        """
+        declared = set(OntologiesStubsTransform.DATA_INPUTS)
+        collected = {path.relative_to(REPO_ROOT).as_posix() for path in DEFAULT_MAPPING_PATHS}
+        self.assertEqual(
+            collected - declared,
+            set(),
+            "collect_stub_curies reads these but DATA_INPUTS does not declare them",
+        )
+
+    def test_the_declaration_is_derived_rather_than_restated(self):
+        """
+        Two hand-kept copies of one list drift; that is how this defect arose.
+
+        Asserting only that the sets match today would let someone "fix" a
+        future mismatch by pasting a literal back in, which reintroduces the
+        drift the derivation exists to prevent.
+        """
+        source = inspect.getsource(OntologiesStubsTransform)
+        # Anchor on the assignment, not the bare name. The comment above it
+        # discusses `DATA_INPUTS` and `DEFAULT_MAPPING_PATHS` in prose, so
+        # splitting on the name alone captured the comment and passed against a
+        # hardcoded literal — caught by reverting the fix and re-running.
+        declaration = source.split("DATA_INPUTS = ")[1].split("def ")[0]
+        self.assertIn("DEFAULT_MAPPING_PATHS", declaration)
+
+    def test_the_sssom_dependency_is_visible(self):
+        """
+        The one-file declaration implied this transform was SSSOM-independent.
+
+        It is not: `DEFAULT_MAPPING_PATHS[0]` is the unified mapping set, so an
+        incoming MIM release makes this output stale. Getting that wrong means
+        skipping this transform in a rebuild and merging stale stub nodes.
+        """
+        self.assertIn(
+            "mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",
+            OntologiesStubsTransform.DATA_INPUTS,
+        )
+
+    def test_declared_paths_are_repo_relative_and_resolvable(self):
+        """
+        The checker resolves these against the repo root and asks git about them.
+
+        An absolute path, or one that does not exist, silently contributes no
+        staleness signal — a declaration that looks complete but is inert.
+        `DEFAULT_MAPPING_PATHS` documents that missing files are skipped by the
+        *collector*, so absence is tolerated there; it must not be tolerated
+        here, where it would mean a typo reads as "nothing changed".
+        """
+        for declared in OntologiesStubsTransform.DATA_INPUTS:
+            self.assertFalse(Path(declared).is_absolute(), f"{declared} is absolute")
+            self.assertTrue((REPO / declared).is_file(), f"{declared} does not exist")
+
+    def test_the_collector_has_no_second_undeclared_source(self):
+        """
+        Guard the derivation's premise, not just its output.
+
+        `DATA_INPUTS` is derived from `DEFAULT_MAPPING_PATHS`, so it is only
+        complete while that constant is the collector's sole source of files.
+        If someone adds a second list, or globs `mappings/`, the derivation
+        keeps passing every other test here while quietly under-declaring
+        again.
+        """
+        source = inspect.getsource(stub_curie_collection)
+        body = source.split("def collect_stub_curies")[1]
+        self.assertNotIn(".glob(", body, "collector globs for files outside DEFAULT_MAPPING_PATHS")
+        self.assertNotIn(".rglob(", body, "collector globs for files outside DEFAULT_MAPPING_PATHS")

--- a/tests/test_data_inputs_cover_reads.py
+++ b/tests/test_data_inputs_cover_reads.py
@@ -90,3 +90,27 @@ class OntologiesStubsDeclarationTest(TestCase):
         body = source.split("def collect_stub_curies")[1]
         self.assertNotIn(".glob(", body, "collector globs for files outside DEFAULT_MAPPING_PATHS")
         self.assertNotIn(".rglob(", body, "collector globs for files outside DEFAULT_MAPPING_PATHS")
+
+
+class OutOfRepoPathTest(TestCase):
+
+    """The derivation must not turn a config mistake into an ImportError (#841)."""
+
+    def test_a_path_outside_the_repo_is_skipped_not_raised(self):
+        """
+        `relative_to` raises; this runs in a class body, so it raises at import.
+
+        That breaks every importer of the module and points the traceback at a
+        tuple comprehension rather than at the entry someone just added. An
+        out-of-repo path carries no git signal anyway, so skipping it loses
+        nothing the checker could have used.
+        """
+        # Never opened — only its position relative to the repo root matters.
+        outside = Path(REPO_ROOT).parent / "elsewhere" / "mappings" / "external.tsv"
+        kept = sorted(
+            p.relative_to(REPO_ROOT).as_posix()
+            for p in (*DEFAULT_MAPPING_PATHS, outside)
+            if p.is_relative_to(REPO_ROOT)
+        )
+        self.assertEqual(len(kept), len(DEFAULT_MAPPING_PATHS))
+        self.assertNotIn("external.tsv", " ".join(kept))


### PR DESCRIPTION
Closes #839.

## The gap

`OntologiesStubsTransform` declared **one** mapping file:

```python
DATA_INPUTS = ("mappings/isolation_source_to_ontology.tsv",)
```

and read **eleven**, via `stub_curie_collection.DEFAULT_MAPPING_PATHS`. `kgm-freshness-check` consults `DATA_INPUTS` and nothing else, so a change to any of the other ten left the output reported fresh when it wasn't.

That's the #812 blind spot — the same defect class that let a merged KG silently ship without the #778/#786 corrections. A sweep of every transform declaring `DATA_INPUTS` shows this was the **last one** still carrying it; bacdive, mediadive, madin_etal, metatraits, microbedecoder and ctd all declare what they read.

## It was already biting, twice

The currently-failing `test_every_referenced_curie_has_stub_node` concerns `PO:0009005`, which enters through `madin_environment_id_corrections.tsv` — an undeclared input. So the checker attributed that staleness entirely to code.

More consequentially, it gave the wrong answer to "what can be re-run ahead of the incoming MIM SSSOM". `DEFAULT_MAPPING_PATHS[0]` **is** the unified mapping set, so `ontologies_stubs` is SSSOM-dependent. On the strength of the one-file declaration I was about to call it safe to re-run early; it isn't, and doing so would have meant re-running it again after the SSSOM lands.

## The fix

Derived from the constant rather than restated, so the two cannot drift.

## Tests

Five, and I verified them by reverting to the old literal and re-running — **three fail**, which is what makes them worth having.

That exercise caught a defect in one of my own tests: `test_the_declaration_is_derived_rather_than_restated` split on the bare string `"DATA_INPUTS"`, which appears in the *prose of the comment* above the assignment, so it captured the comment's own mention of `DEFAULT_MAPPING_PATHS` and passed against a hardcoded literal. Now anchored on the assignment. Without the negative run it would have shipped as a test that could never fail.

Two of the five guard the derivation's *premise* rather than its output:
- no declared path is absolute or missing — either reads to the checker as "nothing changed", so a typo would produce a declaration that looks complete and is inert
- `collect_stub_curies` doesn't glob for files outside the constant, which would under-declare again while every other test here kept passing

`poetry run tox`: 1134 passed. The one failure, `test_every_referenced_curie_has_stub_node`, reproduces on master unchanged — it needs `kg transform -s ontologies_stubs`, which is on hold for the SSSOM (and this PR is part of why that ordering is now correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)