### PR TITLE
fix: stop ruff format and ruff check --fix undoing each other

### DIFF
--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -25,7 +25,6 @@ PENDING_HOSTING_MARKER = "REPLACE_ME_"
 
 
 class UnknownDownloadTagError(ValueError):
-
     """
     Raised when a requested -t tag matches no entry in the download config.
 

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -30,7 +30,6 @@ from kg_microbe.utils.transform_fingerprint import write_fingerprint
 
 
 class LazyTransform:
-
     """Resolve one transform class only when it is used."""
 
     def __init__(self, dotted_path: str) -> None:
@@ -72,9 +71,7 @@ DATA_SOURCES = {
     # "TCRDTransform": TCRDTransform,
     # "ProteinAtlasTransform": ProteinAtlasTransform,
     # "STRINGTransform": STRINGTransform,
-    ONTOLOGIES: LazyTransform(
-        "kg_microbe.transform_utils.ontologies.ontologies_transform.OntologiesTransform"
-    ),
+    ONTOLOGIES: LazyTransform("kg_microbe.transform_utils.ontologies.ontologies_transform.OntologiesTransform"),
     # Run ontologies_stubs after ontologies so the SemSQL DBs are present and
     # so the stub-node TSVs land in data/transformed/ontologies_stubs/ before
     # the merge step picks them up.
@@ -94,17 +91,13 @@ DATA_SOURCES = {
     METATRAITS_GTDB: LazyTransform(
         "kg_microbe.transform_utils.metatraits_gtdb.metatraits_gtdb.MetaTraitsGTDBTransform"
     ),
-    RHEAMAPPINGS: LazyTransform(
-        "kg_microbe.transform_utils.rhea_mappings.rhea_mappings.RheaMappingsTransform"
-    ),
+    RHEAMAPPINGS: LazyTransform("kg_microbe.transform_utils.rhea_mappings.rhea_mappings.RheaMappingsTransform"),
     BACTOTRAITS: LazyTransform("kg_microbe.transform_utils.bactotraits.bactotraits.BactoTraitsTransform"),
     # Run gold after ontologies: it reads ncbitaxon_nodes.tsv to apply the
     # NCBITaxon trim, so GOLD cannot reintroduce excluded branches. Set
     # GOLD_APPLY_TAXON_TRIM=false to ingest unfiltered.
     GOLD: LazyTransform("kg_microbe.transform_utils.gold.gold.GOLDTransform"),
-    MICROBEDECODER: LazyTransform(
-        "kg_microbe.transform_utils.microbedecoder.microbedecoder.MicrobeDecoderTransform"
-    ),
+    MICROBEDECODER: LazyTransform("kg_microbe.transform_utils.microbedecoder.microbedecoder.MicrobeDecoderTransform"),
     PREGO: LazyTransform("kg_microbe.transform_utils.prego.prego.PregoTransform"),
     # UNIPROT_HUMAN: UniprotHumanTransform,
     # CTD: CTDTransform,

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -220,7 +220,6 @@ logger = logging.getLogger(__name__)
 
 
 class BacDiveTransform(Transform):
-
     """Template for how the transform class would be designed."""
 
     DATA_INPUTS = (

--- a/kg_microbe/transform_utils/bacdive/emission.py
+++ b/kg_microbe/transform_utils/bacdive/emission.py
@@ -4,7 +4,6 @@ STRAIN_BACDIVE_PREFIX = "kgmicrobe.strain:bacdive_"
 
 
 class StrainProvenanceWriter:
-
     """Add a BacDive strain CURIE to provenance for strain-derived edges."""
 
     def __init__(self, inner_writer, *, knowledge_source: str, ks_column_index: int):

--- a/kg_microbe/transform_utils/bactotraits/bactotraits.py
+++ b/kg_microbe/transform_utils/bactotraits/bactotraits.py
@@ -47,7 +47,6 @@ from kg_microbe.utils.pandas_utils import drop_duplicates
 
 
 class BactoTraitsTransform(Transform):
-
     """
     BactoTraits transform.
 

--- a/kg_microbe/transform_utils/bakta/bakta.py
+++ b/kg_microbe/transform_utils/bakta/bakta.py
@@ -54,7 +54,6 @@ logger = logging.getLogger(__name__)
 
 
 class BaktaTransform(Transform):
