### PR TITLE
fix(bacdive): resolve contradictory parents on shared deposit nodes, and link deposits to their records (#892, #894, #897, #898, #902, #903)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,11 @@ always agree on the taxon. Such a node gets the one claimed parent that every
 claimant entails — the claim itself when they agree, the shared ancestor when
 they differ only in depth along one lineage. Never a computed common ancestor
 nobody claimed, and never one of two disjoint claims: those get no parent at all
-and go to the source's deposit-conflict report, because picking one would make
-the answer depend on file order. Every record that cites a deposit links to it
+and go to the source's deposit-claim report, because picking one would make
+the answer depend on file order. That report carries every deposit whose
+claimants disagreed, whichever way it went, so a coarsened taxonomy and a
+suppressed one are both visible and neither is confused with an ontology
+lookup that failed. Every record that cites a deposit links to it
 with `biolink:close_match`, so the deposit's provenance is in the graph and its
 taxonomy stays reachable through the record even when no parent is asserted.
 See issues #892 and #894.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,13 @@ traversable; it is not a claim that the isolate is an ontology class. Biolink
 validators will report it; do not silently change the convention. See issue
 #834 and [the 4.4.2 revalidation](docs/BIOLINK_4_4_2_REVALIDATION.md).
 
+A `kgmicrobe.strain:<code>` node minted from a culture-collection deposit number
+is shared: several source records can cite the same deposit. Such a node gets a
+`subclass_of` parent only when every record citing it agrees on the taxon. When
+they disagree, no parent is asserted and the claim is written to the source's
+deposit-conflict report instead — picking one would make the answer depend on
+file order. See issue #892.
+
 ## Operational traps
 
 - PREGO defaults to `PREGO_SHAPES=habitat` and `PREGO_MIN_CONFIDENCE=0`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,13 @@ validators will report it; do not silently change the convention. See issue
 #834 and [the 4.4.2 revalidation](docs/BIOLINK_4_4_2_REVALIDATION.md).
 
 A `kgmicrobe.strain:<code>` node minted from a culture-collection deposit number
-is shared: several source records can cite the same deposit. Such a node gets a
-`subclass_of` parent only when every record citing it agrees on the taxon. When
-they disagree, no parent is asserted and the claim is written to the source's
-deposit-conflict report instead — picking one would make the answer depend on
-file order. See issue #892.
+is shared: several source records can cite the same deposit, and they do not
+always agree on the taxon. Such a node gets the one claimed parent that every
+claimant entails — the claim itself when they agree, the shared ancestor when
+they differ only in depth along one lineage. Never a computed common ancestor
+nobody claimed, and never one of two disjoint claims: those get no parent at all
+and go to the source's deposit-conflict report, because picking one would make
+the answer depend on file order. See issue #892.
 
 ## Operational traps
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,10 @@ claimant entails — the claim itself when they agree, the shared ancestor when
 they differ only in depth along one lineage. Never a computed common ancestor
 nobody claimed, and never one of two disjoint claims: those get no parent at all
 and go to the source's deposit-conflict report, because picking one would make
-the answer depend on file order. See issue #892.
+the answer depend on file order. Every record that cites a deposit links to it
+with `biolink:close_match`, so the deposit's provenance is in the graph and its
+taxonomy stays reachable through the record even when no parent is asserted.
+See issues #892 and #894.
 
 ## Operational traps
 

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -290,6 +290,7 @@ class BacDiveTransform(Transform):
         self.ncbitaxon_synonyms: Dict[str, frozenset] = {}  # {ncbitaxon_id: frozenset(lowercased synonyms)}
         self.ncbitaxon_fallback_cache: Dict[str, Optional[str]] = {}  # Cache for fallback lookups
         self._ncbitaxon_rank_cache: Dict[str, Optional[str]] = {}  # {ncbitaxon_id: rank_name}
+        self._ncbitaxon_ancestor_cache: Dict[str, frozenset] = {}  # {ncbitaxon_id: proper is_a ancestors}
         self._load_ncbitaxon_labels()
 
         # Load CHEBI categories from ontologies transform output (for category alignment).
@@ -917,6 +918,30 @@ class BacDiveTransform(Transform):
             if n >= self._MIN_SHARED_PREFIX and token[: self._MIN_SHARED_PREFIX] == name[: self._MIN_SHARED_PREFIX]:
                 return True
         return False
+
+    def _ncbitaxon_ancestors(self, ncbitaxon_id: str) -> frozenset:
+        """
+        Return the proper ``is_a`` ancestors of an NCBITaxon CURIE, cached.
+
+        Used to tell a real taxonomic disagreement between two records citing one
+        culture-collection deposit from two claims at different depths of the same
+        lineage (#892). Only a few hundred deposits ever reach this, so the cost is
+        a handful of adapter calls per run.
+        """
+        cached = self._ncbitaxon_ancestor_cache.get(ncbitaxon_id)
+        if cached is not None:
+            return cached
+        try:
+            ancestors = frozenset(self.ncbi_impl.ancestors([ncbitaxon_id], predicates=[RDFS_SUBCLASS_OF]))
+            ancestors -= {ncbitaxon_id}
+        except OntologyDbUnavailableError:
+            # An unusable NCBITaxon DB is not an empty ancestry — surface it rather
+            # than silently declaring every pair of claims disjoint.
+            raise
+        except Exception:
+            ancestors = frozenset()
+        self._ncbitaxon_ancestor_cache[ncbitaxon_id] = ancestors
+        return ancestors
 
     def _parse_genus_from_scientific_name(self, scientific_name: str) -> Optional[str]:
         """
@@ -3367,8 +3392,11 @@ class BacDiveTransform(Transform):
                     progress.update()
 
                 # Resolve the buffered culture-collection deposit claims: assert a
-                # parent only where every record citing the deposit agrees (#892).
-                resolved_deposits, deposit_parent_conflicts = resolve_deposit_parents(deposit_parent_claims)
+                # parent only where every record citing the deposit supports it (#892).
+                resolved_deposits, deposit_parent_conflicts = resolve_deposit_parents(
+                    deposit_parent_claims, ancestors_of=self._ncbitaxon_ancestors
+                )
+                deposits_collapsed = sum(1 for curie, _ in resolved_deposits if len(deposit_parent_claims[curie]) > 1)
                 for strain_curie, deposit_parent_id in resolved_deposits:
                     knowledge_level, agent_type = self._add_edge_metadata(
                         SUBCLASS_PREDICATE, RDFS_SUBCLASS_OF, deposit_parent_id
@@ -3409,8 +3437,10 @@ class BacDiveTransform(Transform):
             conflict_writer.writerow(DEPOSIT_CONFLICT_HEADER)
             conflict_writer.writerows(deposit_conflict_rows(deposit_parent_conflicts))
         logger.info(
-            "[bacdive] culture-collection deposits with conflicting parent taxa: %s "
+            "[bacdive] culture-collection deposits claimed by disagreeing records: "
+            "%s collapsed to the taxon every claimant entails, %s disjoint "
             "(subclass_of suppressed; listed in %s)",
+            f"{deposits_collapsed:,}",
             f"{len(deposit_parent_conflicts):,}",
             conflicts_file,
         )

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+from collections import Counter
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -24,6 +25,9 @@ from tqdm import tqdm
 
 from kg_microbe.transform_utils.bacdive.emission import (
     DEPOSIT_CONFLICT_HEADER,
+    RESOLUTION_COLLAPSED,
+    RESOLUTION_SUPPRESSED,
+    RESOLUTION_SUPPRESSED_NO_ANCESTRY,
     deposit_conflict_rows,
     resolve_deposit_parents,
 )
@@ -293,6 +297,7 @@ class BacDiveTransform(Transform):
         self.ncbitaxon_fallback_cache: Dict[str, Optional[str]] = {}  # Cache for fallback lookups
         self._ncbitaxon_rank_cache: Dict[str, Optional[str]] = {}  # {ncbitaxon_id: rank_name}
         self._ncbitaxon_ancestor_cache: Dict[str, frozenset] = {}  # {ncbitaxon_id: proper is_a ancestors}
+        self._ncbitaxon_ancestry_failures: set = set()  # taxa whose ancestry could not be read (#897)
         self._load_ncbitaxon_labels()
 
         # Load CHEBI categories from ontologies transform output (for category alignment).
@@ -941,6 +946,10 @@ class BacDiveTransform(Transform):
             # than silently declaring every pair of claims disjoint.
             raise
         except Exception:
+            # An empty ancestry makes two claims on one lineage look disjoint, which
+            # suppresses a correct edge. Record the taxon so the suppression can be
+            # reported as a precaution rather than a verdict about BacDive (#897).
+            self._ncbitaxon_ancestry_failures.add(ncbitaxon_id)
             ancestors = frozenset()
         self._ncbitaxon_ancestor_cache[ncbitaxon_id] = ancestors
         return ancestors
@@ -3415,10 +3424,11 @@ class BacDiveTransform(Transform):
 
                 # Resolve the buffered culture-collection deposit claims: assert a
                 # parent only where every record citing the deposit supports it (#892).
-                resolved_deposits, deposit_parent_conflicts = resolve_deposit_parents(
-                    deposit_parent_claims, ancestors_of=self._ncbitaxon_ancestors
+                resolved_deposits, contested_deposits = resolve_deposit_parents(
+                    deposit_parent_claims,
+                    ancestors_of=self._ncbitaxon_ancestors,
+                    ancestry_failed=self._ncbitaxon_ancestry_failures.__contains__,
                 )
-                deposits_collapsed = sum(1 for curie, _ in resolved_deposits if len(deposit_parent_claims[curie]) > 1)
                 for strain_curie, deposit_parent_id in resolved_deposits:
                     knowledge_level, agent_type = self._add_edge_metadata(
                         SUBCLASS_PREDICATE, RDFS_SUBCLASS_OF, deposit_parent_id
@@ -3457,13 +3467,17 @@ class BacDiveTransform(Transform):
         with open(conflicts_file, "w", newline="") as f:
             conflict_writer = csv.writer(f, delimiter="\t")
             conflict_writer.writerow(DEPOSIT_CONFLICT_HEADER)
-            conflict_writer.writerows(deposit_conflict_rows(deposit_parent_conflicts))
+            conflict_writer.writerows(deposit_conflict_rows(contested_deposits))
+        resolution_counts = Counter(resolution for _, _, resolution, _ in contested_deposits)
         logger.info(
             "[bacdive] culture-collection deposits claimed by disagreeing records: "
-            "%s collapsed to the taxon every claimant entails, %s disjoint "
-            "(subclass_of suppressed; listed in %s)",
-            f"{deposits_collapsed:,}",
-            f"{len(deposit_parent_conflicts):,}",
+            "%s collapsed to the taxon every claimant entails, %s disjoint, "
+            "%s undecidable because ancestry for %s taxa could not be read "
+            "(all listed in %s)",
+            f"{resolution_counts[RESOLUTION_COLLAPSED]:,}",
+            f"{resolution_counts[RESOLUTION_SUPPRESSED]:,}",
+            f"{resolution_counts[RESOLUTION_SUPPRESSED_NO_ANCESTRY]:,}",
+            f"{len(self._ncbitaxon_ancestry_failures):,}",
             conflicts_file,
         )
 

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -61,6 +61,8 @@ from kg_microbe.transform_utils.constants import (
     CHEBI_NODES_FILE,
     CHEBI_PREFIX,
     CLASS,
+    CLOSE_MATCH_PREDICATE,
+    CLOSE_MATCH_RELATION,
     COLONY_MORPHOLOGY,
     COMPOUND_PRODUCTION,
     CULTURE_AND_GROWTH_CONDITIONS,
@@ -2747,6 +2749,26 @@ class BacDiveTransform(Transform):
                             strain_label = culture_number.strip() if len(culture_number_cleaned) > 3 else None
                             if strain_curie and strain_label:
                                 node_writer.writerow(self._create_node_row(strain_curie, NCBI_CATEGORY, strain_label))
+                                # Link the record to the deposit it cites, mirroring the
+                                # edge LPSN already emits onto these same CURIEs
+                                # (``lpsn.py::_make_close_match_edge``). Without it a
+                                # deposit node has no way back to whoever asserted it, and
+                                # a deposit whose claimants disagree — which gets no
+                                # subclass_of below — would reach no taxon at all (#894).
+                                knowledge_level, agent_type = self._add_edge_metadata(
+                                    CLOSE_MATCH_PREDICATE, CLOSE_MATCH_RELATION, strain_curie
+                                )
+                                edge_writer.writerow(
+                                    [
+                                        organism_id,
+                                        CLOSE_MATCH_PREDICATE,
+                                        strain_curie,
+                                        CLOSE_MATCH_RELATION,
+                                        self.knowledge_source,
+                                        knowledge_level,
+                                        agent_type,
+                                    ]
+                                )
                                 # Record this record's claim about the deposit's parent
                                 # taxon. The edge itself is written after the loop, once
                                 # every record that cites this deposit has been seen (#892).

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -22,6 +22,11 @@ from typing import Dict, List, Optional, Union
 import yaml
 from tqdm import tqdm
 
+from kg_microbe.transform_utils.bacdive.emission import (
+    DEPOSIT_CONFLICT_HEADER,
+    deposit_conflict_rows,
+    resolve_deposit_parents,
+)
 from kg_microbe.transform_utils.bacdive.emission import StrainProvenanceWriter as _StrainProvenanceWriter
 from kg_microbe.transform_utils.constants import (
     ACTIVITY_KEY,
@@ -36,6 +41,7 @@ from kg_microbe.transform_utils.constants import (
     BACDIVE,
     BACDIVE_API_BASE_URL,
     BACDIVE_ASSAY_PREDICATE,
+    BACDIVE_DEPOSIT_CONFLICTS_FILE,
     BACDIVE_ENVIRONMENT_CATEGORY,
     BACDIVE_GROWTH_MEDIUM_CLASS,
     BACDIVE_ID_COLUMN,
@@ -1641,6 +1647,13 @@ class BacDiveTransform(Transform):
         # Track non-matching media links
         non_matching_media_links = set()
 
+        # Culture-collection deposit numbers are shared identifiers: several BacDive
+        # records can cite the same deposit, and they do not always agree on the taxon.
+        # Which parent a deposit should get therefore cannot be decided while streaming
+        # records, so claims are buffered here and resolved after the loop (see #892).
+        # Shape: {kgmicrobe.strain:<deposit>: {NCBITaxon:<id>: [bacdive record key, ...]}}
+        deposit_parent_claims: Dict[str, Dict[str, List[str]]] = {}
+
         COLUMN_NAMES = [
             BACDIVE_ID_COLUMN,
             DSM_NUMBER_COLUMN,
@@ -2709,22 +2722,13 @@ class BacDiveTransform(Transform):
                             strain_label = culture_number.strip() if len(culture_number_cleaned) > 3 else None
                             if strain_curie and strain_label:
                                 node_writer.writerow(self._create_node_row(strain_curie, NCBI_CATEGORY, strain_label))
-                                # Link culture collection strain to NCBITaxon (if available)
+                                # Record this record's claim about the deposit's parent
+                                # taxon. The edge itself is written after the loop, once
+                                # every record that cites this deposit has been seen (#892).
                                 if ncbitaxon_id:
-                                    knowledge_level, agent_type = self._add_edge_metadata(
-                                        SUBCLASS_PREDICATE, RDFS_SUBCLASS_OF, ncbitaxon_id
-                                    )
-                                    edge_writer.writerow(
-                                        [
-                                            strain_curie,
-                                            SUBCLASS_PREDICATE,
-                                            ncbitaxon_id,
-                                            RDFS_SUBCLASS_OF,
-                                            self.knowledge_source,
-                                            knowledge_level,
-                                            agent_type,
-                                        ]
-                                    )
+                                    deposit_parent_claims.setdefault(strain_curie, {}).setdefault(
+                                        ncbitaxon_id, []
+                                    ).append(key)
 
                     if phys_and_metabolism_enzymes:
                         # Normalize to list
@@ -3361,6 +3365,26 @@ class BacDiveTransform(Transform):
                     progress.set_description(f"Processing BacDive file: {str(index)}.yaml")
                     # After each iteration, call the update method to advance the progress bar.
                     progress.update()
+
+                # Resolve the buffered culture-collection deposit claims: assert a
+                # parent only where every record citing the deposit agrees (#892).
+                resolved_deposits, deposit_parent_conflicts = resolve_deposit_parents(deposit_parent_claims)
+                for strain_curie, deposit_parent_id in resolved_deposits:
+                    knowledge_level, agent_type = self._add_edge_metadata(
+                        SUBCLASS_PREDICATE, RDFS_SUBCLASS_OF, deposit_parent_id
+                    )
+                    edge_writer.writerow(
+                        [
+                            strain_curie,
+                            SUBCLASS_PREDICATE,
+                            deposit_parent_id,
+                            RDFS_SUBCLASS_OF,
+                            self.knowledge_source,
+                            knowledge_level,
+                            agent_type,
+                        ]
+                    )
+
                 # Write metabolite_map to a file
                 if len(METABOLITE_MAP) > 0 and not Path(METABOLITE_MAPPING_FILE).is_file():
                     with open(METABOLITE_MAPPING_FILE, "w") as f:
@@ -3374,6 +3398,22 @@ class BacDiveTransform(Transform):
             f.write("# These links do not match the https://mediadive.dsmz.de/medium/ pattern\n\n")
             for link in sorted(non_matching_media_links):
                 f.write(f"{link}\n")
+
+        # Culture-collection deposits whose claiming records disagree on the parent
+        # taxon. These get no subclass_of edge (see the resolution loop above); the
+        # report is the record that the claim existed and what it was, so a consumer
+        # who needs the ambiguous taxonomy can still recover it (#892).
+        conflicts_file = os.path.join(self.output_dir, BACDIVE_DEPOSIT_CONFLICTS_FILE)
+        with open(conflicts_file, "w", newline="") as f:
+            conflict_writer = csv.writer(f, delimiter="\t")
+            conflict_writer.writerow(DEPOSIT_CONFLICT_HEADER)
+            conflict_writer.writerows(deposit_conflict_rows(deposit_parent_conflicts))
+        logger.info(
+            "[bacdive] culture-collection deposits with conflicting parent taxa: %s "
+            "(subclass_of suppressed; listed in %s)",
+            f"{len(deposit_parent_conflicts):,}",
+            conflicts_file,
+        )
 
         drop_duplicates(
             self.output_node_file,

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -45,7 +45,7 @@ from kg_microbe.transform_utils.constants import (
     BACDIVE,
     BACDIVE_API_BASE_URL,
     BACDIVE_ASSAY_PREDICATE,
-    BACDIVE_DEPOSIT_CONFLICTS_FILE,
+    BACDIVE_DEPOSIT_CLAIMS_FILE,
     BACDIVE_ENVIRONMENT_CATEGORY,
     BACDIVE_GROWTH_MEDIUM_CLASS,
     BACDIVE_ID_COLUMN,
@@ -192,6 +192,7 @@ from kg_microbe.transform_utils.constants import (
     XREF_COLUMN,
 )
 from kg_microbe.transform_utils.transform import Transform
+from kg_microbe.utils.atomic_io import atomic_write
 from kg_microbe.utils.chemical_mapping_utils import ChemicalMappingLoader
 from kg_microbe.utils.dummy_tqdm import DummyTqdm
 from kg_microbe.utils.isolation_source_mapping_utils import (
@@ -3452,22 +3453,27 @@ class BacDiveTransform(Transform):
 
         # Write non-matching media links to a file
         media_links_file = os.path.join(self.output_dir, "bacdive_media_links.txt")
-        with open(media_links_file, "w") as f:
+        with atomic_write(media_links_file) as f:
             f.write("# Non-matching media links found in BacDive data\n")
             f.write(f"# Total unique non-matching links: {len(non_matching_media_links)}\n")
             f.write("# These links do not match the https://mediadive.dsmz.de/medium/ pattern\n\n")
             for link in sorted(non_matching_media_links):
                 f.write(f"{link}\n")
 
-        # Culture-collection deposits whose claiming records disagree on the parent
-        # taxon. These get no subclass_of edge (see the resolution loop above); the
-        # report is the record that the claim existed and what it was, so a consumer
-        # who needs the ambiguous taxonomy can still recover it (#892).
-        conflicts_file = os.path.join(self.output_dir, BACDIVE_DEPOSIT_CONFLICTS_FILE)
-        with open(conflicts_file, "w", newline="") as f:
-            conflict_writer = csv.writer(f, delimiter="\t")
-            conflict_writer.writerow(DEPOSIT_CONFLICT_HEADER)
-            conflict_writer.writerows(deposit_conflict_rows(contested_deposits))
+        # Every culture-collection deposit whose claiming records disagreed on the
+        # parent taxon, and what became of it: `collapsed` rows carry the shared
+        # ancestor that was asserted, `suppressed` rows got no subclass_of edge at
+        # all. Both belong here — the file answers "what happened to this deposit
+        # and why", not just "which ones lost their edge" (#892, #898).
+        #
+        # Written atomically: an absent or truncated report reads exactly like
+        # "nothing was contested", which is the silent failure this file exists to
+        # prevent (#903).
+        claims_file = os.path.join(self.output_dir, BACDIVE_DEPOSIT_CLAIMS_FILE)
+        with atomic_write(claims_file, newline="") as f:
+            claims_writer = csv.writer(f, delimiter="\t")
+            claims_writer.writerow(DEPOSIT_CONFLICT_HEADER)
+            claims_writer.writerows(deposit_conflict_rows(contested_deposits))
         resolution_counts = Counter(resolution for _, _, resolution, _ in contested_deposits)
         logger.info(
             "[bacdive] culture-collection deposits claimed by disagreeing records: "
@@ -3478,7 +3484,7 @@ class BacDiveTransform(Transform):
             f"{resolution_counts[RESOLUTION_SUPPRESSED]:,}",
             f"{resolution_counts[RESOLUTION_SUPPRESSED_NO_ANCESTRY]:,}",
             f"{len(self._ncbitaxon_ancestry_failures):,}",
-            conflicts_file,
+            claims_file,
         )
 
         drop_duplicates(

--- a/kg_microbe/transform_utils/bacdive/emission.py
+++ b/kg_microbe/transform_utils/bacdive/emission.py
@@ -33,7 +33,34 @@ class StrainProvenanceWriter:
 DEPOSIT_CONFLICT_HEADER = ["strain_id", "parent_count", "parents", "bacdive_ids"]
 
 
-def resolve_deposit_parents(claims):
+def entailed_by_every_claim(parents, ancestors_of):
+    """
+    Return the one claimed taxon that every other claim entails, or None.
+
+    Claims can differ without contradicting each other: one record records the
+    species (``Brevundimonas vesicularis``) and another the strain beneath it
+    (``Brevundimonas vesicularis NBRC 12165``). The species claim is true either
+    way, so it is the strongest statement all claimants support, and asserting it
+    privileges neither record. Only a claim that was actually made is eligible --
+    falling back to a computed common ancestor would put a taxon nobody claimed
+    (often just ``Bacteria``) on the node.
+
+    :param parents: Iterable of claimed NCBITaxon CURIEs.
+    :param ancestors_of: Callable mapping a CURIE to its proper ``is_a``
+        ancestors, or None when no ontology is available.
+    :return: The entailed CURIE, or None when the claims are disjoint.
+    """
+    if ancestors_of is None:
+        return None
+    parents = set(parents)
+    ancestry = {parent: ancestors_of(parent) for parent in parents}
+    for candidate in sorted(parents):
+        if all(candidate in ancestry[other] for other in parents if other != candidate):
+            return candidate
+    return None
+
+
+def resolve_deposit_parents(claims, ancestors_of=None):
     """
     Decide which culture-collection deposits may assert a parent taxon (#892).
 
@@ -42,9 +69,14 @@ def resolve_deposit_parents(claims):
     about the taxon, emitting one ``subclass_of`` edge per claiming record leaves
     the deposit node with several parents and nothing to tell them apart, so a
     consumer that takes "the" parent gets whichever one file order put first.
-    A parent is asserted only when every claiming record agrees.
+
+    A parent is asserted when the claimants agree outright, and when they differ
+    only in depth along one lineage -- there the shared ancestor is asserted, per
+    :func:`entailed_by_every_claim`. Genuinely disjoint claims get no edge.
 
     :param claims: ``{strain CURIE: {NCBITaxon CURIE: [BacDive record key, ...]}}``.
+    :param ancestors_of: Callable mapping an NCBITaxon CURIE to its proper ``is_a``
+        ancestors. When None, any disagreement is treated as a conflict.
     :return: ``(resolved, conflicts)`` where ``resolved`` is a sorted list of
         ``(strain CURIE, NCBITaxon CURIE)`` pairs safe to emit, and ``conflicts``
         is a sorted list of ``(strain CURIE, claims-for-that-deposit)`` pairs.
@@ -53,10 +85,14 @@ def resolve_deposit_parents(claims):
     conflicts = []
     for strain_curie in sorted(claims):
         parents = claims[strain_curie]
-        if len(parents) > 1:
+        if len(parents) == 1:
+            resolved.append((strain_curie, next(iter(parents))))
+            continue
+        agreed = entailed_by_every_claim(parents, ancestors_of)
+        if agreed is None:
             conflicts.append((strain_curie, parents))
         else:
-            resolved.append((strain_curie, next(iter(parents))))
+            resolved.append((strain_curie, agreed))
     return resolved, conflicts
 
 

--- a/kg_microbe/transform_utils/bacdive/emission.py
+++ b/kg_microbe/transform_utils/bacdive/emission.py
@@ -27,3 +27,57 @@ class StrainProvenanceWriter:
         """Apply provenance augmentation to a sequence of rows."""
         for row in rows:
             self.writerow(row)
+
+
+#: Header of the deposit-conflict report written alongside nodes.tsv / edges.tsv.
+DEPOSIT_CONFLICT_HEADER = ["strain_id", "parent_count", "parents", "bacdive_ids"]
+
+
+def resolve_deposit_parents(claims):
+    """
+    Decide which culture-collection deposits may assert a parent taxon (#892).
+
+    A deposit number such as ``ATCC 13722`` identifies a physical deposit, not a
+    BacDive record, so several records can cite the same one. When they disagree
+    about the taxon, emitting one ``subclass_of`` edge per claiming record leaves
+    the deposit node with several parents and nothing to tell them apart, so a
+    consumer that takes "the" parent gets whichever one file order put first.
+    A parent is asserted only when every claiming record agrees.
+
+    :param claims: ``{strain CURIE: {NCBITaxon CURIE: [BacDive record key, ...]}}``.
+    :return: ``(resolved, conflicts)`` where ``resolved`` is a sorted list of
+        ``(strain CURIE, NCBITaxon CURIE)`` pairs safe to emit, and ``conflicts``
+        is a sorted list of ``(strain CURIE, claims-for-that-deposit)`` pairs.
+    """
+    resolved = []
+    conflicts = []
+    for strain_curie in sorted(claims):
+        parents = claims[strain_curie]
+        if len(parents) > 1:
+            conflicts.append((strain_curie, parents))
+        else:
+            resolved.append((strain_curie, next(iter(parents))))
+    return resolved, conflicts
+
+
+def deposit_conflict_rows(conflicts):
+    """
+    Render conflicting deposit claims as report rows.
+
+    The report is the record that a claim existed and what it was, so a consumer
+    who needs the ambiguous taxonomy can still recover what was suppressed.
+
+    :param conflicts: ``conflicts`` as returned by :func:`resolve_deposit_parents`.
+    :return: List of rows matching :data:`DEPOSIT_CONFLICT_HEADER`.
+    """
+    rows = []
+    for strain_curie, parents in conflicts:
+        rows.append(
+            [
+                strain_curie,
+                len(parents),
+                "|".join(sorted(parents)),
+                "|".join(sorted({key for keys in parents.values() for key in keys})),
+            ]
+        )
+    return rows

--- a/kg_microbe/transform_utils/bacdive/emission.py
+++ b/kg_microbe/transform_utils/bacdive/emission.py
@@ -29,8 +29,25 @@ class StrainProvenanceWriter:
             self.writerow(row)
 
 
-#: Header of the deposit-conflict report written alongside nodes.tsv / edges.tsv.
-DEPOSIT_CONFLICT_HEADER = ["strain_id", "parent_count", "parents", "bacdive_ids"]
+#: Header of the deposit-claim report written alongside nodes.tsv / edges.tsv.
+DEPOSIT_CONFLICT_HEADER = [
+    "strain_id",
+    "parent_count",
+    "parents",
+    "bacdive_ids",
+    "resolution",
+    "asserted_parent",
+]
+
+#: The claims sat on one lineage; the shared ancestor was asserted (#898).
+RESOLUTION_COLLAPSED = "collapsed"
+#: The claims were disjoint; no parent was asserted.
+RESOLUTION_SUPPRESSED = "suppressed"
+#: Ancestry for at least one claim could not be read, so the claims could not be
+#: compared and the deposit was suppressed as a precaution rather than a verdict.
+#: Distinguishing this matters -- a degraded NCBITaxon adapter otherwise looks
+#: exactly like a data problem in BacDive (#897).
+RESOLUTION_SUPPRESSED_NO_ANCESTRY = "suppressed_ancestry_unavailable"
 
 
 def entailed_by_every_claim(parents, ancestors_of):
@@ -60,7 +77,7 @@ def entailed_by_every_claim(parents, ancestors_of):
     return None
 
 
-def resolve_deposit_parents(claims, ancestors_of=None):
+def resolve_deposit_parents(claims, ancestors_of=None, ancestry_failed=None):
     """
     Decide which culture-collection deposits may assert a parent taxon (#892).
 
@@ -74,15 +91,23 @@ def resolve_deposit_parents(claims, ancestors_of=None):
     only in depth along one lineage -- there the shared ancestor is asserted, per
     :func:`entailed_by_every_claim`. Genuinely disjoint claims get no edge.
 
+    Every deposit with more than one claim is reported, whichever way it went, so
+    the report answers "what happened here and why" rather than listing only the
+    half that lost its edge (#898).
+
     :param claims: ``{strain CURIE: {NCBITaxon CURIE: [BacDive record key, ...]}}``.
     :param ancestors_of: Callable mapping an NCBITaxon CURIE to its proper ``is_a``
         ancestors. When None, any disagreement is treated as a conflict.
-    :return: ``(resolved, conflicts)`` where ``resolved`` is a sorted list of
-        ``(strain CURIE, NCBITaxon CURIE)`` pairs safe to emit, and ``conflicts``
-        is a sorted list of ``(strain CURIE, claims-for-that-deposit)`` pairs.
+    :param ancestry_failed: Callable reporting whether a CURIE's ancestry could not
+        be read, used to mark a suppression that is a precaution rather than a
+        verdict (#897). When None, no suppression is marked that way.
+    :return: ``(resolved, contested)``. ``resolved`` is a sorted list of
+        ``(strain CURIE, NCBITaxon CURIE)`` pairs to emit. ``contested`` is a sorted
+        list of ``(strain CURIE, claims, resolution, asserted parent)`` for every
+        deposit with more than one claim; ``asserted parent`` is empty when none was.
     """
     resolved = []
-    conflicts = []
+    contested = []
     for strain_curie in sorted(claims):
         parents = claims[strain_curie]
         if len(parents) == 1:
@@ -90,30 +115,34 @@ def resolve_deposit_parents(claims, ancestors_of=None):
             continue
         agreed = entailed_by_every_claim(parents, ancestors_of)
         if agreed is None:
-            conflicts.append((strain_curie, parents))
+            degraded = ancestry_failed is not None and any(ancestry_failed(parent) for parent in parents)
+            resolution = RESOLUTION_SUPPRESSED_NO_ANCESTRY if degraded else RESOLUTION_SUPPRESSED
+            contested.append((strain_curie, parents, resolution, ""))
         else:
             resolved.append((strain_curie, agreed))
-    return resolved, conflicts
+            contested.append((strain_curie, parents, RESOLUTION_COLLAPSED, agreed))
+    return resolved, contested
 
 
-def deposit_conflict_rows(conflicts):
+def deposit_conflict_rows(contested):
     """
-    Render conflicting deposit claims as report rows.
+    Render contested deposit claims as report rows.
 
-    The report is the record that a claim existed and what it was, so a consumer
-    who needs the ambiguous taxonomy can still recover what was suppressed.
+    The report is the record that a claim existed and what became of it, so a
+    consumer can recover the taxonomy that was suppressed, and see which deposits
+    had theirs coarsened to a shared ancestor.
 
-    :param conflicts: ``conflicts`` as returned by :func:`resolve_deposit_parents`.
+    :param contested: ``contested`` as returned by :func:`resolve_deposit_parents`.
     :return: List of rows matching :data:`DEPOSIT_CONFLICT_HEADER`.
     """
-    rows = []
-    for strain_curie, parents in conflicts:
-        rows.append(
-            [
-                strain_curie,
-                len(parents),
-                "|".join(sorted(parents)),
-                "|".join(sorted({key for keys in parents.values() for key in keys})),
-            ]
-        )
-    return rows
+    return [
+        [
+            strain_curie,
+            len(parents),
+            "|".join(sorted(parents)),
+            "|".join(sorted({key for keys in parents.values() for key in keys})),
+            resolution,
+            asserted,
+        ]
+        for strain_curie, parents, resolution, asserted in contested
+    ]

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -776,9 +776,12 @@ UNIPROT_DATA_LIST = [
 ]
 
 BACDIVE_MAPPING_FILE = "bacdive_mappings.tsv"
-# Report of culture-collection deposit numbers claimed by more than one BacDive
-# record with a different parent taxon; those deposits get no subclass_of edge (#892).
-BACDIVE_DEPOSIT_CONFLICTS_FILE = "bacdive_strain_deposit_conflicts.tsv"
+# Report of every culture-collection deposit number claimed by more than one
+# BacDive record with a different parent taxon, and what became of it: `collapsed`
+# rows were given the ancestor every claimant entails, `suppressed` rows were given
+# no subclass_of edge at all. Named for the claims, not the conflicts, because a
+# resolved claim is in here too (#892, #898).
+BACDIVE_DEPOSIT_CLAIMS_FILE = "bacdive_strain_deposit_claims.tsv"
 MICROMEDIAPARAM_COMPOUND_MAPPINGS_FILE = "compound_mappings_strict.tsv"
 MICROMEDIAPARAM_HYDRATE_MAPPINGS_FILE = "compound_mappings_strict_hydrate.tsv"
 

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -776,6 +776,9 @@ UNIPROT_DATA_LIST = [
 ]
 
 BACDIVE_MAPPING_FILE = "bacdive_mappings.tsv"
+# Report of culture-collection deposit numbers claimed by more than one BacDive
+# record with a different parent taxon; those deposits get no subclass_of edge (#892).
+BACDIVE_DEPOSIT_CONFLICTS_FILE = "bacdive_strain_deposit_conflicts.tsv"
 MICROMEDIAPARAM_COMPOUND_MAPPINGS_FILE = "compound_mappings_strict.tsv"
 MICROMEDIAPARAM_HYDRATE_MAPPINGS_FILE = "compound_mappings_strict_hydrate.tsv"
 

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -180,3 +180,51 @@ def test_without_ancestry_any_disagreement_is_a_conflict():
     )
     assert resolved == []
     assert len(conflicts) == 1
+
+
+def test_the_record_is_linked_to_every_deposit_it_cites():
+    """
+    A deposit node must reach back to whoever asserted it (#894).
+
+    Without this edge a `kgmicrobe.strain:<deposit>` node has one outgoing
+    `subclass_of` and nothing else, so a deposit whose claimants disagree —
+    which gets no `subclass_of` at all — would reach no taxon by any path.
+
+    Inspected rather than run: `BacDiveTransform.run` needs the NCBITaxon
+    adapter, which makes an end-to-end unit test impractical (see the module
+    docstring of `test_bacdive_lpsn_crossref.py`).
+    """
+    import inspect
+    from pathlib import Path
+
+    from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
+
+    source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
+    block = source.split("if culture_number_from_external_links:")[1].split("if phys_and_metabolism_enzymes:")[0]
+    assert "CLOSE_MATCH_RELATION" in block
+    # Subject is the record node and object the deposit node, not the reverse —
+    # the record is the thing making the assertion.
+    row = block.split("edge_writer.writerow(")[1].split("]")[0]
+    assert [line.strip().rstrip(",") for line in row.splitlines() if line.strip() and "[" not in line][:3] == [
+        "organism_id",
+        "CLOSE_MATCH_PREDICATE",
+        "strain_curie",
+    ]
+
+
+def test_bacdive_and_lpsn_land_on_the_same_deposit_curie():
+    """
+    Both transforms must mint one CURIE per deposit, or the link does not meet.
+
+    LPSN emits `lpsn:<record> close_match kgmicrobe.strain:<code>` and BacDive
+    now emits `kgmicrobe.strain:bacdive_<id> close_match kgmicrobe.strain:<code>`.
+    They reconcile at merge only while both normalise a deposit string the same
+    way, so pin that rather than trusting two copies of the rule to stay equal.
+    """
+    from kg_microbe.transform_utils.lpsn.lpsn import COL_NOMENCLATURAL_TYPE, LPSNTransform
+
+    lpsn = LPSNTransform.__new__(LPSNTransform)
+    for raw in ("ATCC 11775", "DSM 30083", "JCM 1649", "NCTC 9001"):
+        bacdive_curie = "kgmicrobe.strain:" + raw.strip().replace(" ", "-").replace(":", "-")
+        lpsn_curies = lpsn._extract_strain_curies({COL_NOMENCLATURAL_TYPE: raw})
+        assert lpsn_curies == [bacdive_curie], f"{raw}: {lpsn_curies} != [{bacdive_curie}]"

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from kg_microbe.transform_utils.bacdive.emission import (
     DEPOSIT_CONFLICT_HEADER,
+    RESOLUTION_COLLAPSED,
+    RESOLUTION_SUPPRESSED,
+    RESOLUTION_SUPPRESSED_NO_ANCESTRY,
     deposit_conflict_rows,
     resolve_deposit_parents,
 )
@@ -41,7 +44,9 @@ def test_disagreeing_records_suppress_the_edge_entirely():
     }
     resolved, conflicts = resolve_deposit_parents(claims)
     assert resolved == []
