### PR TITLE
fix: detect staleness against upstream transforms, and stop firing on whitespace

### DIFF
--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -77,6 +77,21 @@ def _declared_data_inputs(source: str) -> tuple:
         return ()
 
 
+def _declared_transform_inputs(source: str) -> tuple:
+    """
+    Registered sources whose output this transform reads, from ``TRANSFORM_INPUTS``.
+
+    :param source: Transform source name.
+    :return: Tuple of source names, empty when none are declared.
+    """
+    try:
+        from kg_microbe.transform import DATA_SOURCES  # noqa: PLC0415 - optional, see _declared_data_inputs
+    except Exception:
+        return ()
+    cls = DATA_SOURCES.get(source)
+    return tuple(getattr(cls, "TRANSFORM_INPUTS", ()) or ()) if cls is not None else ()
+
+
 def _latest_data_input_commit(source: str, ref: str) -> tuple[Optional[int], Optional[str]]:
     """
     Latest commit time across a source's declared data inputs.
@@ -314,6 +329,7 @@ def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
             code_fingerprint,
             data_fingerprint,
             read_fingerprint,
+            upstream_fingerprint,
         )
     except ImportError:
         return None
@@ -324,6 +340,15 @@ def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
             continue
         code_stale = recorded.get("code") != code_fingerprint(code_dir)
         data_stale = recorded.get("data") != data_fingerprint(REPO, _declared_data_inputs(source))
+        upstream_stale = recorded.get("upstream") != upstream_fingerprint(
+            TRANSFORMED_DIR, _declared_transform_inputs(source)
+        )
+        if upstream_stale and not (code_stale or data_stale):
+            upstreams = ", ".join(_declared_transform_inputs(source)) or "an upstream"
+            return (
+                "STALE_VS_UPSTREAM",
+                f"{upstreams} rebuilt since this output; rerun `poetry run kg transform -s {source}`",
+            )
         if code_stale and data_stale:
             return "STALE_VS_CODE_AND_DATA", f"code and data differ from the recorded build; rerun `poetry run kg transform -s {source}`"
         if code_stale:

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -186,6 +186,7 @@ def _record_fingerprint(transform_obj, source: str) -> None:
             code_dir=code_dir,
             repo_root=Path(__file__).resolve().parent.parent,
             data_inputs=getattr(type(transform_obj), "DATA_INPUTS", ()),
+            transform_inputs=getattr(type(transform_obj), "TRANSFORM_INPUTS", ()),
         )
     except Exception as exc:  # noqa: BLE001 - bookkeeping must not fail the run
         print(f"[transform] {source}: could not record fingerprint ({exc})", flush=True)

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -285,6 +285,9 @@ _TAXON_PREFIX = "NCBITaxon:"
 class GOLDTransform(Transform):
     """Conform the pre-transformed GOLD KGX TSVs to the KG-Microbe standard."""
 
+    #: Reads this transform's output; see Transform.TRANSFORM_INPUTS (#845).
+    TRANSFORM_INPUTS = ("ontologies", "ontologies_stubs")
+
     #: The MeSH site curation this transform reads. Declared so the freshness
     #: check notices an edit to it — a transform that reads a curation file
     #: without declaring it is reported fresh while its output is stale, which

--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -243,6 +243,9 @@ class _NCBILabelIndex:
 class LPSNTransform(Transform):
     """Transform LPSN GSS CSV bulk export into KGX nodes + edges."""
 
+    #: Reads this transform's output; see Transform.TRANSFORM_INPUTS (#845).
+    TRANSFORM_INPUTS = ("gtdb",)
+
     def __init__(
         self,
         input_dir: Optional[Path] = None,

--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -117,6 +117,9 @@ GSS_NODES_RELPATH = "transformed/lpsn/nodes.tsv"
 class LPSNAPITransform(Transform):
     """Fetch per-record LPSN JSON, emit enrichment nodes + edges."""
 
+    #: Reads this transform's output; see Transform.TRANSFORM_INPUTS (#845).
+    TRANSFORM_INPUTS = ("lpsn",)
+
     def __init__(
         self,
         input_dir: Optional[Path] = None,

--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -134,6 +134,9 @@ _GROUP_TO_KS: Dict[str, str] = {
 class MicrobeDecoderTransform(Transform):
     """Transform the MicrobeDecoder wide CSV into KGX nodes and edges."""
 
+    #: Reads this transform's output; see Transform.TRANSFORM_INPUTS (#845).
+    TRANSFORM_INPUTS = ("lpsn",)
+
     DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
 
     def __init__(

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -173,6 +173,9 @@ def _as_float(value) -> float:
 class PregoTransform(Transform):
     """Ingest PREGO taxon↔environment/process associations."""
 
+    #: Reads this transform's output; see Transform.TRANSFORM_INPUTS (#845).
+    TRANSFORM_INPUTS = ("ontologies",)
+
     # Ceiling on distinct habitat values tracked per run. The measured value
     # space is ~42; 1000 leaves generous headroom while bounding memory if the
     # upstream column shape changes.

--- a/kg_microbe/transform_utils/transform.py
+++ b/kg_microbe/transform_utils/transform.py
@@ -55,6 +55,27 @@ class Transform:
     #: constant, derive this from it rather than restating it.
     DATA_INPUTS: tuple = ()
 
+    #: Registered source names whose **output** this transform reads.
+    #:
+    #: `DATA_INPUTS` covers curation files under ``mappings/``. It does not
+    #: cover a dependency on another transform's output, and five exist: gold
+    #: reads ``ontologies/ncbitaxon_nodes.tsv`` (and refuses to run without it)
+    #: plus ``ontologies_stubs/po_nodes.tsv``, lpsn reads ``gtdb/nodes.tsv``,
+    #: lpsn_api and microbedecoder read ``lpsn/nodes.tsv``, and prego reads
+    #: ``ontologies/``.
+    #:
+    #: Undeclared, re-running an upstream leaves every downstream genuinely
+    #: stale while all three freshness signals report fresh — the #812 shape,
+    #: across transforms rather than within one (#845). The ordering was
+    #: already encoded in ``DATA_SOURCES`` comments ("Run gold after
+    #: ontologies…"); this makes it machine-readable so the fingerprint can
+    #: fold the upstream in.
+    #:
+    #: `tests/test_cross_transform_inputs.py` derives the real dependency map
+    #: from the source and fails on anything undeclared, because every previous
+    #: version of this contract was opt-in and was forgotten (#812, #839, #876).
+    TRANSFORM_INPUTS: tuple = ()
+
     def __init__(
         self,
         source_name,

--- a/kg_microbe/utils/transform_fingerprint.py
+++ b/kg_microbe/utils/transform_fingerprint.py
@@ -21,6 +21,7 @@ Code and data are fingerprinted separately so a stale output can still say
 versus ``STALE_VS_DATA``.
 """
 
