### PR TITLE
fix(gold): bridge MeSH per term, recovering the sites #821 gave up

### DIFF
--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -285,6 +285,12 @@ _TAXON_PREFIX = "NCBITaxon:"
 class GOLDTransform(Transform):
     """Conform the pre-transformed GOLD KGX TSVs to the KG-Microbe standard."""
 
+    #: The MeSH site curation this transform reads. Declared so the freshness
+    #: check notices an edit to it — a transform that reads a curation file
+    #: without declaring it is reported fresh while its output is stale, which
+    #: is #812, then #839, and would have been this transform next (#876).
+    DATA_INPUTS = (f"mappings/{_MESH_SITE_FILE}",)
+
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):
         """
         Instantiate the transform.

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -258,6 +258,14 @@ _HOST_TAXON_PREFIXES = ("NCBITaxon:",)
 #: that cannot otherwise be bounded by a rule.
 _SITE_PREFIXES = ("ENVO:", "UBERON:", "FOODON:", "PO:", "FAO:")
 
+#: Per-term MeSH decisions, because a prefix rule cannot express "is a site"
+#: for a thesaurus spanning anatomy, disease, chemicals and organisms (#823).
+#: Every reachable MeSH term is listed and decided; anything unlisted is not
+#: bridged, so unknown means no and a new upstream label cannot readmit the
+#: class of error the file exists to prevent.
+_MESH_SITE_FILE = "gold_ecosystem_mesh_sites.tsv"
+_MESH_PREFIX = "mesh:"
+
 
 def _normalise_label(text: str) -> str:
     """
@@ -289,6 +297,7 @@ class GOLDTransform(Transform):
         self._envo_map: Optional[dict] = None
         self._envo_nodes_cache: Optional[set] = None
         self._label_index: Optional[dict] = None
+        self._mesh_sites: Optional[set] = None
 
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True) -> None:
         """
@@ -467,6 +476,26 @@ class GOLDTransform(Transform):
             )
         return collapse
 
+    def _mesh_site_terms(self) -> set:
+        """
+        MeSH CURIEs curated as sites.
+
+        :return: The ``SITE`` CURIEs; empty when the curation file is absent,
+            which keeps the #821 behaviour of bridging no MeSH at all.
+        """
+        if self._mesh_sites is not None:
+            return self._mesh_sites
+        path = Path(__file__).resolve().parents[3] / "mappings" / _MESH_SITE_FILE
+        allowed: set = set()
+        if path.is_file():
+            with path.open(newline="", encoding="utf-8") as handle:
+                rows = (line for line in handle if not line.startswith("#"))
+                for row in csv.DictReader(rows, delimiter="\t"):
+                    if (row.get("decision") or "").strip().upper() == "SITE":
+                        allowed.add((row.get("mesh_id") or "").strip())
+        self._mesh_sites = {curie for curie in allowed if curie}
+        return self._mesh_sites
+
     def _ontology_label_index(self) -> dict:
         """
         Label to CURIE across the ontologies already in the graph.
@@ -496,6 +525,10 @@ class GOLDTransform(Transform):
         # `is_file()` silently, so PO never contributed despite the log line
         # claiming it did.
         sources.append(self.output_base_dir / "ontologies_stubs" / "po_nodes.tsv")
+        # MeSH is indexed so the curated SITE terms are reachable. Everything
+        # else it contributes is refused by the per-term gate below, which is
+        # why indexing the whole file here is safe.
+        sources.append(self.output_base_dir / "ontologies_stubs" / "mesh_nodes.tsv")
         for path in sources:
             if not path.is_file():
                 continue
@@ -904,6 +937,30 @@ class GOLDTransform(Transform):
                     continue  # already bridged by the curated GOLD mapping
                 curie = index.get(_normalise_label(label))
                 if not curie or curie.startswith(_ECOSYSTEM_PREFIX):
+                    continue
+                if curie.startswith(_MESH_PREFIX):
+                    # Per-term, not per-prefix: `Invertebrates`, `Bacteria` and
+                    # `Cnidaria` are taxon groups and `Polycyclic aromatic
+                    # hydrocarbons` is a chemical class, all label-matching
+                    # exactly. Unlisted MeSH terms are refused.
+                    if curie not in self._mesh_site_terms():
+                        non_site += 1
+                        continue
+                    kept += 1
+                    anatomy += 1
+                    bridged_prefixes[_MESH_PREFIX.rstrip(":")] += 1
+                    writer.writerow(
+                        [
+                            eco_id,
+                            EXACT_MATCH_PREDICATE,
+                            curie,
+                            EXACT_MATCH,
+                            f"infores:{GOLD}",
+                            KNOWLEDGE_ASSERTION,
+                            MANUAL_AGENT,
+                            "",
+                        ]
+                    )
                     continue
                 if not curie.startswith(_SITE_PREFIXES + _HOST_TAXON_PREFIXES):
                     non_site += 1