-    assert conflicts == [("kgmicrobe.strain:ATCC-13722", claims["kgmicrobe.strain:ATCC-13722"])]
+    assert conflicts == [
+        ("kgmicrobe.strain:ATCC-13722", claims["kgmicrobe.strain:ATCC-13722"], RESOLUTION_SUPPRESSED, "")
+    ]
 
 
 def test_conflicts_do_not_suppress_unrelated_deposits():
@@ -56,7 +61,7 @@ def test_conflicts_do_not_suppress_unrelated_deposits():
         }
     )
     assert resolved == [("kgmicrobe.strain:NCDO-1718", "NCBITaxon:272240")]
-    assert [curie for curie, _ in conflicts] == ["kgmicrobe.strain:ATCC-13722"]
+    assert [entry[0] for entry in conflicts] == ["kgmicrobe.strain:ATCC-13722"]
 
 
 def test_the_report_records_what_was_suppressed():
@@ -77,6 +82,8 @@ def test_the_report_records_what_was_suppressed():
             2,
             "NCBITaxon:1915061|NCBITaxon:272240",
             "3081|7476",
+            RESOLUTION_SUPPRESSED,
+            "",
         ]
     ]
 
@@ -115,7 +122,7 @@ def test_claims_differing_only_in_depth_collapse_to_the_shared_ancestor():
         ancestors_of=_ancestors,
     )
     assert resolved == [("kgmicrobe.strain:ATCC-11426", "NCBITaxon:41276")]
