### PR TITLE
fix(microbedecoder): a separator inside brackets is not a separator

### DIFF
--- a/kg_microbe/transform_utils/microbedecoder/utils.py
+++ b/kg_microbe/transform_utils/microbedecoder/utils.py
@@ -163,18 +163,41 @@ BACDIVE_SNAPSHOT_COLUMNS: Tuple[str, ...] = (
 # ``d__Bacteria;g__Bacillus;s__Bacillus subtilis``); a semicolon split
 # would shred those into three orphan CURIEs (issue #655 regression net).
 #
-# Known limitation shared with ``madin_etal``: a chemical name containing a
-# literal comma (e.g. ``2,3-butanediol``) still over-splits on the primary
-# splitter. MicrobeDecoder rows use simple end-product names in practice
-# ("acetate", "lactate", "butanol"); a follow-up can promote this to a
-# smarter parser once a curated exceptions list exists.
-_MULTIVALUE_SPLIT = re.compile(r"\s*[,;]\s*")
-_MULTIVALUE_SPLIT_COMMA_ONLY = re.compile(r"\s*,\s*")
+# Separators inside brackets are NOT separators (#838). Splitting on every
+# comma cut four real labels in half, each fragment then reaching
+# ``microbedecoder_unmapped_labels_to_curate.tsv`` as its own unmappable
+# "term":
+#
+#   "O/129 (2,4-diamino-6,7-di-iso-propylpteridine phosphate)"
+#       -> "0129 (2"  +  "7-di-iso-propylpteridine phosphate)"   (1,212 occ)
+#   "#Herbaceous plants (Grass, Crops)"
+#       -> "#Herbaceous plants (Grass"  +  "Crops)"              (1,021 occ)
+#   "#Bovinae (Cow, Cattle)"     -> ... (200 occ)
+#   "#Suidae (Pig, Swine)"       -> ... (156 occ)
+#
+# The matched occurrence counts are what proved these were one string each:
+# every label with an unclosed ``(`` paired exactly with one carrying an
+# orphan ``)``. MediaIngredientMech hit the same defect on the ingredient side
+# (its #308) and had to tombstone the fragments after the fact.
+#
+# Still a known limitation, shared with ``madin_etal``: a comma inside a
+# chemical name with no brackets around it (``2,3-butanediol``) is
+# indistinguishable from a separator by any structural rule, and still
+# over-splits. MicrobeDecoder rows use simple end-product names in practice.
+_MULTIVALUE_SEPARATORS = ",;"
+_COMMA_ONLY_SEPARATORS = ","
+_OPENERS = "([{"
+_CLOSERS = ")]}"
 
 
 def split_multivalue(cell: object) -> List[str]:
-    """Split a multi-value cell on comma OR semicolon; return trimmed tokens."""
-    return _split(cell, _MULTIVALUE_SPLIT)
+    """
+    Split a multi-value cell on comma OR semicolon, outside brackets only.
+
+    :param cell: Raw cell value.
+    :return: Trimmed, non-empty tokens.
+    """
+    return _split(cell, _MULTIVALUE_SEPARATORS)
 
 
 def split_multivalue_comma_only(cell: object) -> List[str]:
@@ -185,17 +208,46 @@ def split_multivalue_comma_only(cell: object) -> List[str]:
     a raw semicolon is part of the identifier (``GTDB_ID`` rank separator)
     rather than a value separator.
     """
-    return _split(cell, _MULTIVALUE_SPLIT_COMMA_ONLY)
+    return _split(cell, _COMMA_ONLY_SEPARATORS)
 
 
-def _split(cell: object, pattern: "re.Pattern") -> List[str]:
-    """Shared helper for :func:`split_multivalue` and its comma-only variant."""
+def _split(cell: object, separators: str) -> List[str]:
+    """
+    Split a cell on separators that sit outside any bracket.
+
+    An unclosed bracket leaves the depth above zero for the rest of the
+    string, so everything after it stays in one token. That is the
+    conservative reading: with the structure broken we cannot tell where a
+    value ends, and inventing a boundary is what produced the orphan fragments
+    in the first place.
+
+    :param cell: Raw cell value.
+    :param separators: Characters that separate values at bracket depth zero.
+    :return: Trimmed, non-empty tokens.
+    """
     if cell is None:
         return []
     text = str(cell).strip()
     if not text or text.lower() in _EMPTY_MARKERS:
         return []
-    return [tok for tok in (t.strip() for t in pattern.split(text)) if tok]
+
+    tokens: List[str] = []
+    buffer: List[str] = []
+    depth = 0
+    for char in text:
+        if char in _OPENERS:
+            depth += 1
+        elif char in _CLOSERS:
+            # Clamp at zero: a stray closer must not drive the depth negative
+            # and make every later separator look nested.
+            depth = max(0, depth - 1)
+        if depth == 0 and char in separators:
+            tokens.append("".join(buffer))
+            buffer = []
+        else:
+            buffer.append(char)
+    tokens.append("".join(buffer))
+    return [tok for tok in (t.strip() for t in tokens) if tok]
 
 
 # Values MicrobeDecoder uses to indicate "no data" for a cell. Detected

--- a/tests/test_microbedecoder_split.py
+++ b/tests/test_microbedecoder_split.py
@@ -1,0 +1,93 @@
+"""A separator inside brackets is not a separator (#838)."""
+
+import pytest
+
+from kg_microbe.transform_utils.microbedecoder.utils import (
+    split_multivalue,
+    split_multivalue_comma_only,
+)
+
+#: The four labels #838 found cut in half, with their occurrence counts. Each
+#: paired exactly with a fragment carrying an orphan `)` — same count, same
+#: source column — which is what proved they were one string each.
+SPLIT_IN_HALF = [
+    ("O/129 (2,4-diamino-6,7-di-iso-propylpteridine phosphate)", 1212, "Antibiotic_resistance/sensitivity"),
+    ("#Herbaceous plants (Grass, Crops)", 1021, "Isolation_category_3"),
+    ("#Bovinae (Cow, Cattle)", 200, "Isolation_category_3"),
+    ("#Suidae (Pig, Swine)", 156, "Isolation_category_3"),
+]
+
+
+@pytest.mark.parametrize("label,occurrences,column", SPLIT_IN_HALF, ids=lambda v: str(v)[:28])
+def test_a_bracketed_comma_does_not_split_the_label(label, occurrences, column):
+    """
+    2,589 occurrences across four labels, each becoming two unmappable "terms".
+
+    MediaIngredientMech hit the same defect on the ingredient side (its #308)
+    and had to tombstone the fragments after the fact — evidence that repairing
+    downstream is the expensive way to handle this.
+    """
+    assert split_multivalue(label) == [label], f"{column} label was split ({occurrences} occurrences affected)"
+
+
+def test_genuine_multi_values_still_split():
+    """
+    The fix must not turn the splitter off.
+
+    Bergey / VPI end-product columns really are comma-separated lists, and
+    collapsing them would silently drop every value after the first.
+    """
+    assert split_multivalue("acetate, lactate, ethanol") == ["acetate", "lactate", "ethanol"]
+    assert split_multivalue("acetate; lactate") == ["acetate", "lactate"]
+
+
+def test_a_separator_after_a_closed_bracket_still_splits():
+    """Depth returns to zero, so the list continues normally."""
+    assert split_multivalue("#Bovinae (Cow, Cattle), acetate") == ["#Bovinae (Cow, Cattle)", "acetate"]
+
+
+def test_nested_brackets_are_tracked():
+    """One closer must not re-open splitting inside an outer bracket."""
+    assert split_multivalue("a (b (c, d), e), f") == ["a (b (c, d), e)", "f"]
+
+
+def test_an_unclosed_bracket_keeps_the_remainder_whole():
+    """
+    Conservative on malformed input.
+
+    With the structure broken we cannot tell where a value ends, and inventing
+    a boundary is exactly what produced the orphan fragments.
+    """
+    assert split_multivalue("foo (bar, baz") == ["foo (bar, baz"]
+
+
+def test_a_stray_closer_does_not_disable_later_splitting():
+    """
+    Depth is clamped at zero.
+
+    Letting it go negative would make every subsequent separator look nested,
+    silently collapsing the rest of the cell into one value.
+    """
+    assert split_multivalue("foo) , bar") == ["foo)", "bar"]
+
+
+def test_the_comma_only_variant_still_preserves_gtdb_semicolons():
+    """
+    `GTDB_ID` uses semicolons as rank separators (#655).
+
+    Splitting on them shredded one CURIE into three orphans, which is why the
+    comma-only variant exists; the bracket change must not disturb it.
+    """
+    lineage = "d__Bacteria;g__Bacillus;s__Bacillus subtilis"
+    assert split_multivalue_comma_only(lineage) == [lineage]
+
+
+def test_the_comma_only_variant_is_also_bracket_aware():
+    """Both splitters share the walk, so neither can regress independently."""
+    assert split_multivalue_comma_only("#Bovinae (Cow, Cattle)") == ["#Bovinae (Cow, Cattle)"]
+
+
+@pytest.mark.parametrize("empty", ["", "  ", "NA", "na", None])
+def test_empty_markers_still_yield_nothing(empty):
+    """The rewrite must not turn a blank cell into a one-element list."""
+    assert split_multivalue(empty) == []


### PR DESCRIPTION
Closes #838.

## The defect

`_split` called `pattern.split(text)`, cutting at every comma and semicolon regardless of nesting. Four real labels were cut in half, each fragment reaching `microbedecoder_unmapped_labels_to_curate.tsv` as its own unmappable "term":

| occ | label | became |
|---:|---|---|
| 1,212 | `O/129 (2,4-diamino-6,7-di-iso-propylpteridine phosphate)` | `0129 (2` + `7-di-iso-propylpteridine phosphate)` |
| 1,021 | `#Herbaceous plants (Grass, Crops)` | `#Herbaceous plants (Grass` + `Crops)` |
| 200 | `#Bovinae (Cow, Cattle)` | … |
| 156 | `#Suidae (Pig, Swine)` | … |

2,589 occurrences. All five fragments are still present in the curation file — verified, rather than taken from the issue.

## The fix

The split walks the string tracking bracket depth and cuts only at depth zero.

Two edge cases decided deliberately rather than falling out of the implementation:

- **Unclosed bracket** → the remainder stays whole. With the structure broken we can't tell where a value ends, and inventing a boundary is precisely what produced the orphan fragments.
- **Stray closer** → depth clamps at zero instead of going negative, which would make every later separator look nested and silently collapse the rest of the cell into one value.

**Not fixed**, and still documented: a comma inside an *unbracketed* chemical name (`2,3-butanediol`) is indistinguishable from a separator by any structural rule. That limitation is shared with `madin_etal` and needs a curated exceptions list, not a parser change.

MediaIngredientMech hit this same defect on the ingredient side (its #308) and had to tombstone the fragments after the fact — evidence that repairing downstream costs more than not emitting them.

## Tests

16, covering the four real labels by name, and the regressions the fix could plausibly cause: genuine comma/semicolon multi-values still split, a separator *after* a closed bracket still splits, nested brackets are tracked, and the comma-only variant still preserves `GTDB_ID` rank semicolons (#655). Both splitters share the walk, so neither can regress alone.

`poetry run tox`: 1169 passed. The one failure, `test_every_referenced_curie_has_stub_node` (`PO:0009005`), reproduces on master unchanged.

**Effect is not visible until microbedecoder re-runs**, which is held for the incoming MIM SSSOM. The curation file still lists the fragments until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)