--- a/mappings/gold_ecosystem_mesh_sites.tsv
+++ b/mappings/gold_ecosystem_mesh_sites.tsv
@@ -1,0 +1,35 @@
+# Per-term decisions for bridging GOLD ecosystem labels to MeSH (#823).
+#
+# WHY THIS FILE EXISTS
+# The GOLD ecosystem label join bridges `gold.ecosystem:` labels to ontology
+# terms KG-Microbe already loads, gated by an allow-list of prefixes
+# (`_SITE_PREFIXES` in gold.py). That works for ENVO / UBERON / FOODON / PO /
+# FAO because each is about one kind of thing, so the prefix carries the
+# semantics. It cannot work for MeSH, which spans anatomy, disease, chemicals,
+# organisms and environments under one namespace — and our MeSH stubs are all
+# `biolink:OntologyClass`, so the category does not disambiguate either.
+#
+# With `mesh:` allowed wholesale the join asserted that organisms are
+# `located_in` a taxon group and a chemical class. #821 dropped the prefix
+# entirely, which was correct but also discarded five genuine sites. This file
+# restores them one term at a time.
+#
+# Every MeSH term reachable by this join is listed, decided, and given a
+# reason. REJECTED rows are kept rather than deleted so the reasoning survives
+# and re-adding one is a deliberate act, not an oversight.
+#
+# `decision` is SITE (bridge it) or REJECTED (never bridge it). Any MeSH term
+# not listed here is not bridged: unknown means no, so a new upstream label
+# cannot quietly readmit the class of error this file exists to prevent.
+#
+# Edge counts measured 2026-08-21 against data/transformed/gold/edges.tsv.
+gold_label	mesh_id	mesh_label	decision	edges	reason	curator	verified_date
+Built environment	mesh:D000076624	Built Environment	SITE	277	Anthropogenic environment; a place an organism is isolated from.	claude	2026-08-21
+Solid waste	mesh:D062611	Solid Waste	SITE	77	Environmental material, and the substrate organisms are recovered from.	claude	2026-08-21
+Abscess	mesh:D000038	Abscess	SITE	34	Body site / lesion. bacdive already uses mesh:D000038 as an isolation-source target, so this is consistent with an existing decision rather than a new one.	claude	2026-08-21
+Eggs	mesh:D004531	Eggs	SITE	20	Food/biological material an organism is isolated from, in the same family as the FOODON targets this join already bridges.	claude	2026-08-21
+Seawater	mesh:D012623	Seawater	SITE	0	Unambiguously an environmental site. Zero edges today, listed so the decision is recorded if GOLD ever attaches organisms to it. ENVO has no matching label in our extract.	claude	2026-08-21
+Invertebrates	mesh:D007448	Invertebrates	REJECTED	188	A TAXON GROUP, not a site. `located_in <taxon>` reads as classification — the exact case already excluded for NCBITaxon, readmitted through a different prefix. Needs `taxon location_of organism` instead; see #790.	claude	2026-08-21
+Bacteria	mesh:D001419	Bacteria	REJECTED	189	A taxon group, and a self-referential one: the subject of these edges is itself a bacterium. Not named in #823 — found by enumerating every reachable term rather than trusting the two examples.	claude	2026-08-21
+Cnidaria	mesh:D003063	Cnidaria	REJECTED	175	A taxon group (corals, jellyfish). Host taxon, not a site. Also not named in #823.	claude	2026-08-21
+Polycyclic aromatic hydrocarbons	mesh:D011084	Polycyclic Aromatic Hydrocarbons	REJECTED	0	A CHEMICAL CLASS. An organism is not `located_in` a molecule; this is the substrate/quality confusion partitioned in madin_etal.py and DISALLOWED_OBJECT_SOURCES.	claude	2026-08-21

--- a/tests/test_gold_mesh_site_curation.py
+++ b/tests/test_gold_mesh_site_curation.py
@@ -96,3 +96,50 @@ class TransformGateTest(TestCase):
             self.assertEqual(transform._mesh_site_terms(), set())
         finally:
             gold_module._MESH_SITE_FILE = original