-    assert conflicts == []
+    assert [entry[2] for entry in conflicts] == [RESOLUTION_COLLAPSED]
 
 
 def test_disjoint_lineages_are_still_suppressed_when_ancestry_is_available():
@@ -130,7 +137,7 @@ def test_disjoint_lineages_are_still_suppressed_when_ancestry_is_available():
         ancestors_of=_ancestors,
     )
     assert resolved == []
-    assert [curie for curie, _ in conflicts] == ["kgmicrobe.strain:ATCC-13722"]
+    assert [entry[0] for entry in conflicts] == ["kgmicrobe.strain:ATCC-13722"]
 
 
 def test_no_unclaimed_taxon_is_ever_asserted():
@@ -165,7 +172,7 @@ def test_a_three_way_chain_collapses_to_its_shallowest_member():
         ancestors_of=_ancestors,
     )
     assert resolved == [("kgmicrobe.strain:X-1", "NCBITaxon:41275")]
-    assert conflicts == []
+    assert [entry[2] for entry in conflicts] == [RESOLUTION_COLLAPSED]
 
 
 def test_without_ancestry_any_disagreement_is_a_conflict():
@@ -228,3 +235,82 @@ def test_bacdive_and_lpsn_land_on_the_same_deposit_curie():
         bacdive_curie = "kgmicrobe.strain:" + raw.strip().replace(" ", "-").replace(":", "-")
         lpsn_curies = lpsn._extract_strain_curies({COL_NOMENCLATURAL_TYPE: raw})
         assert lpsn_curies == [bacdive_curie], f"{raw}: {lpsn_curies} != [{bacdive_curie}]"