+import ast
 import hashlib
 import json
 from pathlib import Path
@@ -33,7 +34,7 @@ FINGERPRINT_FILE = "source_fingerprint.json"
 
 #: Bumped when the hashing scheme changes, so an old marker is treated as
 #: absent rather than silently compared under different rules.
-FINGERPRINT_VERSION = 1
+FINGERPRINT_VERSION = 2
 
 # Files at or below this size are cheap enough to hash completely. Larger graph
 # TSVs are sampled at evenly spaced offsets so a freshness check does bounded IO
@@ -102,6 +103,35 @@ def _hash_files(paths: Iterable[Path]) -> str:
     return digest.hexdigest()
 
 
+def _behaviour_digest(path: Path) -> bytes:
+    """
+    Digest a Python file by what it *does*, not how it is laid out.
+
+    Hashing raw bytes cannot tell "this transform will produce different
+    output" from "someone ran the formatter". #875 reformatted 98 files —
+    removing one blank line before each class docstring — and every transform's
+    fingerprint moved, so the freshness check indicated a full rebuild when no
+    behaviour had changed (#879). A signal that fires on whitespace gets
+    overridden, and then it is absent when behaviour really does change.
+
+    The AST is insensitive to formatting and comments, and sensitive to
+    everything that can alter output — docstrings included, since they appear
+    in it. A file that will not parse falls back to its bytes: a syntax error
+    must not read as "no change".
+
+    :param path: Python file.
+    :return: Digest bytes.
+    """
+    try:
+        source = path.read_bytes()
+    except OSError:
+        return b"<absent>"
+    try:
+        return hashlib.sha256(ast.dump(ast.parse(source.decode("utf-8"))).encode("utf-8")).digest()
+    except (SyntaxError, UnicodeDecodeError):
+        return hashlib.sha256(source).digest()
+
+
 def code_fingerprint(code_dir: Path) -> str:
     """
     Fingerprint every Python file in a transform's package directory.
@@ -114,7 +144,42 @@ def code_fingerprint(code_dir: Path) -> str:
     :param code_dir: e.g. ``kg_microbe/transform_utils/gold``.
     :return: Hex digest, or the digest of nothing when the directory is absent.
     """