+
+
+class DeclaredInputTest(TestCase):
+
+    """A curation file a transform reads must be declared, or staleness is invisible."""
+
+    def test_the_curation_file_is_declared_as_a_data_input(self):
+        """
+        `kgm-freshness-check` reads `DATA_INPUTS` and nothing else.
+
+        Undeclared, an edit to the MeSH decisions changes gold's output while
+        every check reports it fresh, and a re-merge ships the old bridges.
+        That is #812, then #839 for ontologies_stubs, and would have been this
+        transform next (#876) — the declaration is opt-in and nothing fails
+        when you forget it.
+        """
+        from kg_microbe.transform_utils.gold.gold import GOLDTransform
+
+        self.assertIn("mappings/gold_ecosystem_mesh_sites.tsv", GOLDTransform.DATA_INPUTS)
+
+    def test_the_declaration_is_derived_from_the_filename_constant(self):
+        """Two hand-kept copies of one path drift; the constant is the single source."""
+        import inspect
+
+        from kg_microbe.transform_utils.gold.gold import GOLDTransform
+
+        declaration = inspect.getsource(GOLDTransform).split("DATA_INPUTS = ")[1].split("\n")[0]
+        self.assertIn("_MESH_SITE_FILE", declaration)
+
+    def test_every_declared_input_exists_and_is_tracked(self):
+        """
+        An untracked path contributes no signal, so the declaration would be inert.
+
+        Same reasoning as #843: the checker asks git, and `is_file()` is the
+        wrong property to assert.
+        """
+        import subprocess
+
+        from kg_microbe.transform_utils.gold.gold import GOLDTransform
+
+        for declared in GOLDTransform.DATA_INPUTS:
+            tracked = subprocess.run(  # noqa: S603 - fixed argv, path from our own constant
+                ["/usr/bin/git", "ls-files", "--error-unmatch", declared],  # noqa: S607
+                cwd=REPO_ROOT,
+                capture_output=True,
+            )
+            self.assertEqual(tracked.returncode, 0, f"{declared} is not tracked in git")

--- a/tests/test_gold_mesh_site_curation.py
+++ b/tests/test_gold_mesh_site_curation.py
@@ -1,0 +1,98 @@
+"""MeSH is bridged per term, because a prefix cannot mean "is a site" (#823)."""
+
+import csv
+from pathlib import Path
+from unittest import TestCase
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CURATION = REPO_ROOT / "mappings" / "gold_ecosystem_mesh_sites.tsv"
+
+
+def _rows():
+    """Curated decisions, skipping the comment header."""
+    with CURATION.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader((ln for ln in handle if not ln.startswith("#")), delimiter="\t"))
+
+
+class CurationFileTest(TestCase):
+
+    """The file is the mechanism, so its shape is part of the contract."""
+
+    def test_every_row_carries_a_decision_and_a_reason(self):
+        """
+        A row without a reason is a decision nobody can review or reverse.
+
+        The whole point of listing REJECTED terms rather than deleting them is
+        that the reasoning survives; an empty reason defeats that.
+        """
+        for row in _rows():
+            self.assertIn(row["decision"], {"SITE", "REJECTED"}, row)
+            self.assertTrue(row["reason"].strip(), f"no reason given for {row['mesh_id']}")
+
+    def test_the_taxon_groups_and_the_chemical_class_are_rejected(self):
+        """
+        The four terms that made a prefix rule untenable.
+
+        `Invertebrates` is the pointed one: it is the host-taxon case already
+        excluded for NCBITaxon on the grounds that `located_in <taxon>` reads as
+        classification, readmitted through a different prefix. `Bacteria` and
+        `Cnidaria` were not named in #823 — found by enumerating every
+        reachable term instead of trusting the two examples, which is why they
+        are here.
+        """
+        rejected = {r["mesh_id"] for r in _rows() if r["decision"] == "REJECTED"}
+        self.assertEqual(
+            rejected,
+            {"mesh:D007448", "mesh:D001419", "mesh:D003063", "mesh:D011084"},
+        )
+
+    def test_the_genuine_sites_are_allowed(self):
+        """The 410 edges #821 gave up are recovered one term at a time."""
+        sites = {r["mesh_id"] for r in _rows() if r["decision"] == "SITE"}
+        self.assertEqual(
+            sites,
+            {"mesh:D000076624", "mesh:D062611", "mesh:D000038", "mesh:D004531", "mesh:D012623"},
+        )
+
+    def test_no_mesh_id_is_decided_twice(self):
+        """Two rows for one term make the outcome depend on read order."""
+        ids = [r["mesh_id"] for r in _rows()]
+        self.assertEqual(sorted(ids), sorted(set(ids)))
+
+
+class TransformGateTest(TestCase):
+
+    """Unlisted means refused, so a new upstream label cannot readmit the error."""
+
+    def test_the_loader_returns_only_site_rows(self):
+        """A REJECTED row must never reach the allow-set."""
+        from kg_microbe.transform_utils.gold.gold import GOLDTransform
+
+        transform = GOLDTransform(
+            input_dir=REPO_ROOT / "data" / "raw",
+            output_dir=REPO_ROOT / "data" / "transformed",
+        )
+        allowed = transform._mesh_site_terms()
+        self.assertIn("mesh:D000038", allowed)
+        self.assertNotIn("mesh:D007448", allowed)
+
+    def test_an_absent_curation_file_bridges_no_mesh(self):
+        """
+        Fail closed to the #821 behaviour.
+
+        If the file goes missing, bridging every MeSH term would silently
+        restore the defect; bridging none is the state #821 deliberately chose.
+        """
+        from kg_microbe.transform_utils.gold import gold as gold_module
+
+        transform = gold_module.GOLDTransform(
+            input_dir=REPO_ROOT / "data" / "raw",
+            output_dir=REPO_ROOT / "data" / "transformed",
+        )
+        original = gold_module._MESH_SITE_FILE
+        try:
+            gold_module._MESH_SITE_FILE = "does_not_exist.tsv"
+            transform._mesh_sites = None
+            self.assertEqual(transform._mesh_site_terms(), set())
+        finally:
+            gold_module._MESH_SITE_FILE = original