+
+
+def test_a_collapsed_deposit_is_reported_not_just_counted():
+    """
+    Coarsening a deposit's taxonomy must leave a trace (#898).
+
+    A collapsed deposit still gets an edge, so it is tempting to treat it as
+    resolved and say nothing. But the discarded claim then exists in no artifact
+    at all, and nobody can tell that `ATCC 11426` was ever claimed as anything
+    more specific than the species now asserted on it.
+    """
+    resolved, contested = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-11426": {
+                "NCBITaxon:1349759": ["1"],
+                "NCBITaxon:41276": ["2"],
+            }
+        },
+        ancestors_of=_ancestors,
+    )
+    assert resolved == [("kgmicrobe.strain:ATCC-11426", "NCBITaxon:41276")]
+    rows = deposit_conflict_rows(contested)
+    assert rows == [
+        [
+            "kgmicrobe.strain:ATCC-11426",
+            2,
+            "NCBITaxon:1349759|NCBITaxon:41276",
+            "1|2",
+            RESOLUTION_COLLAPSED,
+            "NCBITaxon:41276",
+        ]
+    ]
+    # The claim that was dropped is still readable from the row.
+    assert "NCBITaxon:1349759" in rows[0][2]
+
+
+def test_a_deposit_with_one_claim_is_not_in_the_report():
+    """The report is about contested deposits; 150k uncontested ones are noise."""
+    _, contested = resolve_deposit_parents(
+        {"kgmicrobe.strain:DSM-20154": {"NCBITaxon:272240": ["3081"]}},
+        ancestors_of=_ancestors,
+    )
+    assert contested == []
+
+
+def test_a_suppression_caused_by_unreadable_ancestry_says_so():
+    """
+    A degraded adapter must not read as a data problem in BacDive (#897).
+
+    With no ancestry, two claims on one lineage look disjoint and the edge is
+    suppressed. That is the right precaution, but reporting it as a plain
+    conflict blames the source for the ontology's failure.
+    """
+    _, contested = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-11426": {
+                "NCBITaxon:1349759": ["1"],
+                "NCBITaxon:41276": ["2"],
+            }
+        },
+        ancestors_of=lambda curie: frozenset(),
+        ancestry_failed={"NCBITaxon:1349759"}.__contains__,
+    )
+    assert [entry[2] for entry in contested] == [RESOLUTION_SUPPRESSED_NO_ANCESTRY]
+
+
+def test_a_real_conflict_is_not_blamed_on_the_ontology():
+    """A working lookup that finds genuine disagreement stays a plain suppression."""
+    _, contested = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-13722": {
+                "NCBITaxon:272240": ["3081"],
+                "NCBITaxon:1915061": ["7476"],
+            }
+        },
+        ancestors_of=_ancestors,
+        ancestry_failed=set().__contains__,
+    )
+    assert [entry[2] for entry in contested] == [RESOLUTION_SUPPRESSED]

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -314,3 +314,40 @@ def test_a_real_conflict_is_not_blamed_on_the_ontology():
         ancestry_failed=set().__contains__,
     )
     assert [entry[2] for entry in contested] == [RESOLUTION_SUPPRESSED]
