### PR TITLE
fix(bacdive): withhold close_match on deposits proven to be shared designations (#899, #907, #908)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,10 +95,12 @@ and go to the source's deposit-claim report, because picking one would make
 the answer depend on file order. That report carries every deposit whose
 claimants disagreed, whichever way it went, so a coarsened taxonomy and a
 suppressed one are both visible and neither is confused with an ontology
-lookup that failed. Every record that cites a deposit links to it
-with `biolink:close_match`, so the deposit's provenance is in the graph and its
-taxonomy stays reachable through the record even when no parent is asserted.
-See issues #892 and #894.
+lookup that failed. A record that cites a deposit links to it with
+`biolink:close_match`, so the deposit's provenance is in the graph — but only
+where the deposit kept a parent. `close_match` is symmetric and maps to
+`SEMMEDDB:same_as`, so on a deposit whose claimants proved to be unrelated
+organisms it would assert an equivalence between them; those citations stay in
+the claims report. See issues #892, #894 and #899.
 
 ## Operational traps
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,8 @@ lookup that failed. A record that cites a deposit links to it with
 where the deposit kept a parent. `close_match` is symmetric and maps to
 `SEMMEDDB:same_as`, so on a deposit whose claimants proved to be unrelated
 organisms it would assert an equivalence between them; those citations stay in
-the claims report. See issues #892, #894 and #899.
+the claims report, and the node carries a description saying so. See issues
+#892, #894, #899 and #907.
 
 ## Operational traps
 

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -29,6 +29,7 @@ from kg_microbe.transform_utils.bacdive.emission import (
     RESOLUTION_SUPPRESSED,
     RESOLUTION_SUPPRESSED_NO_ANCESTRY,
     deposit_conflict_rows,
+    resolution_asserts_a_parent,
     resolve_deposit_parents,
 )
 from kg_microbe.transform_utils.bacdive.emission import StrainProvenanceWriter as _StrainProvenanceWriter
@@ -1690,6 +1691,10 @@ class BacDiveTransform(Transform):
         # records, so claims are buffered here and resolved after the loop (see #892).
         # Shape: {kgmicrobe.strain:<deposit>: {NCBITaxon:<id>: [bacdive record key, ...]}}
         deposit_parent_claims: Dict[str, Dict[str, List[str]]] = {}
+        # Every (BacDive record, deposit) citation seen, buffered for the same reason:
+        # whether the link is safe to assert depends on what the other records citing
+        # that deposit turn out to say (#899).
+        deposit_citations: List[tuple] = []
 
         COLUMN_NAMES = [
             BACDIVE_ID_COLUMN,
@@ -2759,26 +2764,14 @@ class BacDiveTransform(Transform):
                             strain_label = culture_number.strip() if len(culture_number_cleaned) > 3 else None
                             if strain_curie and strain_label:
                                 node_writer.writerow(self._create_node_row(strain_curie, NCBI_CATEGORY, strain_label))
-                                # Link the record to the deposit it cites, mirroring the
-                                # edge LPSN already emits onto these same CURIEs
-                                # (``lpsn.py::_make_close_match_edge``). Without it a
-                                # deposit node has no way back to whoever asserted it, and
-                                # a deposit whose claimants disagree — which gets no
-                                # subclass_of below — would reach no taxon at all (#894).
-                                knowledge_level, agent_type = self._add_edge_metadata(
-                                    CLOSE_MATCH_PREDICATE, CLOSE_MATCH_RELATION, strain_curie
-                                )
-                                edge_writer.writerow(
-                                    [
-                                        organism_id,
-                                        CLOSE_MATCH_PREDICATE,
-                                        strain_curie,
-                                        CLOSE_MATCH_RELATION,
-                                        self.knowledge_source,
-                                        knowledge_level,
-                                        agent_type,
-                                    ]
-                                )
+                                # Buffer the record -> deposit link, mirroring the edge
+                                # LPSN emits onto these same CURIEs
+                                # (``lpsn.py::_make_close_match_edge``). It cannot be
+                                # written yet: ``biolink:close_match`` is symmetric and
+                                # maps to ``SEMMEDDB:same_as``, so on a deposit whose
+                                # claimants turn out to be unrelated organisms it would
+                                # assert an equivalence between them (#899).
+                                deposit_citations.append((organism_id, strain_curie))
                                 # Record this record's claim about the deposit's parent
                                 # taxon. The edge itself is written after the loop, once
                                 # every record that cites this deposit has been seen (#892).
@@ -3430,6 +3423,34 @@ class BacDiveTransform(Transform):
                     ancestors_of=self._ncbitaxon_ancestors,
                     ancestry_failed=self._ncbitaxon_ancestry_failures.__contains__,
                 )
+                # A deposit whose claimants are taxonomically disjoint is a designation
+                # two unrelated organisms happen to share, not one identifier. Linking a
+                # record to it with a symmetric, same_as-mapped predicate would put those
+                # organisms two hops apart over close_match, so the citation is recorded
+                # in the claims report instead of asserted in the graph (#899).
+                unsafe_deposits = {
+                    curie
+                    for curie, _, resolution, _ in contested_deposits
+                    if not resolution_asserts_a_parent(resolution)
+                }
+                for organism_curie, strain_curie in deposit_citations:
+                    if strain_curie in unsafe_deposits:
+                        continue
+                    knowledge_level, agent_type = self._add_edge_metadata(
+                        CLOSE_MATCH_PREDICATE, CLOSE_MATCH_RELATION, strain_curie
+                    )
+                    edge_writer.writerow(
+                        [
+                            organism_curie,
+                            CLOSE_MATCH_PREDICATE,
+                            strain_curie,
+                            CLOSE_MATCH_RELATION,
+                            self.knowledge_source,
+                            knowledge_level,
+                            agent_type,
+                        ]
+                    )
+
                 for strain_curie, deposit_parent_id in resolved_deposits:
                     knowledge_level, agent_type = self._add_edge_metadata(
                         SUBCLASS_PREDICATE, RDFS_SUBCLASS_OF, deposit_parent_id

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -28,6 +28,7 @@ from kg_microbe.transform_utils.bacdive.emission import (
     RESOLUTION_COLLAPSED,
     RESOLUTION_SUPPRESSED,
     RESOLUTION_SUPPRESSED_NO_ANCESTRY,
+    contested_deposit_description,
     deposit_conflict_rows,
     resolution_asserts_a_parent,
     resolve_deposit_parents,
@@ -1695,6 +1696,8 @@ class BacDiveTransform(Transform):
         # whether the link is safe to assert depends on what the other records citing
         # that deposit turn out to say (#899).
         deposit_citations: List[tuple] = []
+        # Deposit CURIE -> the label first seen for it, written after resolution (#907).
+        deposit_labels: Dict[str, str] = {}
 
         COLUMN_NAMES = [
             BACDIVE_ID_COLUMN,
@@ -2763,7 +2766,10 @@ class BacDiveTransform(Transform):
                             )
                             strain_label = culture_number.strip() if len(culture_number_cleaned) > 3 else None
                             if strain_curie and strain_label:
-                                node_writer.writerow(self._create_node_row(strain_curie, NCBI_CATEGORY, strain_label))
+                                # The node is buffered too: whether it needs a description
+                                # saying its claimants disagreed is not knowable until every
+                                # record citing it has been read (#907).
+                                deposit_labels.setdefault(strain_curie, strain_label)
                                 # Buffer the record -> deposit link, mirroring the edge
                                 # LPSN emits onto these same CURIEs
                                 # (``lpsn.py::_make_close_match_edge``). It cannot be
@@ -3428,11 +3434,26 @@ class BacDiveTransform(Transform):
                 # record to it with a symmetric, same_as-mapped predicate would put those
                 # organisms two hops apart over close_match, so the citation is recorded
                 # in the claims report instead of asserted in the graph (#899).
+                contested_claims = {curie: parents for curie, parents, _, _ in contested_deposits}
                 unsafe_deposits = {
                     curie
                     for curie, _, resolution, _ in contested_deposits
                     if not resolution_asserts_a_parent(resolution)
                 }
+                for strain_curie, strain_label in deposit_labels.items():
+                    node_writer.writerow(
+                        self._create_node_row(
+                            strain_curie,
+                            NCBI_CATEGORY,
+                            strain_label,
+                            description=(
+                                contested_deposit_description(contested_claims[strain_curie])
+                                if strain_curie in unsafe_deposits
+                                else None
+                            ),
+                        )
+                    )
+
                 for organism_curie, strain_curie in deposit_citations:
                     if strain_curie in unsafe_deposits:
                         continue

--- a/kg_microbe/transform_utils/bacdive/emission.py
+++ b/kg_microbe/transform_utils/bacdive/emission.py
@@ -50,6 +50,23 @@ RESOLUTION_SUPPRESSED = "suppressed"
 RESOLUTION_SUPPRESSED_NO_ANCESTRY = "suppressed_ancestry_unavailable"
 
 
+def resolution_asserts_a_parent(resolution):
+    """
+    Report whether a resolution left the deposit with a parent taxon.
+
+    Used to decide whether a record may be linked to the deposit at all. A
+    deposit that got a parent is one identifier its claimants agree about, so
+    linking to it is sound. One that got none is a designation two unrelated
+    organisms happen to share, and ``biolink:close_match`` -- symmetric, and
+    mapped to ``SEMMEDDB:same_as`` -- would put those organisms two hops apart
+    (#899).
+
+    :param resolution: One of the ``RESOLUTION_*`` values.
+    :return: True when a parent was asserted.
+    """
+    return resolution == RESOLUTION_COLLAPSED
+
+
 def entailed_by_every_claim(parents, ancestors_of):
     """
     Return the one claimed taxon that every other claim entails, or None.

--- a/kg_microbe/transform_utils/bacdive/emission.py
+++ b/kg_microbe/transform_utils/bacdive/emission.py
@@ -60,14 +60,20 @@ def contested_deposit_description(parents):
     The description says which taxa were claimed so the emptiness reads as a
     decision.
 
+    Scoped to BacDive on purpose: 55 of these deposits are the object of an LPSN
+    ``close_match`` edge, so a sentence claiming nothing links to the node would
+    be false in the merged graph (#908). This transform cannot see LPSN's output
+    and should not try to -- it states only what it did itself.
+
     :param parents: ``{NCBITaxon CURIE: [BacDive record key, ...]}`` for the deposit.
     :return: One-sentence description naming the conflicting claims.
     """
     claims = ", ".join(f"{taxon} (BacDive {', '.join(sorted(keys))})" for taxon, keys in sorted(parents.items()))
     return (
         "Culture-collection designation claimed by BacDive records that disagree on "
-        f"the organism: {claims}. No parent taxon or record link is asserted because "
-        "the designation does not identify a single organism."
+        f"the organism: {claims}. BacDive asserts no parent taxon and no record link "
+        "for it, because the designation does not identify a single organism. Other "
+        "sources may still reference this node."
     )
 
 

--- a/kg_microbe/transform_utils/bacdive/emission.py
+++ b/kg_microbe/transform_utils/bacdive/emission.py
@@ -50,6 +50,27 @@ RESOLUTION_SUPPRESSED = "suppressed"
 RESOLUTION_SUPPRESSED_NO_ANCESTRY = "suppressed_ancestry_unavailable"
 
 
+def contested_deposit_description(parents):
+    """
+    Explain, on the node itself, why a contested deposit has no edges (#907).
+
+    A deposit whose claimants disagreed gets neither a parent nor a link to the
+    records that cited it, which leaves an organism-typed node with a culture
+    number for a label and nothing else -- indistinguishable from an ingest gap.
+    The description says which taxa were claimed so the emptiness reads as a
+    decision.
+
+    :param parents: ``{NCBITaxon CURIE: [BacDive record key, ...]}`` for the deposit.
+    :return: One-sentence description naming the conflicting claims.
+    """
+    claims = ", ".join(f"{taxon} (BacDive {', '.join(sorted(keys))})" for taxon, keys in sorted(parents.items()))
+    return (
+        "Culture-collection designation claimed by BacDive records that disagree on "
+        f"the organism: {claims}. No parent taxon or record link is asserted because "
+        "the designation does not identify a single organism."
+    )
+
+
 def resolution_asserts_a_parent(resolution):
     """
     Report whether a resolution left the deposit with a parent taxon.

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -425,6 +425,9 @@ def test_a_contested_deposit_node_explains_its_own_emptiness():
     assert "NCBITaxon:1122236 (BacDive 7239)" in text
     assert "NCBITaxon:398036 (BacDive 134230)" in text
     assert "does not identify a single organism" in text
+    # Scoped to BacDive: 55 of these nodes do carry an LPSN close_match (#908).
+    assert "BacDive asserts no parent taxon and no record link" in text
+    assert "Other sources may still reference this node." in text
 
 
 def test_the_description_is_deterministic():

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -408,3 +408,49 @@ def test_close_match_is_emitted_after_resolution_not_during_the_loop():
     loop_block = source.split("if culture_number_from_external_links:")[1].split("if phys_and_metabolism_enzymes:")[0]
     assert "deposit_citations.append" in loop_block
     assert "CLOSE_MATCH_PREDICATE" not in loop_block, "citation must not be asserted inline"
+
+
+def test_a_contested_deposit_node_explains_its_own_emptiness():
+    """
+    An edgeless node must not look like an ingest gap (#907).
+
+    A contested deposit gets no parent and no record link, which leaves an
+    organism-typed node carrying a culture number and nothing else. Without a
+    description it is indistinguishable from a term the transform failed to
+    process, which is the failure mode it is the fix for.
+    """
+    from kg_microbe.transform_utils.bacdive.emission import contested_deposit_description
+
+    text = contested_deposit_description({"NCBITaxon:1122236": ["7239"], "NCBITaxon:398036": ["134230"]})
+    assert "NCBITaxon:1122236 (BacDive 7239)" in text
+    assert "NCBITaxon:398036 (BacDive 134230)" in text
+    assert "does not identify a single organism" in text
+
+
+def test_the_description_is_deterministic():
+    """Node rows must not change between runs on dict ordering alone."""
+    from kg_microbe.transform_utils.bacdive.emission import contested_deposit_description
+
+    a = contested_deposit_description({"NCBITaxon:2": ["9", "1"], "NCBITaxon:1": ["5"]})
+    b = contested_deposit_description({"NCBITaxon:1": ["5"], "NCBITaxon:2": ["1", "9"]})
+    assert a == b
+    assert a.index("NCBITaxon:1") < a.index("NCBITaxon:2")
+
+
+def test_only_contested_deposits_carry_a_description():
+    """
+    The 151,575 uncontested deposits must stay as they were.
+
+    A description on every deposit would bury the 437 that mean something.
+    """
+    import inspect
+    from pathlib import Path
+
+    from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
+
+    source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
+    block = source.split("for strain_curie, strain_label in deposit_labels.items():")[1].split(
+        "for organism_curie, strain_curie in deposit_citations:"
+    )[0]
+    assert "if strain_curie in unsafe_deposits" in block
+    assert "else None" in block

--- a/tests/test_bacdive_deposit_parents.py
+++ b/tests/test_bacdive_deposit_parents.py
@@ -189,13 +189,16 @@ def test_without_ancestry_any_disagreement_is_a_conflict():
     assert len(conflicts) == 1
 
 
-def test_the_record_is_linked_to_every_deposit_it_cites():
+def test_the_record_is_linked_to_the_deposits_it_safely_cites():
     """
     A deposit node must reach back to whoever asserted it (#894).
 
     Without this edge a `kgmicrobe.strain:<deposit>` node has one outgoing
-    `subclass_of` and nothing else, so a deposit whose claimants disagree —
-    which gets no `subclass_of` at all — would reach no taxon by any path.
+    `subclass_of` and nothing else, so a deposit whose claimants agree would
+    still have no provenance. The link is written after resolution rather than
+    inline, because whether it is safe to assert depends on records not yet read
+    (#899) — that ordering is pinned by
+    `test_close_match_is_emitted_after_resolution_not_during_the_loop`.
 
     Inspected rather than run: `BacDiveTransform.run` needs the NCBITaxon
     adapter, which makes an end-to-end unit test impractical (see the module
@@ -207,13 +210,16 @@ def test_the_record_is_linked_to_every_deposit_it_cites():
     from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
 
     source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
-    block = source.split("if culture_number_from_external_links:")[1].split("if phys_and_metabolism_enzymes:")[0]
+    block = source.split("for organism_curie, strain_curie in deposit_citations:")[1].split(
+        "for strain_curie, deposit_parent_id in resolved_deposits:"
+    )[0]
+    assert "CLOSE_MATCH_PREDICATE" in block
     assert "CLOSE_MATCH_RELATION" in block
     # Subject is the record node and object the deposit node, not the reverse —
     # the record is the thing making the assertion.
     row = block.split("edge_writer.writerow(")[1].split("]")[0]
     assert [line.strip().rstrip(",") for line in row.splitlines() if line.strip() and "[" not in line][:3] == [
-        "organism_id",
+        "organism_curie",
         "CLOSE_MATCH_PREDICATE",
         "strain_curie",
     ]
@@ -351,3 +357,54 @@ def test_the_report_is_not_described_as_edgeless():
     constants = Path("kg_microbe/transform_utils/constants.py").read_text()
     stanza = constants.split("BACDIVE_DEPOSIT_CLAIMS_FILE")[0].rsplit("\n\n", 1)[-1]
     assert "collapsed" in stanza and "suppressed" in stanza
+
+
+def test_a_deposit_that_kept_its_parent_is_safe_to_link():
+    """Claimants that agree describe one deposit; linking to it asserts nothing false."""
+    from kg_microbe.transform_utils.bacdive.emission import resolution_asserts_a_parent
+
+    assert resolution_asserts_a_parent(RESOLUTION_COLLAPSED) is True
+
+
+def test_a_deposit_with_disjoint_claims_is_not_safe_to_link():
+    """
+    `close_match` is symmetric and maps to `SEMMEDDB:same_as` (#899).
+
+    `kgmicrobe.strain:AS-1` is claimed by BacDive 7239 (*Methylophilus
+    methylotrophus*) and 134230 (*Alteromonas simiduii*) — one in-house
+    designation two labs reused. Linking both records to it puts two unrelated
+    organisms two hops apart over a predicate consumers read as identity.
+    """
+    from kg_microbe.transform_utils.bacdive.emission import resolution_asserts_a_parent
+
+    assert resolution_asserts_a_parent(RESOLUTION_SUPPRESSED) is False
+
+
+def test_an_unverifiable_deposit_is_not_linked_either():
+    """
+    Not asserting beats asserting what could not be checked (#897, #899).
+
+    When ancestry is unreadable the claims cannot be compared, so the deposit may
+    or may not be a collision. The claims report records which it was.
+    """
+    from kg_microbe.transform_utils.bacdive.emission import resolution_asserts_a_parent
+
+    assert resolution_asserts_a_parent(RESOLUTION_SUPPRESSED_NO_ANCESTRY) is False
+
+
+def test_close_match_is_emitted_after_resolution_not_during_the_loop():
+    """
+    Whether a citation is safe depends on records not yet read (#899).
+
+    Emitting inline is what shipped the false equivalences: the edge was written
+    before the deposit's other claimants had been seen.
+    """
+    import inspect
+    from pathlib import Path
+
+    from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
+
+    source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
+    loop_block = source.split("if culture_number_from_external_links:")[1].split("if phys_and_metabolism_enzymes:")[0]
+    assert "deposit_citations.append" in loop_block
+    assert "CLOSE_MATCH_PREDICATE" not in loop_block, "citation must not be asserted inline"


### PR DESCRIPTION
Closes #899

## The problem

#894 added `kgmicrobe.strain:bacdive_<id> --biolink:close_match--> kgmicrobe.strain:<deposit>` for every deposit a record cites. In Biolink 4.4.2 `close match` is `symmetric: true` with `exact_mappings: [skos:closeMatch, SEMMEDDB:same_as]`, so where two unrelated organisms happen to bear the same in-house designation, the graph now asserts a path between them over a predicate consumers read as identity.

| deposit | record | taxon |
|---|---|---|
| `AS-1` | BacDive 7239 | NCBITaxon:1122236 *Methylophilus methylotrophus* |
| | BacDive 134230 | NCBITaxon:398036 *Alteromonas simiduii* |
| `Agre-8` | BacDive 100025 | NCBITaxon:1612 *Lactobacillus farciminis* |
| | BacDive 104641 | NCBITaxon:35761 *Nocardioides* sp. |

Before #894 that collision was an artifact of a shared node. #894 turned it into an assertion.

## Why the allowlist in #899 is the wrong tool

#899 proposed restricting minting to recognised culture-collection acronyms, mirroring LPSN's `_CULTURE_CODE`. I built one — derived from the dump by acronym frequency, ≥50 deposits, 107 acronyms covering 96.9% of tokens — and then deleted it, because it admits exactly the tokens the issue is about:

| acronym | in a frequency allowlist | deposits |
|---|---|---|
| `AS` | **yes** | 150 |
| `AJ` | **yes** | 62 |
| `CN` | **yes** | 54 |
| `ATCC` | yes | 7,720 |

This is consistent with the measurement in #892: **494 of the 525 known collisions already carry an acronym any such list would accept.** Frequency measures how often a prefix appears across records, not whether it scopes an identifier — and a prefix reused by many labs is frequent *because* it is unscoped.

A curated registry list would be better than a derived one, but it still could not separate `AS 1` at Academia Sinica from `AS 1` in someone's freezer, and it would need maintaining against a registry we do not vendor.

## What this does instead

Use evidence we already compute. #892's resolution says, per deposit, whether its claiming records are taxonomically disjoint:

- **kept a parent** (agreed outright, or collapsed to the ancestor every claimant entails) → one identifier its claimants agree about → link it.
- **kept no parent** (disjoint claims) → a designation unrelated organisms share → link nothing; the citation goes to `bacdive_strain_deposit_claims.tsv`, which is where #892 already puts what it declines to assert.
- **ancestry unreadable** (#897) → same treatment. Not asserting beats asserting what was never checked.

Citations are buffered and emitted after resolution. Emitting inline is what shipped the problem: the edge was written before the deposit's other claimants had been read.

## Effect, replayed over the real 99,392-record dump

```
deposit citations total:              152,900
  close_match emitted:                152,009
  withheld (unsafe deposits):             891   over 437 deposits
  records touched by a withheld link:     685
contested resolutions: 437 suppressed, 78 collapsed
```

Every demonstrable false equivalence is removed; nothing else changes.

## Also verified

Changing how these deposits are treated breaks no cross-source link. 48,132 deposit CURIEs are shared between the BacDive and LPSN transforms today — but of the tokens a frequency allowlist would have rejected, **zero** are referenced by LPSN or MediaDive, at every threshold from 10 to 100. Those nodes also have no incoming edges: only 4,677 outgoing `subclass_of`.

## Tests

18 → 22. The four new ones pin the three resolutions against link-safety, and that emission happens after resolution rather than inside the record loop — the ordering that caused this. The #894 test was rewritten rather than deleted: it still requires the link, now at its new site, and still pins subject/object orientation.

`tox` green apart from the pre-existing `test_ontologies_stubs` failure that also fails on master.