### PR DESCRIPTION
Closes #823.

## Background

#821 dropped `mesh:` from `_SITE_PREFIXES` because a prefix rule cannot express "is a site" for a thesaurus spanning anatomy, disease, chemicals and organisms. Correct — and it also discarded five genuine sites, which the issue noted would need a per-term mechanism.

## What enumerating actually found

#823 named two bad matches. Listing *every* reachable MeSH term found **four**:

| term | kind | edges |
|---|---|---:|
| `Invertebrates` mesh:D007448 | taxon group | 188 |
| `Bacteria` mesh:D001419 | taxon group | 189 |
| `Cnidaria` mesh:D003063 | taxon group | 175 |
| `Polycyclic aromatic hydrocarbons` mesh:D011084 | chemical class | 0 |

`Bacteria` and `Cnidaria` weren't in the issue. `Bacteria` is self-referential — the subject of those edges is itself a bacterium. Had I trusted the two examples and allow-listed everything else, both would have shipped.

And five genuine sites recovered:

| term | edges |
|---|---:|
| `Built environment` mesh:D000076624 | 277 |
| `Solid waste` mesh:D062611 | 77 |
| `Abscess` mesh:D000038 | 34 |
| `Eggs` mesh:D004531 | 20 |
| `Seawater` mesh:D012623 | 0 |

`Abscess` is consistent with an existing decision rather than a new one — bacdive already uses `mesh:D000038` as an isolation-source target. `Seawater` has no edges today; it's recorded so the decision exists if GOLD ever attaches organisms to it.

I checked whether **ENVO** could serve these instead, since bridging to a proper environmental ontology would beat MeSH. None of the nine labels has an ENVO match in our extract.

## The mechanism

`mappings/gold_ecosystem_mesh_sites.tsv` decides each term, with a reason. Two properties matter:

- **Unlisted is refused.** Unknown means no, so a new upstream label can't readmit the error class.
- **A missing file bridges no MeSH at all** — failing closed to the #821 state rather than to the defect.

REJECTED rows are kept rather than deleted, so the reasoning survives and re-adding one is deliberate.

## Verification

Real run: 12 mesh bridges emitted, covering exactly the five curated sites; all four rejected terms confirmed absent; edges 705,738 → 705,750.

`poetry run tox`: 1175 passed. The failure, `test_every_referenced_curie_has_stub_node` (`PO:0009005`), reproduces on master unchanged.

Related: this is the fourth independent arrival at the same family-mismatch problem (`DISALLOWED_OBJECT_SOURCES`, the madin substrate/quality partition, #790, this). #823's closing question — whether a shared "is this CURIE site-shaped?" helper should exist — is still open and worth answering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)