+
+
+def test_the_report_is_written_atomically():
+    """
+    An absent or truncated report reads as "nothing was contested" (#903).
+
+    `nodes.tsv` and `edges.tsv` are closed and complete before this file is
+    written, so a crash in the gap leaves outputs that look finished beside a
+    report that understates what was suppressed — the silent failure the report
+    exists to prevent.
+    """
+    import inspect
+    from pathlib import Path
+
+    from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
+
+    source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
+    block = source.split("claims_file = os.path.join")[1].split("logger.info")[0]
+    assert "atomic_write(claims_file" in block
+    assert "open(claims_file" not in block
+
+
+def test_the_report_is_not_described_as_edgeless():
+    """
+    Its rows are not all suppressed, and the comments must not say they are (#902).
+
+    `collapsed` rows do get a `subclass_of` edge. A reader who trusts a comment
+    saying otherwise will filter the graph on a false premise.
+    """
+    from pathlib import Path
+
+    from kg_microbe.transform_utils.constants import BACDIVE_DEPOSIT_CLAIMS_FILE
+
+    assert BACDIVE_DEPOSIT_CLAIMS_FILE == "bacdive_strain_deposit_claims.tsv"
+    constants = Path("kg_microbe/transform_utils/constants.py").read_text()
+    stanza = constants.split("BACDIVE_DEPOSIT_CLAIMS_FILE")[0].rsplit("\n\n", 1)[-1]
+    assert "collapsed" in stanza and "suppressed" in stanza

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -1,0 +1,81 @@
+"""Culture-collection deposits must not acquire contradictory parent taxa (#892)."""
+
+from __future__ import annotations
+
+from kg_microbe.transform_utils.bacdive.emission import (
+    DEPOSIT_CONFLICT_HEADER,
+    deposit_conflict_rows,
+    resolve_deposit_parents,
+)
+
+
+def test_a_deposit_claimed_by_one_record_keeps_its_parent():
+    """The ordinary case — one record cites the deposit — is unchanged."""
+    resolved, conflicts = resolve_deposit_parents({"kgmicrobe.strain:DSM-20154": {"NCBITaxon:272240": ["3081"]}})
+    assert resolved == [("kgmicrobe.strain:DSM-20154", "NCBITaxon:272240")]
+    assert conflicts == []
+
+
+def test_agreeing_records_still_yield_a_single_edge():
+    """Several records citing the same deposit and the same taxon do not conflict."""
+    resolved, conflicts = resolve_deposit_parents(
+        {"kgmicrobe.strain:DSM-20154": {"NCBITaxon:272240": ["3081", "7476"]}}
+    )
+    assert resolved == [("kgmicrobe.strain:DSM-20154", "NCBITaxon:272240")]
+    assert conflicts == []
+
+
+def test_disagreeing_records_suppress_the_edge_entirely():
+    """
+    Picking one of two parents makes the answer depend on file order.
+
+    ``ATCC 13722`` is cited by BacDive 3081 (*Gulosibacter faecalis*) and 7476
+    (*Pseudoclavibacter* sp.). Emitting both leaves a consumer that takes "the"
+    parent with whichever came first, so neither is asserted.
+    """
+    claims = {
+        "kgmicrobe.strain:ATCC-13722": {
+            "NCBITaxon:272240": ["3081"],
+            "NCBITaxon:1915061": ["7476"],
+        }
+    }
+    resolved, conflicts = resolve_deposit_parents(claims)
+    assert resolved == []
+    assert conflicts == [("kgmicrobe.strain:ATCC-13722", claims["kgmicrobe.strain:ATCC-13722"])]
+
+
+def test_conflicts_do_not_suppress_unrelated_deposits():
+    """Suppression is per deposit, not per record."""
+    resolved, conflicts = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-13722": {
+                "NCBITaxon:272240": ["3081"],
+                "NCBITaxon:1915061": ["7476"],
+            },
+            "kgmicrobe.strain:NCDO-1718": {"NCBITaxon:272240": ["3081"]},
+        }
+    )
+    assert resolved == [("kgmicrobe.strain:NCDO-1718", "NCBITaxon:272240")]
+    assert [curie for curie, _ in conflicts] == ["kgmicrobe.strain:ATCC-13722"]
+
+
+def test_the_report_records_what_was_suppressed():
+    """A suppressed claim is still recoverable from the report."""
+    _, conflicts = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-13722": {
+                "NCBITaxon:272240": ["3081"],
+                "NCBITaxon:1915061": ["7476"],
+            }
+        }
+    )
+    rows = deposit_conflict_rows(conflicts)
+    assert len(DEPOSIT_CONFLICT_HEADER) == len(rows[0])
+    assert rows == [
+        [
+            "kgmicrobe.strain:ATCC-13722",
+            2,
+            "NCBITaxon:1915061|NCBITaxon:272240",
+            "3081|7476",
+        ]
+    ]

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -79,3 +79,104 @@ def test_the_report_records_what_was_suppressed():
             "3081|7476",
         ]
     ]
