### PR TITLE
fix: bring merge.no_metatraits.yaml current, and report stale merged artifacts

### DIFF
--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -169,11 +169,19 @@ def _cleanup_merged_outputs(yaml_file: str) -> None:
     output_dir = Path(config.get("configuration", {}).get("output_directory", "data/merged"))
     destinations = config.get("merged_graph", {}).get("destination", {})
 
+    # Accumulated across every destination, TSV or not: "did this run write it"
+    # is a property of the whole run. Warning per-destination made each one
+    # report the others' fresh output as stale (#848).
+    written: set = set()
+
     for dest in destinations.values():
-        if dest.get("format") != "tsv":
-            continue
         base = dest.get("filename")
         if not base:
+            continue
+        if dest.get("format") != "tsv":
+            # Not normalised here, but still ours — record it so it is never
+            # reported as a leftover.
+            written.add(output_dir / base)
             continue
         nodes_file = output_dir / f"{base}_nodes.tsv"
         edges_file = output_dir / f"{base}_edges.tsv"
@@ -206,7 +214,9 @@ def _cleanup_merged_outputs(yaml_file: str) -> None:
                     nodes_file.unlink(missing_ok=True)
                     edges_file.unlink(missing_ok=True)
 
-        _warn_about_stale_siblings(output_dir, {nodes_file, edges_file, archive})
+        written |= {nodes_file, edges_file, archive}
+
+    _warn_about_stale_siblings(output_dir, written)
 
 
 def _warn_about_stale_siblings(output_dir: Path, written: set) -> None:

--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -4,6 +4,7 @@ import csv
 import shutil
 import tarfile
 import tempfile
+import time
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -204,6 +205,44 @@ def _cleanup_merged_outputs(yaml_file: str) -> None:
                     # KGX didn't leave loose TSVs before, so don't leave them now.
                     nodes_file.unlink(missing_ok=True)
                     edges_file.unlink(missing_ok=True)
+
+        _warn_about_stale_siblings(output_dir, {nodes_file, edges_file, archive})
+
+
+def _warn_about_stale_siblings(output_dir: Path, written: set) -> None:
+    """
+    Report merged artifacts in the output directory that this run did not write.
+
+    ``data/merged/`` is where consumers look, and it accumulates. A reviewer of
+    #826 read ``merged-kg_default_{nodes,edges}.tsv`` — seven months old, 1.2 GB,
+    sitting beside the current tarball — and reported the graph as 1.51M/6.13M
+    against the tarball's 2.85M/14.66M, then flagged the difference as an
+    unexplained discrepancy. Both numbers were right about different files, and
+    nothing but the mtime said which was current (#828).
+
+    Warns rather than deletes. These are large, untracked, and may be someone's
+    deliberate copy; silently removing a gigabyte of another person's output is
+    not a merge step's call to make.
+
+    :param output_dir: The merge output directory.
+    :param written: Paths this run produced, which are never reported.
+    """
+    if not output_dir.is_dir():
+        return
+    stale = sorted(
+        p for p in output_dir.glob("merged-kg*") if p.is_file() and p not in written and not p.name.endswith(".yaml")
+    )
+    if not stale:
+        return
+    print(
+        f"[merge-cleanup] {len(stale)} older merged artifact(s) remain in {output_dir}/ "
+        "and were NOT written by this run — anything reading them gets the previous graph:"
+    )
+    for path in stale:
+        size_mb = path.stat().st_size / 1_048_576
+        age_days = (time.time() - path.stat().st_mtime) / 86400.0
+        print(f"[merge-cleanup]   {path.name}  ({size_mb:,.0f} MB, {age_days:.0f} days old)")
+    print("[merge-cleanup] Remove them once you are sure nothing depends on them.")
 
 
 def _iter_clean_lines(path: Path):

--- a/merge.no_metatraits.yaml
+++ b/merge.no_metatraits.yaml
@@ -54,6 +54,20 @@ merged_graph:
         filename:
           - data/transformed/ontologies/go_nodes.tsv
           - data/transformed/ontologies/go_edges.tsv
+    # mondo:
+    #   name: "MONDO"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/ontologies/mondo_nodes.tsv
+    #       - data/transformed/ontologies/mondo_edges.tsv
+    # hp:
+    #   name: "HP"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/ontologies/hp_nodes.tsv
+    #       - data/transformed/ontologies/hp_edges.tsv
     ec:
       name: "EC"
       input:
@@ -68,7 +82,10 @@ merged_graph:
         filename:
           - data/transformed/ontologies/metpo_nodes.tsv
           - data/transformed/ontologies/metpo_edges.tsv
-    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, MICRO — see merge.yaml.
+    # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, and MICRO —
+    # only the IDs referenced by mappings/* are imported (not the full
+    # ontologies). See kg_microbe/transform_utils/ontologies_stubs/ for
+    # the transform.
     ontologies_stubs:
       name: "ontologies_stubs"
       input:
@@ -125,6 +142,27 @@ merged_graph:
         filename:
           - data/transformed/bactotraits/nodes.tsv
           - data/transformed/bactotraits/edges.tsv
+    # bakta_cmm:
+    #   name: "bakta_cmm"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/bakta/cmm_bakta/nodes.tsv
+    #       - data/transformed/bakta/cmm_bakta/edges.tsv
+    # bakta_pfas:
+    #   name: "bakta_pfas"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/bakta/pfas_bakta/nodes.tsv
+    #       - data/transformed/bakta/pfas_bakta/edges.tsv
+    # cog:
+    #   name: "cog"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/cog/nodes.tsv
+    #       - data/transformed/cog/edges.tsv
     gtdb:
       name: "GTDB Taxonomy"
       input:
@@ -132,10 +170,115 @@ merged_graph:
         filename:
           - data/transformed/gtdb/nodes.tsv
           - data/transformed/gtdb/edges.tsv
+    # LPSN nomenclature. `lpsn` is the fast GSS/CSV base layer (taxon
+    # names, ranks, GTDB/NCBITaxon cross-refs); `lpsn_api` is the
+    # authenticated JSON-API enrichment (above-genus taxonomy, basonyms,
+    # publication DOIs/PMIDs, 16S INSDC accessions). The API enrichment
+    # nodes reference lpsn:* records minted by the GSS layer, so both are
+    # merged together.
+    lpsn:
+      name: "LPSN"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/lpsn/nodes.tsv
+          - data/transformed/lpsn/edges.tsv
+    lpsn_api:
+      name: "LPSN API"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/lpsn_api/nodes.tsv
+          - data/transformed/lpsn_api/edges.tsv
+    # MicrobeDecoder (Hackmann & Zhang, Sci Adv 2023) — Bergey / VPI /
+    # Literature / FAPROTAX curated fermentation profiles keyed on
+    # lpsn:<LPSN_ID>, plus a pre-joined LPSN ↔ GTDB ↔ NCBI ↔ GOLD ↔ IMG ↔
+    # BacDive identity crosswalk. See kg_microbe/transform_utils/microbedecoder/.
+    microbedecoder:
+      name: "MicrobeDecoder"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/microbedecoder/nodes.tsv
+          - data/transformed/microbedecoder/edges.tsv
+    # GOLD — Genomes OnLine Database (JGI). Pre-transformed KGX, conformed by a
+    # validating passthrough: samples and studies dropped, retired NCBI taxids
+    # remapped from merged.dmp, uninformative ecosystems resolved up to their
+    # nearest named ancestor, and the ecosystem vocabulary bridged to ENVO and
+    # UBERON. Contributes organism→taxon and organism→environment; see
+    # docs/GOLD_TRANSFORM_REVIEW.md.
+    gold:
+      name: "GOLD"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/gold/nodes.tsv
+          - data/transformed/gold/edges.tsv
+    # PREGO — Prokaryotic Environment / Genotype text-mining knowledgebase
+    # (Zafeiropoulos et al 2022, Microorganisms 10:293). Emits
+    # NCBITaxon→GO capable_of, ENVO→NCBITaxon location_of, NCBITaxon→MONDO
+    # associated_with (via DOID→MONDO xref). See docs/PREGO_INGEST_PLAN.md.
+    # PREGO habitat only. Its taxon->GO edges are 99% of the source by volume and
+    # have no positive evidence in any of the four gold standards, so they are not
+    # part of the standard graph — see merge.prego-full.yaml for the experimental
+    # build that keeps them. Produce this input with:
+    #   PREGO_SHAPES=habitat poetry run kg transform -s prego
+    # which writes data/transformed/prego_habitat/ (~238k location_of edges at the
+    # tau=1.0 continuous-channel policy in docs/PREGO_SCORE_VALIDATION.md).
+    prego:
+      name: "PREGO (habitat only)"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/prego_habitat/nodes.tsv
+          - data/transformed/prego_habitat/edges.tsv
+    # kegg:
+    #   name: "kegg"
+    #   input:
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/kegg/nodes.tsv
+    #       - data/transformed/kegg/edges.tsv
+    # ctd:
+    #   input:
+    #     name: "ctd"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/ctd/nodes.tsv
+    #       - data/transformed/ctd/edges.tsv
+    # disbiome:
+    #   input:
+    #     name: "disbiome"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/disbiome/nodes.tsv
+    #       - data/transformed/disbiome/edges.tsv
+    # wallen_etal:
+    #   input:
+    #     name: "wallen_etal"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/wallen_etal/nodes.tsv
+    #       - data/transformed/wallen_etal/edges.tsv
+    # Not feasible using kgx merge process
+    # uniprot_functional_microbes:
+    #   input:
+    #     name: "uniprot_functional_microbes"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/uniprot_functional_microbes/nodes.tsv
+    #       - data/transformed/uniprot_functional_microbes/edges.tsv
+    # uniprot_human:
+    #   input:
+    #     name: "uniprot_human"
+    #     format: tsv
+    #     filename:
+    #       - data/transformed/uniprot_human/nodes.tsv
+    #       - data/transformed/uniprot_human/edges.tsv
   operations:
     - name: kgx.graph_operations.summarize_graph.generate_graph_stats
       args:
-        graph_name: kg-microbe graph (no metatraits)
+        graph_name: kg-microbe graph
         filename: merged_graph_stats.yaml
         node_facet_properties:
           - provided_by
@@ -147,3 +290,7 @@ merged_graph:
       format: tsv
       compression: tar.gz
       filename: merged-kg
+#    merged-kg-nt:
+#      format: nt
+#      compression: gz
+#      filename: kg_microbe.nt.gz

--- a/tests/test_merge_configs.py
+++ b/tests/test_merge_configs.py
@@ -282,3 +282,50 @@ def test_the_stats_yaml_is_not_reported_as_a_stale_artifact(tmp_path, capsys):
     (tmp_path / "merged-kg_stats.yaml").write_text("nodes: 1\n")
     _warn_about_stale_siblings(tmp_path, {written})
     assert capsys.readouterr().out == ""
+
+
+def test_a_second_destination_is_not_reported_as_stale(tmp_path):
+    """
+    "Did this run write it" is a property of the run, not of one destination (#848).
+
+    Warning inside the destination loop meant each destination reported the
+    others' fresh output as a leftover — the exact confusion #828 exists to
+    remove, manufactured by the fix for it. A non-TSV destination is skipped for
+    normalisation but is still ours, so it counts too.
+    """
+    import yaml
+
+    from kg_microbe.merge_utils.merge_kg import _cleanup_merged_outputs
+
+    out = tmp_path / "merged"
+    out.mkdir()
+    (out / "merged-kg_nodes.tsv").write_text("id\tcategory\n")
+    (out / "merged-kg_edges.tsv").write_text("subject\tpredicate\tobject\n")
+    (out / "merged-kg-second_nodes.tsv").write_text("id\tcategory\n")
+    (out / "merged-kg-second_edges.tsv").write_text("subject\tpredicate\tobject\n")
+
+    config = tmp_path / "merge.two.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "configuration": {"output_directory": str(out)},
+                "merged_graph": {
+                    "destination": {
+                        "a": {"format": "tsv", "filename": "merged-kg"},
+                        "b": {"format": "tsv", "filename": "merged-kg-second"},
+                    }
+                },
+            }
+        )
+    )
+
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _cleanup_merged_outputs(str(config))
+    printed = buf.getvalue()
+    assert "were NOT written by this run" not in printed, (
+        f"a destination's own output was reported as stale:\n{printed}"
+    )

--- a/tests/test_merge_configs.py
+++ b/tests/test_merge_configs.py
@@ -122,6 +122,71 @@ def test_the_default_merge_reads_what_the_default_transform_writes():
     )
 
 
