### PR TITLE
fix: make freshness content-based, closing the timestamp class

### DIFF
--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -295,6 +295,40 @@ def _list_transform_sources() -> list[str]:
     return out
 
 
+def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
+    """
+    Compare the recorded fingerprint against the current code and data.
+
+    :param source: Transform source name.
+    :param code_dir: The transform's package directory.
+    :return: ``(status, note)``, or None when there is no usable marker and the
+        caller should fall back to comparing timestamps.
+    """
+    try:
+        from kg_microbe.utils.transform_fingerprint import (
+            code_fingerprint,
+            data_fingerprint,
+            read_fingerprint,
+        )
+    except ImportError:
+        return None
+
+    for name in OUTPUT_DIR_ALIASES.get(source, (source,)):
+        recorded = read_fingerprint(TRANSFORMED_DIR / name)
+        if recorded is None:
+            continue
+        code_stale = recorded.get("code") != code_fingerprint(code_dir)
+        data_stale = recorded.get("data") != data_fingerprint(REPO, _declared_data_inputs(source))
+        if code_stale and data_stale:
+            return "STALE_VS_CODE_AND_DATA", f"code and data differ from the recorded build; rerun `poetry run kg transform -s {source}`"
+        if code_stale:
+            return "STALE_VS_CODE", f"code differs from the recorded build; rerun `poetry run kg transform -s {source}`"
+        if data_stale:
+            return "STALE_VS_DATA", f"a declared data input differs from the recorded build; rerun `poetry run kg transform -s {source}`"
+        return "FRESH", "verified by content fingerprint"
+    return None
+
+
 def check_source(source: str, ref: str) -> SourceReport:
     """Evaluate freshness for one transform source."""
     code_dir = TRANSFORM_ROOT / source
@@ -314,6 +348,33 @@ def check_source(source: str, ref: str) -> SourceReport:
     commit_ts, commit_sha = _latest_commit(code_dir, ref)
     local = _has_local_diff(code_dir, ref)
     out_mtime = _output_mtime(source)
+
+    # Prefer the fingerprint the transform recorded, when there is one. It
+    # compares bytes, which is the only signal that survives routine git
+    # operations: `git checkout` rewrites an mtime with no content change
+    # (#797), and a squash merge advances commit time for content that already
+    # existed (#836). Both produced confident "stale" verdicts on output that
+    # was byte-for-byte current, and a pre-flight that cries wolf gets ignored.
+    # Consulted even when the branch diverges from `ref`. `LOCAL_CHANGES` exists
+    # because a *timestamp* comparison against master is undefined mid-branch —
+    # but a content comparison is not. "Does this output match the code sitting
+    # here right now" is both answerable and the question a pre-flight actually
+    # wants, so the fingerprint answers it rather than deferring.
+    if out_mtime is not None:
+        verdict = _fingerprint_verdict(source, code_dir)
+        if verdict is not None:
+            status, note = verdict
+            if local:
+                note = f"{note} (vs the working tree; branch diverges from {ref})"
+            return SourceReport(
+                source=source,
+                status=status,
+                code_commit_ts=commit_ts,
+                code_commit_sha=commit_sha,
+                output_mtime=out_mtime,
+                local_changes=local,
+                note=note,
+            )
 
     if out_mtime is None:
         status = "MISSING_OUTPUT"

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -1,5 +1,6 @@
 """Transform module."""
 
+import inspect
 from pathlib import Path
 from typing import List, Optional
 
@@ -46,6 +47,7 @@ from kg_microbe.transform_utils.ontologies_stubs.ontologies_stubs_transform impo
 )
 from kg_microbe.transform_utils.prego.prego import PregoTransform
 from kg_microbe.transform_utils.rhea_mappings.rhea_mappings import RheaMappingsTransform