+
+
+# Real NCBITaxon ancestry, trimmed to what these cases need.
+_ANCESTRY = {
+    # Brevundimonas vesicularis NBRC 12165 sits under Brevundimonas vesicularis.
+    "NCBITaxon:1349759": {"NCBITaxon:41276", "NCBITaxon:41275"},
+    "NCBITaxon:41276": {"NCBITaxon:41275"},
+    # Gulosibacter faecalis and Pseudoclavibacter sp. share nothing below the phylum.
+    "NCBITaxon:272240": {"NCBITaxon:201174"},
+    "NCBITaxon:1915061": {"NCBITaxon:201174"},
+}
+
+
+def _ancestors(curie):
+    return _ANCESTRY.get(curie, set())
+
+
+def test_claims_differing_only_in_depth_collapse_to_the_shared_ancestor():
+    """
+    Species and strain-under-that-species are not a contradiction.
+
+    BacDive records one deposit as *Brevundimonas vesicularis* and another as
+    *B. vesicularis NBRC 12165*. The species claim holds either way, so it is
+    the strongest statement both claimants support — and asserting it privileges
+    neither record, which is the whole point of the rule.
+    """
+    resolved, conflicts = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-11426": {
+                "NCBITaxon:1349759": ["1"],
+                "NCBITaxon:41276": ["2"],
+            }
+        },
+        ancestors_of=_ancestors,
+    )
+    assert resolved == [("kgmicrobe.strain:ATCC-11426", "NCBITaxon:41276")]
+    assert conflicts == []
+
+
+def test_disjoint_lineages_are_still_suppressed_when_ancestry_is_available():
+    """Having an ontology must not turn a real contradiction into an answer."""
+    resolved, conflicts = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-13722": {
+                "NCBITaxon:272240": ["3081"],
+                "NCBITaxon:1915061": ["7476"],
+            }
+        },
+        ancestors_of=_ancestors,
+    )
+    assert resolved == []
+    assert [curie for curie, _ in conflicts] == ["kgmicrobe.strain:ATCC-13722"]
+
+
+def test_no_unclaimed_taxon_is_ever_asserted():
+    """
+    The shared phylum is not an acceptable answer.
+
+    Every pair of bacteria has a common ancestor, so falling back to a computed
+    one would put ``Bacteria`` on the node and call the conflict resolved.
+    """
+    _, conflicts = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-13722": {
+                "NCBITaxon:272240": ["3081"],
+                "NCBITaxon:1915061": ["7476"],
+            }
+        },
+        ancestors_of=_ancestors,
+    )
+    assert conflicts, "a shared phylum must not count as agreement"
+
+
+def test_a_three_way_chain_collapses_to_its_shallowest_member():
+    """Chains longer than two claims resolve the same way."""
+    resolved, conflicts = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:X-1": {
+                "NCBITaxon:1349759": ["1"],
+                "NCBITaxon:41276": ["2"],
+                "NCBITaxon:41275": ["3"],
+            }
+        },
+        ancestors_of=_ancestors,
+    )
+    assert resolved == [("kgmicrobe.strain:X-1", "NCBITaxon:41275")]
+    assert conflicts == []
+
+
+def test_without_ancestry_any_disagreement_is_a_conflict():
+    """The helper stays usable, and conservative, with no ontology to consult."""
+    resolved, conflicts = resolve_deposit_parents(
+        {
+            "kgmicrobe.strain:ATCC-11426": {
+                "NCBITaxon:1349759": ["1"],
+                "NCBITaxon:41276": ["2"],
+            }
+        }
+    )
+    assert resolved == []
+    assert len(conflicts) == 1


