### PR TITLE
fix: declare the license as BSD-3-Clause, matching LICENSE.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kg-microbe"
 version = "0.0.0"
 description = "kg-microbe"
 authors = ["Harshad Hegde <hhegde@lbl.gov>"]
-license = "MIT"
+license = "BSD-3-Clause"
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
`pyproject.toml` declared `license = "MIT"`. The repository is **BSD-3-Clause**.

Evidence, not inference:

- **`LICENSE.txt`** is the BSD 3-clause text — all three clause markers present ("Redistributions of source code", "Redistributions in binary form", "Neither the name…"), copyright Lawrence Berkeley National Laboratory, 2020.
- **GitHub's own detection** reports `BSD-3-Clause` for this repo.

So the packaging metadata has been misstating the licence of every artifact built from it. Both are permissive, but they aren't equivalent — BSD-3-Clause carries the non-endorsement clause MIT doesn't — and a downstream consumer reading the wheel metadata was told something `LICENSE.txt` contradicts.

Metadata only; no code paths touched. `poetry check` passes.

**Provenance:** this change appeared in my working tree during other work rather than being made by me — I preserved it across several branch switches rather than committing it into an unrelated PR or discarding it, then verified it was correct before proposing it here. If it was deliberate, this is the PR for it; if it was accidental, it happens to be right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)