+#: How each shipped config relates to ``merge.yaml``, as
+#: ``{name: (extra dirs, missing dirs)}``. ``merge.yaml`` is the baseline and
+#: ``merge.minimal.yaml`` is exempt — it is a deliberately tiny 3-source config,
+#: not a variant of the standard graph.
+#:
+#: A table rather than one test per config, because the failure being fixed is
+#: that coverage was opt-in: the relational invariants named the configs someone
+#: remembered, and ``merge.no_metatraits.yaml`` — added later — inherited none
+#: and drifted seven sources behind (#827). ``test_every_config_has_a_declared
+#: _relationship`` closes that by making an undeclared config a failure.
+CONFIG_RELATIONS = {
+    "merge_bakta.yaml": ({"bakta", "cog", "kegg"}, set()),
+    "merge.noprego.yaml": (set(), {"prego_habitat"}),
+    "merge.prego-full.yaml": ({"prego"}, {"prego_habitat"}),
+    "merge.no_metatraits.yaml": (set(), {"metatraits", "metatraits_gtdb"}),
+}
+BASELINE_CONFIG = "merge.yaml"
+EXEMPT_CONFIGS = {"merge.minimal.yaml"}
+
+
+def test_every_config_has_a_declared_relationship():
+    """
+    A config shipped without a declared relationship gets no drift coverage.
+
+    This is the general defect behind #827, not just the one config that
+    exhibited it: the relational invariants below enumerate configs by hand, so
+    anything added later is silently uncovered. Deriving the expected set from
+    the filesystem makes adding a config *force* a decision about what it is.
+    """
+    on_disk = {p.name for p in _configs()}
+    declared = set(CONFIG_RELATIONS) | EXEMPT_CONFIGS | {BASELINE_CONFIG}
+    assert on_disk - declared == set(), (
+        f"merge configs with no declared relationship: {sorted(on_disk - declared)}. "
+        "Add them to CONFIG_RELATIONS (or EXEMPT_CONFIGS if they are not variants "
+        "of the standard graph), so they are covered by the drift check."
+    )
+    assert declared - on_disk - EXEMPT_CONFIGS - {BASELINE_CONFIG} == set(), (
+        f"CONFIG_RELATIONS names configs that no longer exist: "
+        f"{sorted(declared - on_disk - EXEMPT_CONFIGS - {BASELINE_CONFIG})}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(CONFIG_RELATIONS))
+def test_each_variant_differs_from_the_standard_graph_only_as_declared(name):
+    """
+    Every variant is `merge.yaml` plus its extras, minus its exclusions.
+
+    Both directions matter and the missing one is what bites: an *extra* is
+    visible when the merge runs, whereas a source silently absent from a variant
+    produces a graph that looks fine and is quietly incomplete. That is how
+    `merge_bakta.yaml` and later `merge.no_metatraits.yaml` each fell seven
+    sources behind.
+    """
+    standard = _active_dirs(REPO_ROOT / BASELINE_CONFIG)
+    variant = _active_dirs(REPO_ROOT / name)
+    expected_extra, expected_missing = CONFIG_RELATIONS[name]
+
+    assert variant - standard == expected_extra, (
+        f"{name} has unexpected extras: {sorted((variant - standard) - expected_extra)}"
+    )
+    assert standard - variant == expected_missing, (
+        f"{name} has fallen behind {BASELINE_CONFIG}: missing {sorted((standard - variant) - expected_missing)}"
+    )
+
+
 def test_the_bakta_config_is_the_standard_graph_plus_the_annotation_cluster():
     """
     `merge_bakta.yaml` is defined as `merge.yaml` plus bakta/cog/kegg.
@@ -169,3 +234,51 @@ def test_an_oddly_named_unproducible_dir_is_caught(tmp_path, odd_dir):
     )
     assert _active_dirs(config) == {odd_dir}, "the dir must be visible to the guard"
     assert odd_dir not in set(DATA_SOURCES) | KNOWN_VARIANT_DIRS, "and recognised as unproducible"
+
+
+def test_stale_sibling_artifacts_are_reported(tmp_path, capsys):
+    """
+    `data/merged/` accumulates, and consumers read whatever is there (#828).
+
+    A reviewer of #826 read `merged-kg_default_{nodes,edges}.tsv` — seven months
+    old, 1.2 GB, beside the current tarball — and reported 1.51M/6.13M against
+    the tarball's 2.85M/14.66M, flagging it as an unexplained discrepancy. Both
+    were right about different files; only the mtime distinguished them.
+    """
+    from kg_microbe.merge_utils.merge_kg import _warn_about_stale_siblings
+
+    written = tmp_path / "merged-kg.tar.gz"
+    written.write_bytes(b"current")
+    leftover = tmp_path / "merged-kg_default_nodes.tsv"
+    leftover.write_bytes(b"old")
+
+    _warn_about_stale_siblings(tmp_path, {written})
+    out = capsys.readouterr().out
+    assert "merged-kg_default_nodes.tsv" in out
+    assert "merged-kg.tar.gz" not in out, "the artifact this run wrote must not be reported as stale"
+
+
+def test_a_clean_output_directory_reports_nothing(tmp_path, capsys):
+    """No warning when there is nothing to warn about — noise trains people to ignore it."""
+    from kg_microbe.merge_utils.merge_kg import _warn_about_stale_siblings
+
+    written = tmp_path / "merged-kg.tar.gz"
+    written.write_bytes(b"current")
+    _warn_about_stale_siblings(tmp_path, {written})
+    assert capsys.readouterr().out == ""
+
+
+def test_the_stats_yaml_is_not_reported_as_a_stale_artifact(tmp_path, capsys):
+    """
+    `merged-kg_stats.yaml` sits in the same directory and is not a graph copy.
+
+    Reporting it would be a false positive on every single merge, which is the
+    reliable way to get a warning ignored.
+    """
+    from kg_microbe.merge_utils.merge_kg import _warn_about_stale_siblings
+
+    written = tmp_path / "merged-kg.tar.gz"
+    written.write_bytes(b"current")
+    (tmp_path / "merged-kg_stats.yaml").write_text("nodes: 1\n")
+    _warn_about_stale_siblings(tmp_path, {written})
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
Closes #827 and #828.

## #827 — a config with no drift coverage drifted

`merge.no_metatraits.yaml` carried **14** sources against `merge.yaml`'s 21:

```
missing: gold, lpsn, lpsn_api, metatraits, metatraits_gtdb, microbedecoder, prego_habitat
```

Only two of those seven are excluded by design. Last touched 2026-06-10, predating `lpsn_api`, `microbedecoder` and `prego` entirely.

Rebuilt as `merge.yaml` minus the metatraits pair — **derived from `merge.yaml`, not hand-edited**. The drift came from maintaining two source lists by hand; re-transcribing five blocks would be the same mistake in the same place. Now 19 sources.

### The general defect

Coverage was opt-in. The relational invariants enumerated configs by name, so anything added later inherited none — which is how `merge_bakta.yaml` fell seven sources behind, and then how this one did. Fixing only this config would leave the mechanism intact.

The invariants are now table-driven, and `test_every_config_has_a_declared_relationship` fails on any `merge*.yaml` without an entry. Adding a config forces a decision about what it is.

Both directions are asserted, and the one that matters is the *missing* direction: an extra source shows up when the merge runs, whereas a source silently absent produces a graph that looks fine and is quietly incomplete.

## #828 — `data/merged/` accumulates

A reviewer of #826 read `merged-kg_default_{nodes,edges}.tsv` — seven months old, 1.2 GB, beside the current tarball — reported 1.51M/6.13M against the tarball's 2.85M/14.66M, and flagged it as an unexplained discrepancy. Both numbers were right about different files; only the mtime distinguished them.

The merge now reports artifacts in its output directory it did not write, with size and age.

**It warns rather than deletes.** These are large, untracked, and may be a deliberate copy; removing a gigabyte of someone's output is not a merge step's call to make. `merged-kg_stats.yaml` is excluded — a false positive on every run is the reliable way to get a warning ignored.

## Verification

Both new checks were verified by breaking them, not by observing green:

- dropping a config into the repo → `merge configs with no declared relationship: ['merge.scratch.yaml']`
- removing `gold` from the variant → `merge.no_metatraits.yaml has fallen behind merge.yaml: missing ['gold']`

`poetry run tox`: 1142 passed. The failure, `test_every_referenced_curie_has_stub_node` (`PO:0009005`), reproduces on master unchanged.

**One note:** the second skip in that run is a cross-branch artifact, not from this PR. #844 replaces gold's bespoke `source_checksum.txt` with a shared fingerprint, and deleting that file from disk left master's guard in `test_gold_merge_wiring.py` skipping. It re-arms when #844 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)