### PR DESCRIPTION
Closes #892

## The bug

A `kgmicrobe.strain:<code>` node minted from a culture-collection deposit number identifies a **physical deposit, not a BacDive record**, so several records can cite the same one — and they do not always agree on the taxon. The transform wrote one `subclass_of` edge per claiming record, so the deposit node ended up with several NCBITaxon parents and nothing to tell them apart. A consumer that takes "the" parent gets whichever one file order happened to put first; the reporter's union-find over `subclass_of` chained unrelated organisms into one component.

Worked example from the current dump — BacDive 3081 and 7476 both cite `ATCC 13722`:

| record | taxon | culture collection no. |
|---|---|---|
| 3081 | NCBITaxon:272240 *Gulosibacter faecalis* | DSM 20154, NCDO 1718, **ATCC 13722**, CIP 108568, IAM 15030, IFO 15706, TISTR 1514 |
| 7476 | NCBITaxon:1915061 *Pseudoclavibacter* sp. | DSM 17446, IAM 15030, JCM 12866, NBRC 15706, TISTR 1514, **ATCC 13722**, … |

## The fix

Deposit parent claims are buffered while records stream and resolved after the loop. A parent is asserted only when every record citing the deposit agrees on it. Where they disagree, no edge is written and the claim goes to `bacdive_strain_deposit_conflicts.tsv` in the transform's output directory (`strain_id`, `parent_count`, `parents`, `bacdive_ids`), so the suppressed taxonomy stays recoverable and the conflict is visible instead of silent. A summary count is logged.