-    return _hash_files(code_dir.rglob("*.py")) if code_dir.is_dir() else _hash_files([])
+    if not code_dir.is_dir():
+        return hashlib.sha256(b"").hexdigest()
+    digest = hashlib.sha256()
+    for path in sorted(code_dir.rglob("*.py"), key=lambda p: p.as_posix()):
+        digest.update(path.as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(_behaviour_digest(path))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def upstream_fingerprint(output_base_dir: Path, transform_inputs: Iterable[str]) -> str:
+    """
+    Fingerprint the recorded state of every upstream transform.
+
+    Folds in each upstream's own marker rather than its output TSVs, which can
+    be hundreds of megabytes. If an upstream re-runs, its marker changes and
+    every downstream goes stale — which is the point (#845).
+
+    An upstream with no marker folds in as absent, so a downstream goes stale
+    exactly once when that upstream first records one. That is the correct
+    direction to fail: it prompts a re-run rather than asserting currency that
+    was never established.
+
+    :param output_base_dir: ``data/transformed``.
+    :param transform_inputs: Registered source names read by this transform.
+    :return: Hex digest.
+    """
+    digest = hashlib.sha256()
+    for name in sorted(set(transform_inputs)):
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        recorded = read_fingerprint(output_base_dir / name)
+        digest.update(json.dumps(recorded, sort_keys=True).encode("utf-8") if recorded else b"<absent>")
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
 def data_fingerprint(repo_root: Path, data_inputs: Iterable[str]) -> str:
@@ -128,7 +193,13 @@ def data_fingerprint(repo_root: Path, data_inputs: Iterable[str]) -> str:
     return _hash_files(repo_root / rel for rel in data_inputs)
 
 
-def write_fingerprint(output_dir: Path, code_dir: Path, repo_root: Path, data_inputs: Iterable[str]) -> dict:
+def write_fingerprint(
+    output_dir: Path,
+    code_dir: Path,
+    repo_root: Path,
+    data_inputs: Iterable[str],
+    transform_inputs: Iterable[str] = (),
+) -> dict:
     """
     Record the fingerprint of a completed run.
 
@@ -140,12 +211,16 @@ def write_fingerprint(output_dir: Path, code_dir: Path, repo_root: Path, data_in
     :param code_dir: The transform's package directory.
     :param repo_root: Repository root.
     :param data_inputs: Repo-relative curation paths.
+    :param transform_inputs: Registered sources whose output this one reads.
     :return: The recorded payload.
     """
     payload = {
         "version": FINGERPRINT_VERSION,
         "code": code_fingerprint(code_dir),
         "data": data_fingerprint(repo_root, data_inputs),
+        # Recorded separately so a stale output says which of the three moved:
+        # its code, its curation data, or something it reads (#845).
+        "upstream": upstream_fingerprint(output_dir.parent, transform_inputs),
     }
     with atomic_write(output_dir / FINGERPRINT_FILE, encoding="utf-8") as handle:
         handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")

--- a/tests/test_cross_transform_inputs.py
+++ b/tests/test_cross_transform_inputs.py
@@ -1,0 +1,106 @@
+"""A transform that reads another's output must declare it (#845)."""
+
+import re
+from pathlib import Path
+from unittest import TestCase
+
+from kg_microbe.transform import DATA_SOURCES
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRANSFORM_ROOT = REPO_ROOT / "kg_microbe" / "transform_utils"
+
+#: The three path idioms used to reach another transform's output. Each is in
+#: live use, which is why a single pattern misses dependencies: an earlier
+#: version of this scan caught `gold` and `prego` but not `microbedecoder`,
+#: because that one goes via ``output_dir.parent``.
+_UPSTREAM_PATTERNS = re.compile(
+    r"transformed/([a-z_]+)/"
+    r'|output_base_dir\s*/\s*["\']([a-z_]+)["\']'
+    r'|output_dir\.parent\s*/\s*["\']([a-z_]+)["\']'
+)
+
+
+def _observed_dependencies():
+    """
+    Derive, from the source, which transforms read which others' output.
+
+    :return: ``{source: {upstream, ...}}`` for sources with any dependency.
+    """
+    observed = {}
+    for source in DATA_SOURCES:
+        code_dir = TRANSFORM_ROOT / source
+        if not code_dir.is_dir():
+            continue
+        found = set()
+        for path in code_dir.rglob("*.py"):
+            for match in _UPSTREAM_PATTERNS.finditer(path.read_text(encoding="utf-8")):
+                name = next(group for group in match.groups() if group)
+                if name != source and name in DATA_SOURCES:
+                    found.add(name)
+        if found:
+            observed[source] = found
+    return observed
+
+
+class CrossTransformDeclarationTest(TestCase):
+    """Derived from the code, so the declaration cannot quietly fall behind."""
+
+    def test_every_observed_dependency_is_declared(self):
+        """
+        The contract is worthless if it is remembered rather than checked.
+
+        Three prior versions of this same contract were opt-in and each was
+        forgotten: #812 (DATA_INPUTS invented), #839 (ontologies_stubs declared
+        1 of 11 files), #876 (gold gained a curation file and declared none).
+        Every one was caught by a human reading a diff. This one is caught by
+        the suite.
+        """
+        for source, upstreams in _observed_dependencies().items():
+            declared = set(getattr(DATA_SOURCES[source], "TRANSFORM_INPUTS", ()))
+            self.assertEqual(
+                upstreams - declared,
+                set(),
+                f"{source} reads {sorted(upstreams - declared)} but does not declare it in "
+                "TRANSFORM_INPUTS, so re-running that upstream leaves this output silently stale",
+            )
+
+    def test_the_known_dependencies_are_present(self):
+        """
+        Pin the premise, so a scan that silently stops matching is caught.
+
+        If `_UPSTREAM_PATTERNS` ever fails to match — a new path idiom, a
+        refactor — `_observed_dependencies()` returns less and the check above
+        passes vacuously. This fails instead.
+        """
+        observed = _observed_dependencies()
+        self.assertIn("ontologies", observed.get("gold", set()))
+        self.assertIn("gtdb", observed.get("lpsn", set()))
+        self.assertIn("lpsn", observed.get("microbedecoder", set()))
+
+    def test_no_transform_declares_an_unregistered_upstream(self):
+        """A typo would fold an always-absent marker in and never clear."""
+        for source in DATA_SOURCES:
+            for upstream in getattr(DATA_SOURCES[source], "TRANSFORM_INPUTS", ()):
+                self.assertIn(upstream, DATA_SOURCES, f"{source} declares unknown upstream {upstream!r}")
+
+    def test_no_transform_declares_itself(self):
+        """Self-reference would make a transform permanently stale against itself."""
+        for source in DATA_SOURCES:
+            self.assertNotIn(source, getattr(DATA_SOURCES[source], "TRANSFORM_INPUTS", ()))
+
+    def test_declared_upstreams_run_first(self):
+        """
+        `DATA_SOURCES` order is the run order for a bare `kg transform`.
+
+        An upstream declared but scheduled later would be read stale on every
+        full run — the ordering comments in that dict ("Run gold after
+        ontologies…") are exactly this constraint, previously unchecked.
+        """
+        order = list(DATA_SOURCES)
+        for source in order:
+            for upstream in getattr(DATA_SOURCES[source], "TRANSFORM_INPUTS", ()):
+                self.assertLess(
+                    order.index(upstream),
+                    order.index(source),
+                    f"{upstream} must be registered before {source} in DATA_SOURCES",
+                )

--- a/tests/test_gold_mesh_site_curation.py
+++ b/tests/test_gold_mesh_site_curation.py
@@ -15,7 +15,6 @@ def _rows():
 
 
 class CurationFileTest(TestCase):
-
     """The file is the mechanism, so its shape is part of the contract."""
 
     def test_every_row_carries_a_decision_and_a_reason(self):
@@ -61,7 +60,6 @@ class CurationFileTest(TestCase):
 
 
 class TransformGateTest(TestCase):
-
     """Unlisted means refused, so a new upstream label cannot readmit the error."""
 
     def test_the_loader_returns_only_site_rows(self):
@@ -99,7 +97,6 @@ class TransformGateTest(TestCase):
 
 
 class DeclaredInputTest(TestCase):
-
     """A curation file a transform reads must be declared, or staleness is invisible."""
 
     def test_the_curation_file_is_declared_as_a_data_input(self):


### PR DESCRIPTION
Closes #845 and #879.

Two fingerprint changes. Both alter the schema, so they share **one** `FINGERPRINT_VERSION` bump rather than causing two separate "everything went stale" events — which is why they're together.

## #845 — nothing noticed when an upstream transform was rebuilt

`DATA_INPUTS` covers curation files under `mappings/`. It does not cover reading another transform's *output*, and five transforms do:

| transform | reads |
|---|---|
| `gold` | `ontologies`, `ontologies_stubs` |
| `lpsn` | `gtdb` |
| `lpsn_api` | `lpsn` |
| `microbedecoder` | `lpsn` |
| `prego` | `ontologies` |

`gold` **refuses to run** without `ontologies/ncbitaxon_nodes.tsv`, and its data digest was the digest of the empty set. Re-run `ontologies`, the NCBITaxon trim changes, and gold is genuinely stale while all three freshness signals report fresh. That's #812's shape, across transforms instead of within one.

`TRANSFORM_INPUTS` declares it. The fingerprint folds in each upstream's **own marker** rather than its output TSVs, which are hundreds of megabytes. An upstream with no marker folds in as absent, so a downstream goes stale exactly once when that upstream first records one — the correct direction to fail.

Recorded as a third field, so a stale output says *which* of the three moved: its code, its curation data, or something it reads. The checker reports `STALE_VS_UPSTREAM`.

## #879 — the fingerprint fired on formatting

`code_fingerprint` hashed raw bytes. #875's reformatting (one blank line removed per class docstring) moved **every** transform's fingerprint, so the checker indicated a full rebuild — hours of compute — when no behaviour had changed. Measured on `gtdb.py`:

```
byte hash differs: 1d004a840c0f vs 561f2feca5c5
AST identical    : True
```

It now hashes `ast.dump(ast.parse(source))`: insensitive to layout and comments, sensitive to everything that can alter output (docstrings included, since they're in the AST). A file that won't parse falls back to its bytes — a syntax error must not read as "no change". Cost is 0.54s across all transform modules, once per run.

## The contract is checked, not remembered

Its three predecessors were all opt-in and all forgotten — #812 (invented `DATA_INPUTS`), #839 (`ontologies_stubs` declared 1 of 11 files), #876 (gold gained a curation file and declared none). Every one was caught by a human reading a diff.

`tests/test_cross_transform_inputs.py` derives the real dependency map from the source and fails on anything undeclared. Verified by removing gold's declaration:

```
gold reads ['ontologies', 'ontologies_stubs'] but does not declare it in
TRANSFORM_INPUTS, so re-running that upstream leaves this output silently stale
```

It also pins that the *derivation* still matches known dependencies, so a scan that silently stops finding them can't make the check pass vacuously — and asserts declared upstreams are registered **earlier** in `DATA_SOURCES`, which the ordering comments in that dict have always required and nothing checked.

## Verified end-to-end

```
A. baseline                          -> FRESH
B. write a new marker for ontologies -> STALE_VS_UPSTREAM ("ontologies, ontologies_stubs rebuilt…")
C. re-run gold                       -> FRESH
```

(I removed the fabricated `ontologies` marker afterwards — leaving it would have asserted that 2026-08-08 output was current.)

`poetry run tox`: 1209 passed, all quality envs green. The one failure, `test_every_referenced_curie_has_stub_node` (`PO:0009005`), reproduces on master unchanged.

## Expected follow-on

The next `kg transform` run of each source records a v2 marker. Until then the checker falls back to timestamps for them, which is the pre-existing behaviour. Once #879's AST change is in effect, most of the current mass `STALE_VS_CODE` verdicts should clear without any re-run — that's the correct answer, and whatever stays stale after that is genuinely stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)