-
     """Transform Bakta genome annotations into KGX format."""
 
     def __init__(

--- a/kg_microbe/transform_utils/cog/cog.py
+++ b/kg_microbe/transform_utils/cog/cog.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 class COGTransform(Transform):
-
     """Transform COG functional classifications into KGX format."""
 
     def __init__(

--- a/kg_microbe/transform_utils/ctd/ctd.py
+++ b/kg_microbe/transform_utils/ctd/ctd.py
@@ -37,7 +37,6 @@ RELATIONS_DICT = {
 
 
 class CTDTransform(Transform):
-
     """A class used to represent a transformation process for UniProt data."""
 
     DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)

--- a/kg_microbe/transform_utils/disbiome/disbiome.py
+++ b/kg_microbe/transform_utils/disbiome/disbiome.py
@@ -32,7 +32,6 @@ from kg_microbe.utils.pandas_utils import drop_duplicates
 
 
 class DisbiomeTransform(Transform):
-
     """A class used to represent a transformation process for Disbiome data."""
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/transform_utils/example_transform/example_transform.py
+++ b/kg_microbe/transform_utils/example_transform/example_transform.py
@@ -25,7 +25,6 @@ from kg_microbe.utils.robot_utils import convert_to_json, extract_convert_to_jso
 
 
 class YourTransform(Transform):
-
     """Template for how the transform class would be designed."""
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -275,7 +275,6 @@ _TAXON_PREFIX = "NCBITaxon:"
 
 
 class GOLDTransform(Transform):
-
     """Conform the pre-transformed GOLD KGX TSVs to the KG-Microbe standard."""
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/transform_utils/gtdb/gtdb.py
+++ b/kg_microbe/transform_utils/gtdb/gtdb.py
@@ -41,7 +41,6 @@ from kg_microbe.transform_utils.transform import Transform
 
 
 class GTDBTransform(Transform):
-
     """Transform GTDB taxonomy and genome data into KGX format."""
 
     def __init__(self, input_dir=None, output_dir=None):

--- a/kg_microbe/transform_utils/kegg/kegg.py
+++ b/kg_microbe/transform_utils/kegg/kegg.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 
 class KEGGTransform(Transform):
-
     """Transform KEGG orthology data into KGX format."""
 
     def __init__(

--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -118,7 +118,6 @@ DEPRECATED_STATUSES = frozenset(
 
 
 class _GTDBRankNameIndex:
-
     """
     Pre-load GTDB nodes.tsv into a ``(rank_prefix, name) -> [CURIE, ...]`` map.
 
@@ -163,7 +162,6 @@ class _GTDBRankNameIndex:
 
 
 class _NCBILabelIndex:
-
     """
     Pre-load NCBITaxon labels + exact synonyms, filtered to bacteria + archaea.
 
@@ -243,7 +241,6 @@ class _NCBILabelIndex:
 
 
 class LPSNTransform(Transform):
-
     """Transform LPSN GSS CSV bulk export into KGX nodes + edges."""
 
     def __init__(

--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -115,7 +115,6 @@ GSS_NODES_RELPATH = "transformed/lpsn/nodes.tsv"
 
 
 class LPSNAPITransform(Transform):
-
     """Fetch per-record LPSN JSON, emit enrichment nodes + edges."""
 
     def __init__(

--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -182,7 +182,6 @@ def _partition_substrate_quality_curies(
 
 
 class MadinEtAlTransform(Transform):
-
     """
     Ingest Madin et al dataset (NCBI/GTDB).
 

--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -126,7 +126,6 @@ from kg_microbe.utils.pandas_utils import (
 
 
 class MediaDiveTransform(Transform):
-
     """Template for how the transform class would be designed."""
 
     DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)

--- a/kg_microbe/transform_utils/metatraits/io.py
+++ b/kg_microbe/transform_utils/metatraits/io.py
@@ -28,7 +28,6 @@ def open_jsonl(path: Path) -> IO[str]:
 
 
 class StreamingRowWriter:
-
     """Write TSV rows incrementally without accumulating a graph in memory."""
 
     def __init__(self, output_file: Path, header: List[str]):

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -251,7 +251,6 @@ def _process_file_worker(args: Tuple[Path, Path, Dict[str, Any], bool]) -> Dict[
 
 
 class MetaTraitsTransform(Transform):
-
     """Transform metatraits summary JSONL files into KGX nodes and edges."""
 
     DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)

--- a/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
+++ b/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
@@ -28,7 +28,6 @@ METATRAITS_GTDB_INPUT_FILES = [
 
 
 class MetaTraitsGTDBTransform(MetaTraitsTransform):
-
     """Transform GTDB metatraits summary JSONL files into KGX nodes and edges."""
 
     def __init__(

--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -132,7 +132,6 @@ _GROUP_TO_KS: Dict[str, str] = {
 
 
 class MicrobeDecoderTransform(Transform):
-
     """Transform the MicrobeDecoder wide CSV into KGX nodes and edges."""
 
     DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -138,7 +138,6 @@ def _run_kgx_transform(**kwargs) -> None:
 
 
 class OntologiesTransform(Transform):
-
     """OntologyTransform parses an Obograph JSON form of an Ontology into nodes nad edges."""
 
     # Mapping of ontology names to InforES standard knowledge sources

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -233,7 +233,6 @@ ONTOLOGIES_STUBS_SOURCE_NAME = "ontologies_stubs"
 
 
 class OntologiesStubsTransform(Transform):
-
     """Emit one labelled stub node per referenced NCIT / mesh / BTO / PO / MICRO CURIE."""
 
     #: Derived from the collector's own list rather than restated, so the two

--- a/kg_microbe/transform_utils/prego/calibration.py
+++ b/kg_microbe/transform_utils/prego/calibration.py
@@ -135,7 +135,6 @@ def _bin_index(score: float) -> int:
 
 
 class ScoreHistogram:
-
     """
     Fixed-width histogram of raw scores for one resource.
 

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -171,7 +171,6 @@ def _as_float(value) -> float:
 
 
 class PregoTransform(Transform):
-
     """Ingest PREGO taxon↔environment/process associations."""
 
     # Ceiling on distinct habitat values tracked per run. The measured value

--- a/kg_microbe/transform_utils/prego/quality.py
+++ b/kg_microbe/transform_utils/prego/quality.py
@@ -79,7 +79,6 @@ from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 
 class GoldStandard:
-
     """
     A set of curated ``(subject, object)`` pairs plus the entity space it covers.
 
@@ -279,7 +278,6 @@ def is_monotone_increasing(results: Sequence[Dict[str, float]]) -> bool:
 
 
 class LabelledEvidence:
-
     """
     Positive/negative labels for ``(subject, object)`` pairs.
 

--- a/kg_microbe/transform_utils/rhea_mappings/rhea_mappings.py
+++ b/kg_microbe/transform_utils/rhea_mappings/rhea_mappings.py
@@ -84,7 +84,6 @@ logger = logging.getLogger(__name__)
 
 
 class RheaMappingsTransform(Transform):
-
     """Template for how the transform class would be designed."""
 
     def __init__(

--- a/kg_microbe/transform_utils/transform.py
+++ b/kg_microbe/transform_utils/transform.py
@@ -27,7 +27,6 @@ from kg_microbe.transform_utils.constants import (
 
 
 class Transform:
-
     """Parent class for transforms, that sets up a lot of default file info."""
 
     DATA_DIR = Path(__file__).parent / "data"

--- a/kg_microbe/transform_utils/uniprot_functional_microbes/uniprot_functional_microbes.py
+++ b/kg_microbe/transform_utils/uniprot_functional_microbes/uniprot_functional_microbes.py
@@ -28,7 +28,6 @@ OBSOLETE_TERMS_CSV_FILE = UNIPROT_FUNCTIONAL_MICROBES_TMP_DIR / "go_obsolete_ter
 
 
 class UniprotFunctionalMicrobesTransform(Transform):
-
     """A class used to represent a transformation process for UniProt data."""
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/transform_utils/uniprot_human/uniprot_human.py
+++ b/kg_microbe/transform_utils/uniprot_human/uniprot_human.py
@@ -28,7 +28,6 @@ OBSOLETE_TERMS_CSV_FILE = UNIPROT_HUMAN_TMP_DIR / "go_obsolete_terms.tsv"
 
 
 class UniprotHumanTransform(Transform):
-
     """A class used to represent a transformation process for UniProt data."""
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/transform_utils/uniprot_trembl/uniprot_trembl.py
+++ b/kg_microbe/transform_utils/uniprot_trembl/uniprot_trembl.py
@@ -10,7 +10,6 @@ from kg_microbe.utils.trembl_utils import unzip_trembl_file
 
 
 class UniprotTrEMBLTransform(Transform):
-
     """Uniprot TrEMBL transform."""
 
     def __init__(self, input_dir: Optional[Union[str, Path]], output_dir: Optional[Union[str, Path]]):

--- a/kg_microbe/transform_utils/wallen_etal/wallen_etal.py
+++ b/kg_microbe/transform_utils/wallen_etal/wallen_etal.py
@@ -33,7 +33,6 @@ PARKINSONS_DISEASE_MONDO_ID = "MONDO:0005180"
 
 
 class WallenEtAlTransform(Transform):
-
     """A class used to represent a transformation process for PdMetagenomics data."""
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/utils/biolink_hierarchy.py
+++ b/kg_microbe/utils/biolink_hierarchy.py
@@ -11,7 +11,6 @@ from kg_microbe.transform_utils.constants import BIOLINK_MODEL_FILE
 
 
 class BiolinkHierarchy:
-
     """
     Utility for Biolink Model category hierarchy operations.
 

--- a/kg_microbe/utils/biolink_model.py
+++ b/kg_microbe/utils/biolink_model.py
@@ -28,9 +28,7 @@ def prepare_kgx() -> None:
     its no-argument construction to pinned repository files.
     """
     schema_path = _configured_path("KG_MICROBE_BIOLINK_MODEL", DEFAULT_SCHEMA_PATH)
-    predicate_map_path = _configured_path(
-        "KG_MICROBE_BIOLINK_PREDICATE_MAP", DEFAULT_PREDICATE_MAP_PATH
-    )
+    predicate_map_path = _configured_path("KG_MICROBE_BIOLINK_PREDICATE_MAP", DEFAULT_PREDICATE_MAP_PATH)
     missing = [path for path in (schema_path, predicate_map_path) if not path.is_file()]
     if missing:
         formatted = ", ".join(str(path) for path in missing)
@@ -49,7 +47,6 @@ def prepare_kgx() -> None:
         return
 
     class LocalToolkit(current):
-
         """BMT Toolkit whose omitted inputs resolve to pinned local files."""
 
         _kg_microbe_local_defaults = (str(schema_path), str(predicate_map_path))
@@ -60,6 +57,7 @@ def prepare_kgx() -> None:
             predicate_map: Any = None,
             **kwargs: Any,
         ) -> None:
+            """Substitute the pinned local files for any argument left unset."""
             resolved_schema = str(schema_path) if schema is None else schema
             resolved_predicate_map = predicate_map_path if predicate_map is None else predicate_map
 

--- a/kg_microbe/utils/chemical_mapping_utils.py
+++ b/kg_microbe/utils/chemical_mapping_utils.py
@@ -719,7 +719,6 @@ def get_node_enrichment(curie: str) -> Dict[str, str]:
 
 
 class ChemicalMappingLoader:
-
     """
     Loader class for unified chemical mappings.
 

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -36,7 +36,6 @@ METPO_PROPERTIES_ROBOT_TEMPLATE_URL = (
 
 
 class _LocalTemplateResponse:
-
     """Small requests.Response-compatible wrapper for an immutable local fixture."""
 
     def __init__(self, text: str) -> None:
@@ -54,6 +53,7 @@ def _metpo_template_response(url: str, filename: str):
     if local_path.is_file():
         return _LocalTemplateResponse(local_path.read_text(encoding="utf-8"))
     return requests.get(url, timeout=30)
+
 
 # Remote URL for assay kits mapping (used for API keys from BacDive)
 ASSAY_KITS_SIMPLE_JSON_URL = (
@@ -112,7 +112,6 @@ def uri_to_curie(uri: str) -> str:
 
 
 class MetpoTreeNode:
-
     """
     Represents a node in the METPO class hierarchy tree.
 

--- a/kg_microbe/utils/ontology_resolution.py
+++ b/kg_microbe/utils/ontology_resolution.py
@@ -25,7 +25,6 @@ from kg_microbe.transform_utils.constants import (
 
 
 class CategoryAdapter(Protocol):
-
     """Minimal adapter surface needed by ChEBI category policy."""
 
     def ancestors(self, term_id: str):

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -1016,7 +1016,6 @@ def _read_head(path: Path, nbytes: int, *, prefer_archive: bool = False) -> Opti
 
 
 class FatalOntologyError(BaseException):
-
     """
     An ontology is unusable and no per-item fallback is honest.
 
@@ -1044,7 +1043,6 @@ class FatalOntologyError(BaseException):
 
 
 class OntologyDbUnavailableError(FatalOntologyError):
-
     """
     No usable SemSQL DB could be produced for an ontology.
 
@@ -1055,7 +1053,6 @@ class OntologyDbUnavailableError(FatalOntologyError):
 
 
 class OntologyVersionMismatchError(FatalOntologyError):
-
     """
     A DB and the OWL it must track are stamped with different releases.
 
@@ -1072,7 +1069,6 @@ ChebiDbUnavailableError = OntologyDbUnavailableError
 
 
 class KeptTarget(NamedTuple):
-
     """
     What :func:`_clear_build_target` displaced, so it can be put back.
 
@@ -1092,7 +1088,6 @@ class KeptTarget(NamedTuple):
 
 
 class DbEnsureResult(NamedTuple):
-
     """
     Outcome of an ``_ensure_*_db`` call.
 
@@ -2288,7 +2283,6 @@ get_ontology_adapter.cache_clear = _ontology_adapter_for.cache_clear
 
 
 class _LazyOntologyAdapter:
-
     """
     An ontology adapter that resolves on first use, not on construction.
 

--- a/kg_microbe/utils/transform_fingerprint.py
+++ b/kg_microbe/utils/transform_fingerprint.py
@@ -68,9 +68,7 @@ def bounded_file_fingerprint(path: Path) -> str:
             return f"full-sha256:{digest.hexdigest()}"
 
         last_offset = max(size - SAMPLE_SIZE, 0)
-        offsets = sorted(
-            {(last_offset * index) // (SAMPLE_COUNT - 1) for index in range(SAMPLE_COUNT)}
-        )
+        offsets = sorted({(last_offset * index) // (SAMPLE_COUNT - 1) for index in range(SAMPLE_COUNT)})
         for offset in offsets:
             handle.seek(offset)
             sample = handle.read(SAMPLE_SIZE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,15 @@ target-version = "py310"
 extend-ignore = [
     "D211",  # `no-blank-line-before-class`
     "D212",  # `multi-line-summary-first-line`
+    # D203 and the formatter disagree, and `tox -e format` runs both in sequence:
+    # `ruff format` strips the blank line before a class docstring, then
+    # `ruff check --fix` puts it back. Net zero, exit 0 — so the format env has
+    # been a silent no-op, and `ruff format --check` has reported ~98 files
+    # unformatted indefinitely because the fix can never stick. Ruff warns about
+    # exactly this pairing on every run. D211 (its mutually exclusive opposite)
+    # is already ignored above, so ignoring D203 leaves the formatter to decide,
+    # which is the only self-consistent option (#874).
+    "D203",  # `one-blank-line-before-class` — conflicts with `ruff format`
     "S301",  # `pickle` and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue`
     "S605",  # Starting a process with a shell, possible injection detected
     "S202",  # Uses of `tarfile.extractall()` - needed for KGX merge workflow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,11 +59,13 @@ def block_external_network(monkeypatch: pytest.MonkeyPatch, request: pytest.Fixt
     real_connect = socket.socket.connect
 
     def guarded_getaddrinfo(host: Any, *args: Any, **kwargs: Any):
+        """Resolve loopback hosts only, so a unit test cannot reach the network."""
         if not _is_loopback(host):
             raise RuntimeError(f"external network disabled in unit tests: {host}")
         return real_getaddrinfo(host, *args, **kwargs)
 
     def guarded_connect(sock: socket.socket, address: Any) -> Any:
+        """Permit connections to loopback only, for the same reason."""
         host = address[0] if isinstance(address, tuple) else address
         if not _is_loopback(host):
             raise RuntimeError(f"external network disabled in unit tests: {host}")

--- a/tests/demo_test.py
+++ b/tests/demo_test.py
@@ -6,7 +6,6 @@ from kg_microbe import __version__
 
 
 class TestVersion(unittest.TestCase):
-
     """Test version."""
 
     def test_version_type(self):

--- a/tests/resources/mock_download.py
+++ b/tests/resources/mock_download.py
@@ -5,7 +5,6 @@ def mocked_requests_get(*args, **kwargs):
     """Mock the requests.get method."""
 
     class MockResponse:
-
         """Mock HTTP response object for testing."""
 
         def __init__(self, json_data, status_code):

--- a/tests/test_assay_generation.py
+++ b/tests/test_assay_generation.py
@@ -36,7 +36,6 @@ from kg_microbe.utils.mapping_file_utils import (
 
 
 class TestAssayGeneration(unittest.TestCase):
-
     """Tests for assay node and edge generation functions."""
 
     def setUp(self) -> None:
@@ -328,7 +327,6 @@ class TestAssayGeneration(unittest.TestCase):
 
 
 class TestECSubstrateEdges(unittest.TestCase):
-
     """Tests for EC→substrate edge generation from bacdive_mappings.tsv."""
 
     def setUp(self) -> None:

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -23,7 +23,6 @@ from kg_microbe.utils.atomic_io import atomic_write, cache_is_complete, has_data
 
 
 class TestAtomicWrite:
-
     """The helper itself."""
 
     def test_content_is_committed_on_success(self, tmp_path):
@@ -78,11 +77,9 @@ class TestAtomicWrite:
 
 
 class TestGoCategoryTreesIsNotPoisoned:
-
     """The concrete case: go_category_trees.tsv (Codex F2)."""
 
     class _Unavailable:
-
         """A lazy proxy whose resolution fails."""
 
         def __getattr__(self, name):
@@ -92,7 +89,6 @@ class TestGoCategoryTreesIsNotPoisoned:
             raise ou.OntologyDbUnavailableError("no usable go.db")
 
     class _Fake:
-
         """A working GO adapter."""
 
         def descendants(self, start_curies, predicates, reflexive):
@@ -163,7 +159,6 @@ class TestGoCategoryTreesIsNotPoisoned:
 
 
 class TestExistingPoisonedCacheHeals:
-
     """Atomic writes stop new poisoning; an *existing* poisoned file must heal."""
 
     def test_header_only_cache_is_not_treated_as_complete(self, tmp_path, monkeypatch):
@@ -219,7 +214,6 @@ class TestExistingPoisonedCacheHeals:
 
 
 class TestAllPoisonedCachesHeal:
-
     """
     Every .exists()-guarded cache must reject a header-only file, not just GO's.
 
@@ -256,7 +250,6 @@ class TestAllPoisonedCachesHeal:
 
 
 class TestCallSitesUseTheGuardedHelpers:
-
     """
     Each cache guard must *decide* regeneration, and each writer must be used.
 
@@ -409,7 +402,6 @@ class TestCallSitesUseTheGuardedHelpers:
 
 
 class TestMarkerAndSweeperAdversarial:
-
     """Round-4: the completion marker and the stale-partial sweeper."""
 
     def test_marker_does_not_certify_a_replaced_file(self, tmp_path):
@@ -462,7 +454,6 @@ class TestMarkerAndSweeperAdversarial:
 
 
 class TestMarkerIdentity:
-
     """A marker must certify the file it was written for, and no other."""
 
     def test_same_size_replacement_is_not_certified(self, tmp_path):
@@ -506,7 +497,6 @@ class TestMarkerIdentity:
 
 
 class TestMarkerIsConclusive:
-
     """Round-15: a digest mismatch must not be overridden by a row count."""
 
     def test_a_truncated_marked_cache_is_incomplete(self, tmp_path):

--- a/tests/test_bacdive_json_path_extraction.py
+++ b/tests/test_bacdive_json_path_extraction.py
@@ -29,7 +29,6 @@ ARRAY_SHAPED = {
 
 
 class BacDiveJsonPathExtractionTest(TestCase):
-
     """`_extract_value_from_json_path` must traverse arrays, not bail on them."""
 
     def setUp(self):

--- a/tests/test_bacdive_lpsn_crossref.py
+++ b/tests/test_bacdive_lpsn_crossref.py
@@ -284,7 +284,6 @@ def _provenance_writer():
     captured = []
 
     class _Sink:
-
         """Collect rows instead of writing them."""
 
         def writerow(self, row):
@@ -334,7 +333,6 @@ def test_lpsn_edge_carries_the_list_form_knowledge_source():
     captured = []
 
     class _Sink:
-
         """Collect rows instead of writing them."""
 
         def writerow(self, row):
@@ -361,7 +359,6 @@ def test_non_strain_edges_keep_their_bare_knowledge_source():
     captured = []
 
     class _Sink:
-
         """Collect rows instead of writing them."""
 
         def writerow(self, row):

--- a/tests/test_bacdive_ncbitaxon_stubs.py
+++ b/tests/test_bacdive_ncbitaxon_stubs.py
@@ -59,7 +59,6 @@ def _output_predates(output: Path, tracked_input: Path) -> bool:
 
 
 class NcbiTaxonStubTest(TestCase):
-
     """The trim drops host taxa the isolation-source mapping still points at."""
 
     def test_the_category_used_for_stubs_is_organism_taxon(self):

--- a/tests/test_bacdive_provenance.py
+++ b/tests/test_bacdive_provenance.py
@@ -6,7 +6,6 @@ from kg_microbe.transform_utils.bacdive.emission import StrainProvenanceWriter
 
 
 class _DummyWriter:
-
     """Minimal csv.writer stand-in that captures rows in memory for inspection."""
 
     def __init__(self):

--- a/tests/test_bacdive_reference_conflicts.py
+++ b/tests/test_bacdive_reference_conflicts.py
@@ -34,7 +34,6 @@ SUBSUMPTION = {
 
 
 class ObservationExtractionTest(TestCase):
-
     """Both BacDive block shapes must be read by one code path."""
 
     def test_a_list_of_per_reference_dicts(self):
@@ -72,7 +71,6 @@ class ObservationExtractionTest(TestCase):
 
 
 class ClassifyTest(TestCase):
-
     """Separating 'more specific' from 'contradictory' is the whole point."""
 
     def test_a_term_and_its_parent_is_specificity_not_conflict(self):
@@ -131,7 +129,6 @@ class ClassifyTest(TestCase):
 
 
 class FieldScopedResolutionTest(TestCase):
-
     """
     A synonym shared by two METPO terms must be resolved per field.
 

--- a/tests/test_bakta.py
+++ b/tests/test_bakta.py
@@ -16,7 +16,6 @@ from kg_microbe.transform_utils.bakta.utils import (
 
 
 class TestBaktaUtils(unittest.TestCase):
-
     """Test Bakta utility functions."""
 
     def test_parse_dbxrefs(self):
@@ -119,7 +118,6 @@ class TestBaktaUtils(unittest.TestCase):
 
 
 class TestBaktaTransform(unittest.TestCase):
-
     """Test BaktaTransform class."""
 
     def setUp(self):

--- a/tests/test_biolink_hierarchy.py
+++ b/tests/test_biolink_hierarchy.py
@@ -17,7 +17,6 @@ def hierarchy():
 
 
 class TestBiolinkHierarchy:
-
     """Test BiolinkHierarchy class methods."""
 
     def test_initialization(self, hierarchy):

--- a/tests/test_chebi_db_build.py
+++ b/tests/test_chebi_db_build.py
@@ -73,7 +73,6 @@ def _fake_build(monkeypatch, db_path, *, size=16, fail=False):
 
 
 class TestChebiReleaseReader:
-
     """ChEBI's integer stamp must be read where the date reader cannot."""
 
     def test_reads_version_iri(self, tmp_path):
@@ -132,7 +131,6 @@ class TestChebiReleaseReader:
 
 
 class TestChebiGate:
-
     """The gate must fire on drift and stay quiet otherwise."""
 
     def test_aligned_is_silent(self, tmp_path, monkeypatch, capsys):
@@ -169,7 +167,6 @@ class TestChebiGate:
 
 
 class TestChebiBuild:
-
     """Build behaviour mirrors _ensure_go_db / _ensure_ncbitaxon_db."""
 
     def test_aligned_db_is_reused(self, tmp_path, monkeypatch):
@@ -448,7 +445,6 @@ class TestChebiBuild:
 
 
 class TestAdapterEntryPoint:
-
     """Both category-fixing paths must go through one ensured adapter."""
 
     def test_get_chebi_adapter_ensures_and_gates(self, tmp_path, monkeypatch):

--- a/tests/test_chemical_mapping_utils.py
+++ b/tests/test_chemical_mapping_utils.py
@@ -223,7 +223,6 @@ def reset_cache():
 
 
 class TestNormalizeName:
-
     """Test name normalization."""
 
     def test_normalize_lowercase(self):
@@ -249,7 +248,6 @@ class TestNormalizeName:
 
 
 class TestLoadUnifiedMappings:
-
     """Test loading unified mappings file."""
 
     def test_load_with_path(self, mock_mappings_file):
@@ -277,7 +275,6 @@ class TestLoadUnifiedMappings:
 
 
 class TestFindChebiByName:
-
     """Test ChEBI ID lookup by name."""
 
     def test_find_by_canonical_name(self, mock_mappings_file):
@@ -319,7 +316,6 @@ class TestFindChebiByName:
 
 
 class TestFindChebiByFormula:
-
     """Test ChEBI ID lookup by formula."""
 
     def test_find_by_formula(self, mock_mappings_file):
@@ -349,7 +345,6 @@ class TestFindChebiByFormula:
 
 
 class TestFindChebiByXref:
-
     """Test ChEBI ID lookup by cross-reference."""
 
     def test_find_by_cas_number(self, mock_mappings_file):
@@ -386,7 +381,6 @@ class TestFindChebiByXref:
 
 
 class TestGetCanonicalName:
-
     """Test getting canonical name for ChEBI ID."""
 
     def test_get_canonical_name(self, mock_mappings_file):
@@ -408,7 +402,6 @@ class TestGetCanonicalName:
 
 
 class TestGetSynonyms:
-
     """Test getting synonyms for ChEBI ID."""
 
     def test_get_synonyms(self, mock_mappings_file):
@@ -432,7 +425,6 @@ class TestGetSynonyms:
 
 
 class TestGetXrefs:
-
     """Test getting cross-references for ChEBI ID."""
 
     def test_get_xrefs(self, mock_mappings_file):
@@ -455,7 +447,6 @@ class TestGetXrefs:
 
 
 class TestGetFormula:
-
     """Test getting formula for ChEBI ID."""
 
     def test_get_formula(self, mock_mappings_file):
@@ -477,7 +468,6 @@ class TestGetFormula:
 
 
 class TestChemicalMappingLoader:
-
     """Test ChemicalMappingLoader class."""
 
     def test_loader_initialization(self, mock_mappings_file):
@@ -528,7 +518,6 @@ class TestChemicalMappingLoader:
 
 
 class TestStripStereochemistry:
-
     """Test stereochemistry prefix normalization."""
 
     def test_r_prefix(self):
@@ -567,7 +556,6 @@ class TestStripStereochemistry:
 
 
 class TestFuzzyStereochemistry:
-
     """Test fuzzy stereochemistry retry behavior in find_chebi_by_name."""
 
     def test_fuzzy_retry_finds_match(self, mock_mappings_file):
@@ -599,7 +587,6 @@ class TestFuzzyStereochemistry:
 
 
 class TestNegativeCache:
-
     """Test bounded negative-lookup cache behavior."""
 
     def test_miss_is_cached(self, mock_mappings_file):
@@ -650,7 +637,6 @@ class TestNegativeCache:
 
 
 class TestFuzzyHydrate:
-
     """Hydrate-suffix retry behavior in ``find_chebi_by_name``."""
 
     @pytest.fixture
@@ -719,7 +705,6 @@ class TestFuzzyHydrate:
 
 
 class TestNarrowMatchChildResolution:
-
     """
     Regression tests for the asymmetric-MIM child-CURIE resolution path.
 
@@ -775,7 +760,6 @@ class TestNarrowMatchChildResolution:
 
 
 class TestHydrateEquivalents:
-
     """
     Regression tests for ``get_hydrate_equivalents``.
 
@@ -832,7 +816,6 @@ class TestHydrateEquivalents:
 
 
 class TestKnownBadFilters:
-
     """
     Regression guards for the consolidator's KNOWN_BAD_* filter lists.
 
@@ -875,7 +858,6 @@ class TestKnownBadFilters:
 
 
 class TestNamePrecedence:
-
     """
     Regression tests for canonical-vs-synonym name index precedence.
 

--- a/tests/test_chemical_stereochemistry.py
+++ b/tests/test_chemical_stereochemistry.py
@@ -6,7 +6,6 @@ from kg_microbe.utils.chemical_mapping_utils import normalize_name
 
 
 class TestStereochemistryHandling(unittest.TestCase):
-
     """Test stereochemistry prefix stripping."""
 
     def test_normalize_name_basic(self):

--- a/tests/test_cli_offline_startup.py
+++ b/tests/test_cli_offline_startup.py
@@ -68,10 +68,10 @@ def test_pinned_predicate_map_does_not_use_legacy_bmt_network_path(monkeypatch) 
     from kg_microbe.utils.biolink_model import prepare_kgx
 
     class LegacyToolkit:
-
         """Stand in for BMT 1.4.8, whose constructor always fetches the map."""
 
         def __init__(self, *args, **kwargs):
+            """Fail loudly if constructed, proving the shim is what runs."""
             raise AssertionError("legacy BMT constructor would perform requests.get")
 
     monkeypatch.setattr(bmt, "Toolkit", LegacyToolkit)

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -14,7 +14,6 @@ from kg_microbe.transform_utils.cog.utils import (
 
 
 class TestCOGUtils(unittest.TestCase):
-
     """Test COG utility functions."""
 
     def setUp(self):
@@ -93,7 +92,6 @@ class TestCOGUtils(unittest.TestCase):
 
 
 class TestCOGTransform(unittest.TestCase):
-
     """Test COG transform class."""
 
     def setUp(self):

--- a/tests/test_consolidate_chemical_mappings.py
+++ b/tests/test_consolidate_chemical_mappings.py
@@ -31,7 +31,6 @@ def _load_module():
 
 
 class ExtractCurieTests(unittest.TestCase):
-
     """``extract_curie`` preserves accepted prefixes and rejects everything else."""
 
     @classmethod
@@ -96,7 +95,6 @@ class ExtractCurieTests(unittest.TestCase):
 
 
 class IsMangledChebiTests(unittest.TestCase):
-
     """``is_mangled_chebi_id`` recognises pre-fix mangler outputs."""
 
     @classmethod
@@ -158,7 +156,6 @@ class IsMangledChebiTests(unittest.TestCase):
 
 
 class LoaderFilteringTests(unittest.TestCase):
-
     """
     Loader-side filtering tests.
 

--- a/tests/test_corrected_column_divergence.py
+++ b/tests/test_corrected_column_divergence.py
@@ -15,7 +15,6 @@ _SPEC.loader.exec_module(_MODULE)
 
 
 class CorrectedColumnDivergenceTest(TestCase):
-
     """`corrected_column_primary` must expose ties the production order hides."""
 
     def test_a_correction_that_loses_the_tie_is_visible(self):

--- a/tests/test_data_inputs_cover_reads.py
+++ b/tests/test_data_inputs_cover_reads.py
@@ -14,7 +14,6 @@ REPO = Path(__file__).resolve().parents[1]
 
 
 class OntologiesStubsDeclarationTest(TestCase):
-
     """The freshness checker reads DATA_INPUTS and nothing else."""
 
     def test_every_collected_mapping_file_is_declared(self):
@@ -109,7 +108,6 @@ class OntologiesStubsDeclarationTest(TestCase):
 
 
 class OutOfRepoPathTest(TestCase):
-
     """The derivation must not turn a config mistake into an ImportError (#841)."""
 
     def test_a_path_outside_the_repo_is_skipped_not_raised(self):

--- a/tests/test_download_tags.py
+++ b/tests/test_download_tags.py
@@ -66,7 +66,6 @@ def _entries():
 
 
 class TestYamlTagging:
-
     """Every active download entry must be reachable via -t."""
 
     def test_every_entry_has_a_tag(self):
@@ -119,7 +118,6 @@ class TestYamlTagging:
 
 
 class TestPendingHosting:
-
     """
     Sources with a placeholder URL must be skipped, not attempted.
 
@@ -238,7 +236,6 @@ class TestPendingHosting:
 
 
 class TestCliErrorHandling:
-
     """The CLI must report bad tags as usage errors without hiding real crashes."""
 
     def test_unknown_tag_is_a_usage_error(self, tmp_path):
@@ -272,7 +269,6 @@ class TestCliErrorHandling:
 
 
 class TestTagPlumbing:
-
     """Tags must reach kghub-downloader, and gate the MediaDive bulk step."""
 
     def _run(self, tmp_path, **kwargs):

--- a/tests/test_duckdb_query_cli.py
+++ b/tests/test_duckdb_query_cli.py
@@ -94,6 +94,7 @@ def test_failed_rebuild_preserves_last_valid_database(tmp_path: Path, monkeypatc
     before = hashlib.sha256(db_path.read_bytes()).hexdigest()
 
     def fail_edges(conn, table_name, path, columns):
+        """Load nodes normally, then fail on edges to leave a half-built database."""
         if table_name == "edges":
             raise ValueError("synthetic ingest failure")
         return original_load_table(conn, table_name, path, columns)

--- a/tests/test_ec_db_build.py
+++ b/tests/test_ec_db_build.py
@@ -44,7 +44,6 @@ def _make_ec_db(tmp_path: Path, release, name: str = "ec.db") -> str:
 
 
 class TestEcReleaseReader:
-
     """EC's versionIRI-object stamp must be read where the value-column reader cannot."""
 
     def test_reads_versioniri_date(self, tmp_path):
@@ -97,7 +96,6 @@ class TestEcReleaseReader:
 
 
 class TestEcDbBuild:
-
     """`_ensure_ec_db` must realign on release drift, not serve stale forever."""
 
     def test_aligned_db_is_reused(self, tmp_path, monkeypatch):

--- a/tests/test_extract_metpo_proposals.py
+++ b/tests/test_extract_metpo_proposals.py
@@ -49,7 +49,6 @@ def _diff(actual: Path, expected: Path) -> str:
 
 
 class TestProposalOutputsMatchCommitted(unittest.TestCase):
-
     """Re-run the extractor and assert it reproduces every committed artifact byte-for-byte."""
 
     def test_outputs_match_committed(self):
@@ -159,7 +158,6 @@ def _positive_stems(label: str) -> set[str]:
 
 
 class TestPositiveStemHeuristic(unittest.TestCase):
-
     """
     The pairing test is only as good as its stem derivation.
 
@@ -188,7 +186,6 @@ class TestPositiveStemHeuristic(unittest.TestCase):
 
 
 class TestProposedPredicatePairing(unittest.TestCase):
-
     """
     Guard the pairing contract that #749 broke silently.
 

--- a/tests/test_freshness_output_aliases.py
+++ b/tests/test_freshness_output_aliases.py
@@ -16,7 +16,6 @@ _SPEC.loader.exec_module(_MODULE)
 
 
 class FreshnessOutputAliasTest(TestCase):
-
     """PREGO writes prego_habitat/ by default, prego/ only under PREGO_SHAPES=all."""
 
     def setUp(self):

--- a/tests/test_gold_ecosystem_resolution.py
+++ b/tests/test_gold_ecosystem_resolution.py
@@ -68,7 +68,6 @@ def _run():
 
 
 class EcosystemResolutionTest(TestCase):
-
     """The meaning is in the hierarchy, so a one-hop query must still find it."""
 
     def setUp(self):
@@ -141,7 +140,6 @@ class EcosystemResolutionTest(TestCase):
 
 
 class EnvoCrosswalkTest(TestCase):
-
     """The GOLD ontology's curated ENVO mappings bridge the ecosystem island."""
 
     def test_the_crosswalk_is_gated_on_the_envo_node_existing(self):
@@ -178,7 +176,6 @@ class EnvoCrosswalkTest(TestCase):
 
 
 class PredicateAndSiteTest(TestCase):
-
     """Biolink's definitions decide the predicate and what may be a site."""
 
     def test_environment_edges_are_located_in_not_occurs_in(self):

--- a/tests/test_gold_merge_wiring.py
+++ b/tests/test_gold_merge_wiring.py
@@ -23,7 +23,6 @@ def _sources(name):
 
 
 class GoldMergeWiringTest(TestCase):
-
     """GOLD ran on every transform and reached no merge config until now."""
 
     def test_gold_is_in_every_config_that_carries_the_standard_graph(self):
@@ -43,7 +42,6 @@ class GoldMergeWiringTest(TestCase):
 
 
 class TaxonOverlapTest(TestCase):
-
     """GOLD re-states NCBITaxon nodes the ontologies transform already supplies."""
 
     def setUp(self):
@@ -77,7 +75,6 @@ class TaxonOverlapTest(TestCase):
 
 
 class NameConflictTest(TestCase):
-
     """187 taxon names disagree between GOLD and the ontologies output."""
 
     def test_the_first_source_wins_a_name_conflict(self):
@@ -111,7 +108,6 @@ class NameConflictTest(TestCase):
 
 
 class StaleOutputGuardTest(TestCase):
-
     """A merge config pointing at output older than its transform is a trap."""
 
     def test_the_gold_output_was_built_by_the_current_code(self):

--- a/tests/test_gold_organism_modeling.py
+++ b/tests/test_gold_organism_modeling.py
@@ -74,7 +74,6 @@ def _run(nodes=None, edges=None):
 
 
 class HouseConventionTest(TestCase):
-
     """One graph, one way of saying "this named entity sits under this taxon"."""
 
     def setUp(self):
@@ -115,7 +114,6 @@ class HouseConventionTest(TestCase):
 
 
 class OrganismFoldTest(TestCase):
-
     """An organism node has to earn its place by carrying a name the taxon lacks."""
 
     def setUp(self):
@@ -209,7 +207,6 @@ class OrganismFoldTest(TestCase):
 
 
 class MultiTaxonGuardTest(TestCase):
-
     """An organism claimed by two taxa must not be folded (#833)."""
 
     def setUp(self):

--- a/tests/test_gold_samples_studies_and_taxid_remap.py
+++ b/tests/test_gold_samples_studies_and_taxid_remap.py
@@ -67,7 +67,6 @@ def _rows(path):
 
 
 class DropSamplesAndStudiesTest(TestCase):
-
     """KG-Microbe wants neither samples nor studies — but does want environments."""
 
     def test_sample_and_study_nodes_are_not_emitted(self):
@@ -108,7 +107,6 @@ class DropSamplesAndStudiesTest(TestCase):
 
 
 class TaxidRemapTest(TestCase):
-
     """NCBI merged ~950 of GOLD's taxids; judging them on the retired id loses them."""
 
     def test_a_retired_taxid_is_rewritten_on_the_edge(self):

--- a/tests/test_gold_transform.py
+++ b/tests/test_gold_transform.py
@@ -46,7 +46,6 @@ def _read(path):
 
 
 class GoldTransformTest(TestCase):
-
     """GOLD arrives KGX-shaped; the transform conforms it and applies our trim."""
 
     def setUp(self):

--- a/tests/test_gtdb.py
+++ b/tests/test_gtdb.py
@@ -13,7 +13,6 @@ from kg_microbe.transform_utils.gtdb.utils import (
 
 
 class TestGTDBUtils(unittest.TestCase):
-
     """Test GTDB utility functions."""
 
     def test_parse_taxonomy_string(self):
@@ -75,7 +74,6 @@ class TestGTDBUtils(unittest.TestCase):
 
 
 class TestGTDBTransform(unittest.TestCase):
-
     """Test GTDBTransform class."""
 
     def setUp(self):

--- a/tests/test_isolation_source_label_check.py
+++ b/tests/test_isolation_source_label_check.py
@@ -69,7 +69,6 @@ def _row(subject, object_id, object_label, confidence="high", justification="sem
 
 
 class LabelCheckTest(TestCase):
-
     """A row whose object_id denotes something other than its object_label must fail."""
 
     def setUp(self):

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -15,7 +15,6 @@ from kg_microbe.transform_utils.kegg.utils import (
 
 
 class TestKEGGUtils(unittest.TestCase):
-
     """Test KEGG utility functions."""
 
     @patch("kg_microbe.transform_utils.kegg.utils.requests.get")
@@ -115,7 +114,6 @@ DEFINITION  alcohol dehydrogenase [EC:1.1.1.1]
 
 
 class TestKEGGTransform(unittest.TestCase):
-
     """Test KEGG transform class."""
 
     def setUp(self):

--- a/tests/test_lpsn_api_transform.py
+++ b/tests/test_lpsn_api_transform.py
@@ -11,7 +11,6 @@ from kg_microbe.transform_utils.lpsn_api.lpsn_api import LPSNAPITransform
 
 
 class _FakeLpsnClient:
-
     """
     Stand-in for ``lpsn.LpsnClient`` — deterministic and offline.
 

--- a/tests/test_lpsn_transform.py
+++ b/tests/test_lpsn_transform.py
@@ -16,7 +16,6 @@ FIXTURE_DIR = Path(__file__).parent / "resources"
 
 
 class _NoNCBI:
-
     """OAK-adapter stub used when a test wants NCBITaxon enrichment disabled."""
 
     def curies_by_label(self, label):
@@ -25,7 +24,6 @@ class _NoNCBI:
 
 
 class _NoGTDB:
-
     """GTDB-index stub used when a test wants GTDB enrichment disabled."""
 
     def curies_by_rank_name(self, rank, name):
@@ -34,7 +32,6 @@ class _NoGTDB:
 
 
 class _FakeGTDB:
-
     """Simple GTDB-index fake keyed on ``(rank, name)`` tuples."""
 
     def __init__(self, mapping):
@@ -287,7 +284,6 @@ def test_row_with_no_nomenclatural_type_emits_no_close_match(lpsn_transform):
 
 
 class _FakeNCBI:
-
     """Minimal stub of the subset of OAK's adapter API that LPSN uses."""
 
     def __init__(self, mapping):

--- a/tests/test_lpsn_utils.py
+++ b/tests/test_lpsn_utils.py
@@ -14,7 +14,6 @@ def _rows(*specs):
 
 
 class ResolveAcceptedRecordsTest(TestCase):
-
     """One resolver, shared by bacdive (#684) and microbedecoder (#746)."""
 
     def test_a_synonym_resolves_to_its_accepted_record(self):

--- a/tests/test_madin_environment_corrections.py
+++ b/tests/test_madin_environment_corrections.py
@@ -27,7 +27,6 @@ def _frame(rows):
 
 
 class EnvironmentCorrectionTest(TestCase):
-
     """The two upstream rows that name the wrong term."""
 
     def test_the_taxonomy_root_is_replaced_by_the_plant_root(self):
@@ -77,7 +76,6 @@ class EnvironmentCorrectionTest(TestCase):
 
 
 class StubRegistrationTest(TestCase):
-
     """The corrected targets must resolve to real nodes."""
 
     def test_the_corrections_file_is_scanned_for_stub_curies(self):

--- a/tests/test_mediadive_bulk_download.py
+++ b/tests/test_mediadive_bulk_download.py
@@ -33,7 +33,6 @@ download_module = import_module("kg_microbe.download")
 
 
 class TestDefaults:
-
     """Verify that DEFAULT_MAX_WORKERS and USER_AGENT are sensible values."""
 
     def test_default_max_workers_is_polite(self):
@@ -62,7 +61,6 @@ class TestDefaults:
 
 
 class TestCacheThreadSafety:
-
     """
     Verify HTTP sessions are never shared across threads.
 
@@ -259,7 +257,6 @@ class TestCacheThreadSafety:
 
 @pytest.mark.integration
 class TestBulkDownloadEndToEnd:
-
     """
     Exercise download_mediadive_bulk against a local HTTP server.
 
@@ -276,7 +273,6 @@ class TestBulkDownloadEndToEnd:
         import threading as th
 
         class Handler(http.server.BaseHTTPRequestHandler):
-
             """Answer any path with a MediaDive-shaped payload."""
 
             def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's API
@@ -353,7 +349,6 @@ class TestBulkDownloadEndToEnd:
 
 
 class TestIgnoreCachePlumbing:
-
     """
     Verify `kg download --ignore-cache` reaches the HTTP response cache.
 
@@ -385,7 +380,6 @@ class TestIgnoreCachePlumbing:
 
 
 class TestRetryAfter:
-
     """Verify that 429 responses with Retry-After headers are honoured."""
 
     def test_respects_retry_after_header(self):
@@ -420,7 +414,6 @@ class TestRetryAfter:
 
 
 class TestRetryParameters:
-
     """Verify retry_count and retry_delay flow from download functions into get_json_from_api."""
 
     def test_retry_count_is_configurable(self):
@@ -455,7 +448,6 @@ class TestRetryParameters:
 
 
 class TestRateLimiter:
-
     """Verify the Semaphore rate limiter bounds concurrency."""
 
     def test_concurrency_bounded_by_max_workers(self):

--- a/tests/test_mediadive_coverage_check.py
+++ b/tests/test_mediadive_coverage_check.py
@@ -32,7 +32,6 @@ def _edges(tmp_path, rows):
 
 
 class MediaDiveCoverageCheckTest(TestCase):
-
     """The counting rules the guard depends on."""
 
     def setUp(self):

--- a/tests/test_metatraits.py
+++ b/tests/test_metatraits.py
@@ -55,7 +55,6 @@ ADDITIONAL_TEST_CASES = [
 @patch("kg_microbe.transform_utils.metatraits.metatraits._ensure_ncbitaxon_db_ready")
 @patch("kg_microbe.transform_utils.metatraits.metatraits._get_ncbitaxon_adapter")
 class TestMetaTraitsTransform(unittest.TestCase):
-
     """Test MetaTraitsTransform class."""
 
     def setUp(self):

--- a/tests/test_metatraits_gzip_tolerance.py
+++ b/tests/test_metatraits_gzip_tolerance.py
@@ -28,7 +28,6 @@ def _write_plain(path, text):
 
 
 class TestOpenMaybeGzipped:
-
     """_open_maybe_gzipped must read both real gzip and misnamed plain text."""
 
     def test_reads_real_gzip(self, tmp_path):
@@ -121,7 +120,6 @@ class TestOpenMaybeGzipped:
 
 
 class TestCrosswalkLoading:
-
     """
     NCBI2GTDB.tsv.gz must load whether or not it arrives compressed.
 

--- a/tests/test_microbedecoder_lpsn_stubs.py
+++ b/tests/test_microbedecoder_lpsn_stubs.py
@@ -28,7 +28,6 @@ def _row(genus="Alborzia", species="kermanshahica", subsp="NA"):
 
 
 class LpsnStubTest(TestCase):
-
     """Emit a node only where lpsn cannot, and name it from the crosswalk."""
 
     def setUp(self):

--- a/tests/test_microbedecoder_transform.py
+++ b/tests/test_microbedecoder_transform.py
@@ -24,7 +24,6 @@ FIXTURE_DIR = Path(__file__).parent / "resources" / "microbedecoder"
 
 
 class _NoChebi:
-
     """
     ChemicalMappingLoader stub returning None for every lookup.
 
@@ -459,7 +458,6 @@ def test_constructor_is_inert_wrt_chemical_loader(tmp_path, monkeypatch):
     calls: list = []
 
     class _Tripwire:
-
         """Explode if the transform tries to instantiate the loader eagerly."""
 
         def __init__(self, *a, **kw):
@@ -534,7 +532,6 @@ def test_unmapped_labels_report_omitted_when_no_placeholders(tmp_path):
     """
 
     class _AlwaysResolves:
-
         """ChemicalMappingLoader stub that resolves every label to CHEBI:0."""
 
         def find_chebi_by_name(self, label, fuzzy_stereochemistry=True):

--- a/tests/test_ncbitaxon_db_build.py
+++ b/tests/test_ncbitaxon_db_build.py
@@ -82,7 +82,6 @@ def _fake_build(monkeypatch, db_path, *, size=16, fail=False):
 
 
 class TestSkipsUnnecessaryBuilds:
-
     """A 13 GB build must only run when it is actually needed."""
 
     def test_valid_aligned_db_is_reused(self, tmp_path, owl, tiny_threshold, monkeypatch):
@@ -105,7 +104,6 @@ class TestSkipsUnnecessaryBuilds:
 
 
 class TestRebuildsOnDrift:
-
     """The whole point: a refreshed OWL must produce a matching DB."""
 
     def test_drifted_db_is_rebuilt(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
@@ -152,7 +150,6 @@ class TestRebuildsOnDrift:
 
 
 class TestDegradesGracefully:
-
     """A machine without the build toolchain must not be left broken."""
 
     def test_missing_semsql_keeps_existing_db(self, tmp_path, owl, tiny_threshold, monkeypatch, capsys):
@@ -537,7 +534,6 @@ class TestDegradesGracefully:
 
 
 class TestLockedDatabasesAreNotDestroyed:
-
     """
     A database another process holds open is not damaged (round-4 findings).
 
@@ -880,7 +876,6 @@ class TestLockedDatabasesAreNotDestroyed:
         real_connect = sqlite3.connect
 
         class Failing:
-
             """Answers the first probe, then fails for an unrelated reason."""
 
             def __init__(self, conn):
@@ -921,7 +916,6 @@ class TestLockedDatabasesAreNotDestroyed:
         real_connect = sqlite3.connect
 
         class Failing:
-
             """Answers a set number of statements, then fails unrelatedly."""
 
             def __init__(self, conn):
@@ -963,7 +957,6 @@ class TestLockedDatabasesAreNotDestroyed:
 
 
 class TestOntologyIdentityAndServing:
-
     """Round-13: a generic SemSQL database is not evidence of the right ontology."""
 
     def test_the_wrong_ontology_is_refused(self):

--- a/tests/test_ncbitaxon_db_ready.py
+++ b/tests/test_ncbitaxon_db_ready.py
@@ -41,7 +41,6 @@ def _validation(results):
 
 
 class TestPreflightContract:
-
     """It must either leave a valid DB in place or raise."""
 
     def test_valid_local_db_is_accepted(self, paths, monkeypatch):
@@ -201,7 +200,6 @@ class TestPreflightContract:
 
 
 class TestRealBuilderIntegration:
-
     """
     Exercise the real _ensure_ncbitaxon_db through the pre-flight.
 

--- a/tests/test_negative_cache.py
+++ b/tests/test_negative_cache.py
@@ -9,7 +9,6 @@ from kg_microbe.utils.chemical_mapping_utils import (
 
 
 class TestNegativeLookupCache(unittest.TestCase):
-
     """Test negative lookup cache functionality."""
 
     def test_negative_cache_populated_on_failed_lookup(self):

--- a/tests/test_ontologies_deprecated_filter.py
+++ b/tests/test_ontologies_deprecated_filter.py
@@ -50,7 +50,6 @@ def _make_obograph():
 
 
 class TestDeprecatedFilter(TestCase):
-
     """Test owl:deprecated term removal from obograph JSON before KGX load."""
 
     def setUp(self):

--- a/tests/test_ontologies_derived_json_refresh.py
+++ b/tests/test_ontologies_derived_json_refresh.py
@@ -15,7 +15,6 @@ _JSON = '{{"meta":{{"basicPropertyValues":[{{"pred":"versionInfo","val":"{d}"}}]
 
 
 class DerivedJsonRefreshTest(TestCase):
-
     """`kg download` refreshes <x>.owl.gz in place; the derived JSON must follow."""
 
     def setUp(self):
@@ -146,7 +145,6 @@ _EC_JSON = (
 
 
 class EcSingleSourceTest(TestCase):
-
     """EC must ship one release, not two: derive ec.json from ec.owl, don't download both."""
 
     def setUp(self):
@@ -278,7 +276,6 @@ class EcSingleSourceTest(TestCase):
 
 
 class PostProcessingAtomicityTest(TestCase):
-
     """ROBOT publishes the JSON atomically; the post-processors must not undo that."""
 
     def setUp(self):

--- a/tests/test_ontologies_ec_uri_compaction.py
+++ b/tests/test_ontologies_ec_uri_compaction.py
@@ -124,7 +124,6 @@ def _build_transform(output_dir: Path) -> OntologiesTransform:
 
 
 class TestEcPostProcessUriCompaction(TestCase):
-
     """post_process('ec') must convert every URI to its CURIE and drop UniProt stubs."""
 
     def _run_post_process(self, tmp: Path):
@@ -246,7 +245,6 @@ class TestEcPostProcessUriCompaction(TestCase):
 
 
 class TestStrayHeaderRowsAreDropped(TestCase):
-
     """The incoming KGX header must not survive into the edge body."""
 
     # KGX's edges TSV leads with an `id` column, so its header's first field is

--- a/tests/test_ontologies_metamodel_filter.py
+++ b/tests/test_ontologies_metamodel_filter.py
@@ -21,7 +21,6 @@ _ROWS = [
 
 
 class MetamodelEdgeFilterTest(TestCase):
-
     """Test that rdfs:subPropertyOf / owl:inverseOf / rdf:type edges are dropped."""
 
     def setUp(self):

--- a/tests/test_ontologies_stubs.py
+++ b/tests/test_ontologies_stubs.py
@@ -31,7 +31,6 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class _FakeAdapter:
-
     """Minimal stand-in for an OAK SemSQL adapter — enough for the stub transform."""
 
     def __init__(self, store: Dict[str, Dict]):
@@ -53,7 +52,6 @@ class _FakeAdapter:
 
 
 class _StubbedTransform(OntologiesStubsTransform):
-
     """Subclass that swaps in an in-memory adapter so semsql tests don't touch DBs on disk."""
 
     def __init__(

--- a/tests/test_ontology_resolution.py
+++ b/tests/test_ontology_resolution.py
@@ -11,7 +11,6 @@ from kg_microbe.utils.ontology_resolution import (
 
 
 class FakeAdapter:
-
     """Small injected ChEBI view for deterministic policy tests."""
 
     def __init__(self, *, ancestors=(), label=None, parents=()):

--- a/tests/test_robot_atomic_output.py
+++ b/tests/test_robot_atomic_output.py
@@ -12,7 +12,6 @@ _PARTIAL = '{"meta":{"basicPropertyValues":[{"pred":"versionInfo","val":"2026-07
 
 
 class RobotAtomicOutputTest(TestCase):
-
     """ROBOT wrote to the final filename and its exit status was discarded."""
 
     def test_a_failed_conversion_publishes_nothing(self):

--- a/tests/test_sssom_asymmetric_direction.py
+++ b/tests/test_sssom_asymmetric_direction.py
@@ -43,7 +43,6 @@ def _predicate_counts():
 
 
 class VendoredSetShapeTest(TestCase):
-
     """The declaration only helps if the file's shape matches what it declares."""
 
     def setUp(self):

--- a/tests/test_sssom_predicate_semantics.py
+++ b/tests/test_sssom_predicate_semantics.py
@@ -31,7 +31,6 @@ def _write(tmp, declaration=None, gz=False):
 
 
 class ReadDeclarationTest(TestCase):
-
     """Absence means legacy — the property that makes either half land first."""
 
     def setUp(self):
@@ -76,7 +75,6 @@ class ReadDeclarationTest(TestCase):
 
 
 class DirectionTest(TestCase):
-
     """The same row must index opposite parents under the two declarations."""
 
     def setUp(self):
@@ -119,7 +117,6 @@ class DirectionTest(TestCase):
 
 
 class NestedKeyTest(TestCase):
-
     """A key of this name under a parent is not the declaration (#831)."""
 
     def setUp(self):
@@ -157,7 +154,6 @@ class NestedKeyTest(TestCase):
 
 
 class PropagationTest(TestCase):
-
     """The declaration must survive the consolidator, or the reader never sees it (#830)."""
 
     def test_the_consolidator_emits_the_declaration_it_was_given(self):

--- a/tests/test_stub_source_single_source.py
+++ b/tests/test_stub_source_single_source.py
@@ -26,7 +26,6 @@ def _local_names():
 
 
 class TestPoIsOwlOnly:
-
     """PO's hierarchy comes from the OWL; no SemSQL DB should be fetched."""
 
     def test_po_stub_uses_owl_mireot(self):
@@ -47,7 +46,6 @@ class TestPoIsOwlOnly:
 
 
 class TestNoStubHasTwoSources:
-
     """Generalise the rule across every stub source."""
 
     def test_owl_backed_stubs_have_no_db_download(self):

--- a/tests/test_transform_category_alignment.py
+++ b/tests/test_transform_category_alignment.py
@@ -10,7 +10,6 @@ from kg_microbe.transform_utils.mediadive.mediadive import MediaDiveTransform
 
 
 class TestTransformCategoryAlignment:
-
     """Test that transforms correctly align categories with ontologies transform."""
 
     @pytest.fixture

--- a/tests/test_transform_class.py
+++ b/tests/test_transform_class.py
@@ -10,7 +10,6 @@ from kg_microbe.transform_utils.transform import Transform
 
 
 class TestTransform(TestCase):
-
     """Tests for all transform child classes."""
 
     def setUp(self) -> None:
@@ -104,7 +103,6 @@ class TestTransform(TestCase):
 
 
 class TransformChildClass(Transform):
-
     """An example Transform class."""
 
     def __init__(self):

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -16,7 +16,6 @@ SSSOM = "mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz"
 
 
 class UnknownSourceTest(TestCase):
-
     """A typo'd source must fail, not silently succeed."""
 
     def test_an_unknown_source_raises_rather_than_being_skipped(self):
@@ -46,7 +45,6 @@ class UnknownSourceTest(TestCase):
 
 
 class LazyTransformTest(TestCase):
-
     """Registry metadata inspection must survive unavailable optional modules."""
 
     def test_missing_module_uses_getattr_default_for_metadata(self):
@@ -74,7 +72,6 @@ class LazyTransformTest(TestCase):
 
 
 class DataInputsTest(TestCase):
-
     """Transforms declare the curation files they read, so staleness is visible."""
 
     def test_the_base_class_defaults_to_no_declared_inputs(self):
@@ -134,7 +131,6 @@ class DataInputsTest(TestCase):
 
 
 class FreshnessDataStalenessTest(TestCase):
-
     """The freshness check must report data staleness, not just code staleness."""
 
     def setUp(self):

--- a/tests/test_transform_fingerprint.py
+++ b/tests/test_transform_fingerprint.py
@@ -15,7 +15,6 @@ from kg_microbe.utils.transform_fingerprint import (
 
 
 class FingerprintTest(TestCase):
-
     """The properties the freshness verdict rests on."""
 
     def setUp(self):

--- a/tests/test_unified_ontology_adapters.py
+++ b/tests/test_unified_ontology_adapters.py
@@ -345,7 +345,6 @@ def _assignments_of_node(name, source):
 
 
 class TestNoUnguardedAdapters:
-
     """No source file may construct an adapter that points at an OWL."""
 
     def test_unparsable_files_are_known(self):
@@ -483,7 +482,6 @@ class TestNoUnguardedAdapters:
 
 
 class TestAccessorContract:
-
     """The accessors resolve, memoise and fail predictably."""
 
     @pytest.fixture(autouse=True)
@@ -533,7 +531,6 @@ class TestAccessorContract:
 
 
 class TestLazyResolution:
-
     """
     Adapters must cost nothing until they are used.
 
@@ -607,7 +604,6 @@ class TestLazyResolution:
         calls = []
 
         class FakeAdapter:
-
             """Stand-in with one identifiable method."""
 
             def basic_search(self, term):
@@ -630,7 +626,6 @@ class TestLazyResolution:
 
 
 class TestFatalErrorsAreNotSwallowed:
-
     """
     A fatal ontology failure must survive every broad handler in the tree.
 
@@ -643,7 +638,6 @@ class TestFatalErrorsAreNotSwallowed:
     """
 
     class _Boom:
-
         """A proxy whose resolution raises, standing in for an unusable DB."""
 
         def __getattr__(self, name):
@@ -755,7 +749,6 @@ def _raiser(exc):
 
 
 class TestResolutionIsSerialised:
-
     """lru_cache does not lock across the wrapped call (Codex F7)."""
 
     def test_concurrent_first_use_is_serialised(self, monkeypatch):
@@ -816,7 +809,6 @@ class TestResolutionIsSerialised:
 
 
 class TestGuardBypassesStayClosed:
-
     """Each of these walked past a previous version of the guard."""
 
     @pytest.mark.parametrize(

--- a/tests/test_validation_utils.py
+++ b/tests/test_validation_utils.py
@@ -15,7 +15,6 @@ from kg_microbe.utils.validation_utils import (
 
 
 class TestCURIEValidation(unittest.TestCase):
-
     """Test CURIE format validation."""
 
     def test_validate_curie_valid(self):
@@ -84,7 +83,6 @@ class TestCURIEValidation(unittest.TestCase):
 
 
 class TestKGMTermValidation(unittest.TestCase):
-
     """Test KGM custom term validation."""
 
     def test_load_valid_kgm_terms(self):


### PR DESCRIPTION
Closes #874.

## `tox -e format` has been a silent no-op

`poetry run tox` is mandated before every commit and failed on a clean master. The cause was not what it looked like.

The format env runs `ruff format` then `ruff check --fix`. `D211` (`no-blank-line-before-class`) is ignored, leaving its **mutually exclusive opposite** `D203` (`one-blank-line-before-class`) active. So the formatter strips the blank line before a class docstring and the linter immediately restores it:

```
ruff format      -> 98 files changed
ruff check --fix -> 0 files changed    (all 98 reverted)
```

Net zero, exit 0. The env reports success while changing nothing, and `ruff format --check` has reported the same ~98 files unformatted indefinitely, because the fix can never stick. Ruff prints a warning naming this exact pairing on every run — it was just never acted on.

## I got the diagnosis wrong first

I filed #874 blaming #862 for removing `[tool.black] line-length = 100` without reformatting. The removal is real but is not the cause: **the oscillation reproduces on `6be5f93^`, the commit before #862** (91 files, net zero). It long predates it. Corrected on the issue.

What *is* #862's is the `docstr-coverage` half — five functions with no docstring.

## The fix

`D203` added to `extend-ignore`. With `D211` already ignored, letting the formatter decide is the only self-consistent option. The 98-file reformatting here is the backlog that could never land while the two tools fought.

Verified the oscillation stops:

```
ruff format      -> 98 files changed
ruff check --fix -> 98 files changed   (retained)
ruff format --check -> 196 files already formatted
```

Plus docstrings for `LocalToolkit.__init__`, `LegacyToolkit.__init__`, `guarded_getaddrinfo`, `guarded_connect` and `fail_edges` — each saying what it is for rather than restating its name.

## Result

`format`, `lint`, `codespell` and `docstr-coverage` all pass. Two test failures remain, neither from this change:

- `test_every_referenced_curie_has_stub_node` (`PO:0009005`) — long-standing, needs an `ontologies_stubs` re-run held for the MIM SSSOM
- `StaleOutputGuardTest` — my local gold output was built from #864's `gold.py`, so the content fingerprint correctly reports a mismatch. That is the guard working.

**Mostly mechanical, but large (102 files).** Worth landing on its own and ahead of #863/#864, both of which will need a trivial rebase after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)