Record-scoped `kgmicrobe.strain:bacdive_NNN` nodes are untouched — they already have exactly one parent each (99,386 of them, zero multi-parent).

## Correcting the reported mechanism

The issue hypothesises non-unique bare strain designations used as node ids. Measured against the dump, that is only ~6% of the cases:

| colliding token looks like | count |
|---|---|
| a recognised culture-collection acronym (ATCC, DSM, CIP, …) | 494 |
| uppercase acronym shape but a rare prefix | 26 |
| not a collection code at all (`Agre-8`, `Chol-1`, `Sao-Paulo`) | 5 |

So restricting id minting to recognised collections — the obvious first fix, and the one LPSN's `_CULTURE_CODE` allowlist already applies on its side — would not have fixed this. The dominant cause is BacDive citing the same deposit from records with conflicting taxonomy: 222 of the two-record cases share more than one deposit number (so they look like duplicate records for one physical strain), 306 share exactly one.

## Verification

- New unit tests in `tests/test_bacdive_deposit_parents.py` (5 tests) covering single claimant, agreeing claimants, disagreeing claimants, per-deposit isolation, and the report rows.
- Offline replay of the resolution over the real 99,392-record `bacdive_strains.json`: **515 of 150,918 deposits (0.34%)** have disagreeing claimants, so **1,039 of 151,442** deposit edges are suppressed, and every emitted deposit has exactly one parent. The replay cannot cover the ~818 records that reach their taxon through the OAK name fallback, which is why the live output shows 525 rather than 515.
- `poetry run tox`: format, lint, codespell, docstr-coverage all OK. `tests/test_ontologies_stubs.py::test_every_referenced_curie_has_stub_node` fails identically on `master` (stale local `ontologies_stubs` output, `PO:0009005`) — pre-existing, unrelated.

The transform itself has **not** been rerun; that is on hold pending the updated MIM SSSOM. This change makes `bacdive` stale and will be picked up by that rerun.