+from kg_microbe.utils.transform_fingerprint import write_fingerprint
 
 DATA_SOURCES = {
     # "DrugCentralTransform": DrugCentralTransform,
@@ -134,7 +136,39 @@ def transform(
             t.run(show_status=show_status)
 
         written = _describe_output(t, source)
+        # After the outputs, so a run that dies partway leaves no marker
+        # claiming its output matches the current inputs. Central here rather
+        # than in each transform: every source gets it, and none can forget.
+        _record_fingerprint(t, source)
         print(f"[transform] {source}: done — {written}", flush=True)
+
+
+def _record_fingerprint(transform_obj, source: str) -> None:
+    """
+    Record what produced this output, for content-based freshness checks.
+
+    Timestamps do not survive routine git operations — `git checkout` rewrites
+    an mtime with no content change (#797), and a squash merge advances commit
+    time for content that already existed (#836). Both produced false "stale"
+    verdicts on output that was byte-for-byte current.
+
+    Best-effort: a transform that ran successfully must not be reported as
+    failed because bookkeeping could not be written. A missing marker degrades
+    to the timestamp comparison, which is what every consumer did before.
+
+    :param transform_obj: The transform that just ran.
+    :param source: Registered source name.
+    """
+    try:
+        code_dir = Path(inspect.getsourcefile(type(transform_obj))).parent
+        write_fingerprint(
+            output_dir=transform_obj.output_dir,
+            code_dir=code_dir,
+            repo_root=Path(__file__).resolve().parent.parent,
+            data_inputs=getattr(type(transform_obj), "DATA_INPUTS", ()),
+        )
+    except Exception as exc:  # noqa: BLE001 - bookkeeping must not fail the run
+        print(f"[transform] {source}: could not record fingerprint ({exc})", flush=True)
 
 
 def _describe_output(transform_obj, source: str) -> str:

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -106,7 +106,6 @@ published checksum, and the six ``Saccharomyces`` rows that lose their hybrid
 """
 
 import csv
-import hashlib
 import io
 import os
 import re
@@ -230,13 +229,6 @@ _ORIGINAL_OBJECT = "original_object"
 #: The GOLD ecosystem classification as OWL, carrying curated ENVO mappings.
 #: Joined on **label**, because the ontology uses label-derived IRIs
 #: (``GOLDVOCAB:Paddy-field/soil``) while the export uses numeric ids.
-#: Written beside the output, holding the SHA-256 of the module that produced
-#: it. The merge guard compares content rather than timestamps: `git checkout`
-#: rewrites mtimes with no content change, and a squash merge mints a fresh
-#: commit for content that already existed, so both mtime and commit time
-#: false-positive on output that is perfectly current (#835).
-_SOURCE_CHECKSUM_FILE = "source_checksum.txt"
-
 _GOLD_ONTOLOGY_FILE = "gold_ontology.owl"
 _ENVO_PREFIX = "ENVO:"
 
@@ -326,22 +318,6 @@ class GOLDTransform(Transform):
         collapse = self._organism_collapse(nodes_in, edges_in, dropped)
         incident = self._write_edges(edges_in, dropped, resolution, ecosystem_labels, collapse)
         self._write_nodes(nodes_in, dropped, seen_before, incident, collapse)
-        # Last, so a run that died partway leaves no marker claiming the output
-        # matches this code.
-        self._write_source_checksum()
-
-    @staticmethod
-    def source_checksum() -> str:
-        """
-        SHA-256 of this module's source.
-
-        :return: Hex digest of ``gold.py`` as it exists on disk.
-        """
-        return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
-
-    def _write_source_checksum(self) -> None:
-        """Record which code produced this output, for the merge staleness guard."""
-        (self.output_dir / _SOURCE_CHECKSUM_FILE).write_text(self.source_checksum() + "\n", encoding="utf-8")
 
     def _trimmed_taxa(self) -> Optional[set]:
         """

--- a/kg_microbe/utils/transform_fingerprint.py
+++ b/kg_microbe/utils/transform_fingerprint.py
@@ -1,0 +1,132 @@
+"""
+Record which code and curation data produced a transform's output.
+
+Freshness detection has been timestamp-based, and timestamps do not survive
+routine git operations. Two failure modes, both observed:
+
+- ``git checkout`` rewrites a tracked file's mtime with no content change, so
+  visiting another branch flips the verdict (#797). Moving to commit time fixed
+  that one.
+- A **squash merge** mints a new commit for content that already existed, so
+  commit time jumps forward while the bytes stay identical (#836). #832 squashed
+  at 19:30 for code the gold transform had already run against at 19:06, and the
+  guard reported stale output that was byte-for-byte current.
+
+Content is the only signal immune to both. A transform writes a fingerprint of
+its inputs beside its output; anything comparing them asks whether the bytes
+match rather than which timestamp is larger.
+
+Code and data are fingerprinted separately so a stale output can still say
+*why* — the distinction `kgm-freshness-check` reports as ``STALE_VS_CODE``
+versus ``STALE_VS_DATA``.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Optional
+
+from kg_microbe.utils.atomic_io import atomic_write
+
+#: Filename written beside ``nodes.tsv`` / ``edges.tsv``.
+FINGERPRINT_FILE = "source_fingerprint.json"
+
+#: Bumped when the hashing scheme changes, so an old marker is treated as
+#: absent rather than silently compared under different rules.
+FINGERPRINT_VERSION = 1
+
+
+def _hash_files(paths: Iterable[Path]) -> str:
+    """
+    Hash a set of files by path and content, order-independently.
+
+    The path is folded in as well as the bytes, so renaming a file — which
+    changes what runs without changing any content — is a different
+    fingerprint. Missing files are folded in as such rather than skipped: a
+    deleted curation file is a change, and skipping it would read as no change.
+
+    :param paths: Files to fingerprint.
+    :return: Hex digest.
+    """
+    digest = hashlib.sha256()
+    for path in sorted(set(paths), key=lambda p: p.as_posix()):
+        digest.update(path.as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        try:
+            digest.update(hashlib.sha256(path.read_bytes()).digest())
+        except OSError:
+            digest.update(b"<absent>")
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def code_fingerprint(code_dir: Path) -> str:
+    """
+    Fingerprint every Python file in a transform's package directory.
+
+    Directory rather than the single module, matching what the freshness check
+    already treats as "this transform's code": several transforms are split
+    across helper modules in the same package, and a change to one of those
+    changes the output just as much.
+
+    :param code_dir: e.g. ``kg_microbe/transform_utils/gold``.
+    :return: Hex digest, or the digest of nothing when the directory is absent.
+    """
+    return _hash_files(code_dir.rglob("*.py")) if code_dir.is_dir() else _hash_files([])
+
+
+def data_fingerprint(repo_root: Path, data_inputs: Iterable[str]) -> str:
+    """
+    Fingerprint a transform's declared curation inputs.
+
+    :param repo_root: Repository root, which ``DATA_INPUTS`` are relative to.
+    :param data_inputs: Repo-relative paths from ``Transform.DATA_INPUTS``.
+    :return: Hex digest.
+    """
+    return _hash_files(repo_root / rel for rel in data_inputs)
+
+
+def write_fingerprint(output_dir: Path, code_dir: Path, repo_root: Path, data_inputs: Iterable[str]) -> dict:
+    """
+    Record the fingerprint of a completed run.
+
+    Call **after** the outputs are written, so a run that dies partway leaves
+    no marker claiming its output matches the current inputs. Written through
+    ``atomic_write`` for the same reason a torn marker would be worse than none.
+
+    :param output_dir: Where the transform wrote its TSVs.
+    :param code_dir: The transform's package directory.
+    :param repo_root: Repository root.
+    :param data_inputs: Repo-relative curation paths.
+    :return: The recorded payload.
+    """
+    payload = {
+        "version": FINGERPRINT_VERSION,
+        "code": code_fingerprint(code_dir),
+        "data": data_fingerprint(repo_root, data_inputs),
+    }
+    with atomic_write(output_dir / FINGERPRINT_FILE, encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return payload
+
+
+def read_fingerprint(output_dir: Path) -> Optional[dict]:
+    """
+    Read a recorded fingerprint, if one is present and readable.
+
+    A marker from a different scheme version, or one that will not parse, reads
+    as absent. Callers fall back to their timestamp comparison in that case,
+    which is weaker but defined — better than asserting a mismatch on a marker
+    we cannot interpret.
+
+    :param output_dir: Directory holding the transform's output.
+    :return: The payload, or None.
+    """
+    path = output_dir / FINGERPRINT_FILE
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict) or payload.get("version") != FINGERPRINT_VERSION:
+        return None
+    return payload

--- a/tests/test_gold_merge_wiring.py
+++ b/tests/test_gold_merge_wiring.py
@@ -1,6 +1,7 @@
 """GOLD's merge wiring: prefixes, taxon overlap, and name-conflict resolution."""
 
 import csv
+import inspect
 from pathlib import Path
 from unittest import TestCase
 
@@ -134,17 +135,19 @@ class StaleOutputGuardTest(TestCase):
         absence is a different situation from staleness.
         """
         from kg_microbe.transform_utils.gold.gold import GOLDTransform
+        from kg_microbe.utils.transform_fingerprint import code_fingerprint, read_fingerprint
 
         out = REPO_ROOT / "data" / "transformed" / "gold"
         if not (out / "nodes.tsv").is_file():
             self.skipTest("gold transform output not built")
-        marker = out / "source_checksum.txt"
-        if not marker.is_file():
-            self.skipTest("output predates the checksum marker; re-run `poetry run kg transform -s gold`")
+        recorded = read_fingerprint(out)
+        if recorded is None:
+            self.skipTest("output predates the fingerprint marker; re-run `poetry run kg transform -s gold`")
+        code_dir = Path(inspect.getsourcefile(GOLDTransform)).parent
         self.assertEqual(
-            marker.read_text(encoding="utf-8").strip(),
-            GOLDTransform.source_checksum(),
-            "data/transformed/gold/ was built by a different version of gold.py, and gold is "
-            "in the merge configs — merging would ingest the wrong shape. Run "
+            recorded["code"],
+            code_fingerprint(code_dir),
+            "data/transformed/gold/ was built by a different version of the gold transform, and "
+            "gold is in the merge configs — merging would ingest the wrong shape. Run "
             "`poetry run kg transform -s gold` before merging.",
         )

--- a/tests/test_transform_fingerprint.py
+++ b/tests/test_transform_fingerprint.py
@@ -1,0 +1,117 @@
+"""Content fingerprints, because timestamps do not survive git (#797, #836)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from kg_microbe.utils.transform_fingerprint import (
+    FINGERPRINT_FILE,
+    code_fingerprint,
+    data_fingerprint,
+    read_fingerprint,
+    write_fingerprint,
+)
+
+
+class FingerprintTest(TestCase):
+
+    """The properties the freshness verdict rests on."""
+
+    def setUp(self):
+        """Build a scratch code dir and repo root."""
+        self.tmp = Path(tempfile.mkdtemp())
+        self.code = self.tmp / "code"
+        self.code.mkdir()
+        (self.code / "a.py").write_text("x = 1\n")
+        (self.code / "b.py").write_text("y = 2\n")
+        self.repo = self.tmp / "repo"
+        (self.repo / "mappings").mkdir(parents=True)
+        (self.repo / "mappings" / "m.tsv").write_text("a\tb\n")
+        self.out = self.tmp / "out"
+        self.out.mkdir()
+
+    def test_touching_a_file_does_not_change_the_fingerprint(self):
+        """
+        The whole point: `git checkout` rewrites mtimes with no content change.
+
+        That flipped the merge verdict on a file whose bytes were identical
+        (#797), and two reviewers spent effort on the phantom disagreement.
+        """
+        before = code_fingerprint(self.code)
+        (self.code / "a.py").touch()
+        self.assertEqual(code_fingerprint(self.code), before)
+
+    def test_editing_a_file_changes_it(self):
+        """A guard that never fires is worse than none."""
+        before = code_fingerprint(self.code)
+        (self.code / "a.py").write_text("x = 2\n")
+        self.assertNotEqual(code_fingerprint(self.code), before)
+
+    def test_adding_a_file_changes_it(self):
+        """
+        Several transforms are split across helper modules in one package.
+
+        Hashing only the entry module would miss a change to a helper that
+        alters the output just as much, which is why this is directory-scoped.
+        """
+        before = code_fingerprint(self.code)
+        (self.code / "c.py").write_text("z = 3\n")
+        self.assertNotEqual(code_fingerprint(self.code), before)
+
+    def test_renaming_a_file_changes_it(self):
+        """
+        Content alone is not enough: the path is folded in too.
+
+        Renaming changes what runs — imports resolve differently — while the
+        multiset of file contents is untouched.
+        """
+        before = code_fingerprint(self.code)
+        (self.code / "a.py").rename(self.code / "renamed.py")
+        self.assertNotEqual(code_fingerprint(self.code), before)
+
+    def test_a_deleted_data_input_is_a_change_not_a_skip(self):
+        """
+        Skipping a missing file would read as "nothing changed".
+
+        A curation file being deleted is exactly the kind of change a rebuild
+        must notice, so absence is folded into the digest rather than passed
+        over.
+        """
+        before = data_fingerprint(self.repo, ["mappings/m.tsv"])
+        (self.repo / "mappings" / "m.tsv").unlink()
+        self.assertNotEqual(data_fingerprint(self.repo, ["mappings/m.tsv"]), before)
+
+    def test_code_and_data_are_recorded_separately(self):
+        """
+        A stale output must still be able to say *why*.
+
+        `STALE_VS_CODE` and `STALE_VS_DATA` are different actions for whoever
+        reads the report; one combined hash would collapse them.
+        """
+        payload = write_fingerprint(self.out, self.code, self.repo, ["mappings/m.tsv"])
+        self.assertNotEqual(payload["code"], payload["data"])
+        self.assertEqual(read_fingerprint(self.out), payload)
+
+    def test_an_unparseable_marker_reads_as_absent(self):
+        """
+        Fall back to timestamps rather than asserting a mismatch we cannot judge.
+
+        Claiming "stale" off a corrupt marker would be the cry-wolf failure this
+        work exists to remove.
+        """
+        (self.out / FINGERPRINT_FILE).write_text("{not json")
+        self.assertIsNone(read_fingerprint(self.out))
+
+    def test_a_marker_from_another_scheme_version_reads_as_absent(self):
+        """Comparing across hashing schemes would silently compare nothing."""
+        write_fingerprint(self.out, self.code, self.repo, ["mappings/m.tsv"])
+        path = self.out / FINGERPRINT_FILE
+        payload = json.loads(path.read_text())
+        payload["version"] = 999
+        path.write_text(json.dumps(payload))
+        self.assertIsNone(read_fingerprint(self.out))
+
+    def test_an_absent_marker_reads_as_absent(self):
+        """Fresh checkouts and pre-existing outputs have none; that is not an error."""
+        self.assertIsNone(read_fingerprint(self.tmp / "nowhere"))


### PR DESCRIPTION
Closes #797 and #836.

## The class of defect

Freshness has been timestamp-based, and timestamps do not survive routine git operations:

| trigger | effect | issue |
|---|---|---|
| `git checkout` | rewrites a tracked file's mtime with no content change, so visiting another branch flips the verdict | #797 |
| squash merge | mints a new commit for content that already existed, so commit time jumps while bytes stay identical | #836 |

#797 proposed moving to commit time. That was done — and #836 is the proof it's insufficient. #832 squashed at 19:30 for code the gold transform had already run against at 19:06, and the merge guard confidently reported stale output that was byte-for-byte current.

#797's option 3 (hash the inputs) is the one that closes the class, and is what #826 already did bespokely for gold.

## The change

`kg_microbe/utils/transform_fingerprint.py` generalises it. Transforms record a fingerprint of their code and declared data inputs beside their output; consumers compare bytes.

- **Recorded by the dispatcher**, not per-transform — every source gets it, none can forget.
- **After the outputs**, so a run that dies partway leaves no marker claiming a match.
- **Code and data hashed separately**, so a stale output still says *why*; `STALE_VS_CODE` and `STALE_VS_DATA` are different actions for whoever reads the report.
- **gold's bespoke marker removed** in favour of it. Two mechanisms for one job is exactly the drift this repo keeps filing issues about.

The skill now consults the fingerprint **even when the branch diverges from master**. `LOCAL_CHANGES` exists because a *timestamp* comparison against master is undefined mid-branch — a content comparison isn't, and "does this output match the code sitting here right now" is the question a pre-flight actually wants. My first cut skipped the fingerprint under local changes, which discarded it precisely where it's most useful.

## Verification

Against the scenarios, not by observing green:

```
A. after a real run          -> FRESH  "verified by content fingerprint"
B. touch gold.py (#797)      -> FRESH  (unchanged — this is the whole point)
C. append one line           -> STALE_VS_CODE
D. revert                    -> FRESH
```

Fingerprint properties tested directly too: touching doesn't change it, editing/adding/**renaming** does (path is folded in, since renaming changes what runs while leaving the content multiset identical), and a *deleted* data input is a change rather than a skip — skipping it would read as "nothing changed".

Missing, corrupt, or wrong-version markers all read as absent and fall back to the timestamp path — what every consumer did before. Asserting "stale" off a marker we can't interpret would be the cry-wolf failure this removes.

`poetry run tox`: 1144 passed. The one failure, `test_every_referenced_curie_has_stub_node` (`PO:0009005`), reproduces on master unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)