### PR TITLE
fix: pin every METPO artifact to one release, and keep them there (#900, #912)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,14 @@ KGX/BMT must use the pinned local Biolink files downloaded to
 Biolink version requires changing `download.yaml`, the lock file, fixtures, and
 tests together.
 
+METPO is pinned the same way. `METPO_VERSION` in `transform_utils/constants.py`
+is the single source of truth, and the ontology (`metpo.owl`, `metpo.json`) and
+the two ROBOT templates built from it must all move to the same tag together.
+Never fetch METPO from `refs/heads/main`: an upstream obsoletion then arrives
+with a download and changes nothing observable, which is how a deprecated
+predicate reached 706,765 shipped edges. `tests/test_metpo_version_pin.py`
+enforces this against `download.yaml`. See issues #900 and #909.
+
 ## Operational references
 
 - [Data hosting and ontology build costs](docs/DATA_HOSTING.md)

--- a/download.yaml
+++ b/download.yaml
@@ -351,11 +351,11 @@
 # METPO
 #
 -
-  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/metpo.owl
+  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-06-12/metpo.owl
   local_name: metpo.owl
   tag: ontologies
 -
-  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/heads/main/metpo.json
+  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-06-12/metpo.json
   local_name: metpo.json
   tag: ontologies
 
@@ -600,11 +600,11 @@
 
 # Immutable METPO templates consumed by multiple trait transforms
 -
-  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-03-24/src/templates/metpo_sheet.tsv
+  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-06-12/src/templates/metpo_sheet.tsv
   local_name: metpo_sheet.tsv
   tag: mappings
 -
-  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-03-24/src/templates/metpo-properties.tsv
+  url: https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-06-12/src/templates/metpo-properties.tsv
   local_name: metpo-properties.tsv
   tag: mappings
 

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -776,6 +776,19 @@ UNIPROT_DATA_LIST = [
 ]
 
 BACDIVE_MAPPING_FILE = "bacdive_mappings.tsv"
+
+# The METPO release every METPO artifact in this repo is pinned to: the ontology
+# (metpo.owl / metpo.json) and the two ROBOT templates built from it. They must move
+# together — tracking the ontology from `main` while the templates sat on an older tag
+# is how an obsoleted predicate reached 706,765 shipped edges unnoticed (#900, #909).
+# `download.yaml` repeats these URLs and cannot import them; a test asserts they agree.
+METPO_VERSION = "2026-06-12"
+_METPO_RAW = f"https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/{METPO_VERSION}"
+METPO_OWL_URL = f"{_METPO_RAW}/metpo.owl"
+METPO_JSON_URL = f"{_METPO_RAW}/metpo.json"
+METPO_CLASSES_ROBOT_TEMPLATE_URL = f"{_METPO_RAW}/src/templates/metpo_sheet.tsv"
+METPO_PROPERTIES_ROBOT_TEMPLATE_URL = f"{_METPO_RAW}/src/templates/metpo-properties.tsv"
+
 # Report of every culture-collection deposit number claimed by more than one
 # BacDive record with a different parent taxon, and what became of it: `collapsed`
 # rows were given the ancestor every claimant entails, `suppressed` rows were given

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -25,13 +25,13 @@ LOCAL_METPO_ALIAS_OVERRIDES_PATH = (
     Path(__file__).resolve().parents[2] / "mappings" / "canonical" / "metpo_alias_mappings.tsv"
 )
 
-# remote URL location in metpo GitHub repository for METPO classes and properties
-# sheets/ROBOT templates respectively, which will be used as the source of METPO mappings
-METPO_CLASSES_ROBOT_TEMPLATE_URL = (
-    "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-03-24/src/templates/metpo_sheet.tsv"
-)
-METPO_PROPERTIES_ROBOT_TEMPLATE_URL = (
-    "https://raw.githubusercontent.com/berkeleybop/metpo/refs/tags/2026-03-24/src/templates/metpo-properties.tsv"
+# Remote location of the METPO classes and properties ROBOT templates, the source of
+# METPO mappings. Re-exported from constants so the version lives in exactly one place:
+# this module used to carry its own copy of the tag, which then drifted three releases
+# behind the ontology (#900).
+from kg_microbe.transform_utils.constants import (  # noqa: E402
+    METPO_CLASSES_ROBOT_TEMPLATE_URL,
+    METPO_PROPERTIES_ROBOT_TEMPLATE_URL,
 )
 
 

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -10,7 +10,12 @@ from typing import Dict, List, Optional
 import curies
 import requests
 
-from kg_microbe.transform_utils.constants import PREFIXMAP_JSON_FILEPATH, RAW_DATA_DIR
+from kg_microbe.transform_utils.constants import (
+    METPO_CLASSES_ROBOT_TEMPLATE_URL,
+    METPO_PROPERTIES_ROBOT_TEMPLATE_URL,
+    PREFIXMAP_JSON_FILEPATH,
+    RAW_DATA_DIR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +30,10 @@ LOCAL_METPO_ALIAS_OVERRIDES_PATH = (
     Path(__file__).resolve().parents[2] / "mappings" / "canonical" / "metpo_alias_mappings.tsv"
 )
 
-# Remote location of the METPO classes and properties ROBOT templates, the source of
-# METPO mappings. Re-exported from constants so the version lives in exactly one place:
-# this module used to carry its own copy of the tag, which then drifted three releases
-# behind the ontology (#900).
-from kg_microbe.transform_utils.constants import (  # noqa: E402
-    METPO_CLASSES_ROBOT_TEMPLATE_URL,
-    METPO_PROPERTIES_ROBOT_TEMPLATE_URL,
-)
+# METPO_CLASSES_ROBOT_TEMPLATE_URL and METPO_PROPERTIES_ROBOT_TEMPLATE_URL are
+# imported from constants above rather than spelled out here: this module used to
+# carry its own copy of the tag, which then drifted three releases behind the
+# ontology (#900).
 
 
 class _LocalTemplateResponse:

--- a/tests/test_metpo_version_pin.py
+++ b/tests/test_metpo_version_pin.py
@@ -1,0 +1,70 @@
+"""Every METPO artifact must be pinned, and pinned to the same release (#900)."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+from kg_microbe.transform_utils.constants import (
+    METPO_CLASSES_ROBOT_TEMPLATE_URL,
+    METPO_JSON_URL,
+    METPO_OWL_URL,
+    METPO_PROPERTIES_ROBOT_TEMPLATE_URL,
+    METPO_VERSION,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOWNLOAD_YAML = REPO_ROOT / "download.yaml"
+
+
+def _metpo_urls():
+    """
+    Every berkeleybop/metpo URL in download.yaml.
+
+    :return: List of URL strings.
+    """
+    entries = yaml.safe_load(DOWNLOAD_YAML.read_text(encoding="utf-8"))
+    return [e["url"] for e in entries if isinstance(e, dict) and "berkeleybop/metpo" in str(e.get("url", ""))]
+
+
+def test_download_yaml_pins_every_metpo_artifact_to_a_tag():
+    """
+    An unpinned fetch changes what the pipeline sees with no record that it did.
+
+    `metpo.owl` and `metpo.json` were pulled from `refs/heads/main`, so an upstream
+    obsoletion arrived with a download and altered nothing observable — which is how
+    706,765 edges came to use a deprecated predicate (#909).
+    """
+    urls = _metpo_urls()
+    assert urls, "download.yaml no longer fetches METPO; this guard needs rewriting"
+    unpinned = [u for u in urls if "refs/tags/" not in u]
+    assert not unpinned, f"METPO must be fetched from a tag, not a branch: {unpinned}"
+
+
+def test_every_metpo_artifact_is_pinned_to_the_same_release():
+    """
+    The ontology and the templates built from it must move together.
+
+    They drifted three releases apart — the ontology tracking `main` while the
+    templates sat on `2026-03-24` — and the mismatch is what hid #909.
+    """
+    tags = {re.search(r"refs/tags/([^/]+)/", u).group(1) for u in _metpo_urls()}
+    assert tags == {METPO_VERSION}, f"download.yaml pins {sorted(tags)}, constants says {METPO_VERSION}"
+
+
+def test_the_code_and_download_yaml_agree_on_the_version():
+    """
+    `download.yaml` cannot import the constant, so the two are checked against each other.
+
+    `mapping_file_utils` used to carry its own copy of the tag, which is how one of
+    them fell behind without the other noticing.
+    """
+    urls = set(_metpo_urls())
+    for url in (METPO_OWL_URL, METPO_JSON_URL, METPO_CLASSES_ROBOT_TEMPLATE_URL, METPO_PROPERTIES_ROBOT_TEMPLATE_URL):
+        assert url in urls, f"{url} is used by the code but not fetched by download.yaml"
+
+
+def test_mapping_file_utils_does_not_keep_its_own_copy_of_the_pin():
+    """One version, one place. A second literal is what drifted last time."""
+    source = (REPO_ROOT / "kg_microbe" / "utils" / "mapping_file_utils.py").read_text(encoding="utf-8")
+    assert "raw.githubusercontent.com/berkeleybop/metpo" not in source


### PR DESCRIPTION
Closes #900

## The problem

`download.yaml` fetched METPO two different ways:

```yaml
  url: .../berkeleybop/metpo/refs/heads/main/metpo.owl        # unpinned
  url: .../berkeleybop/metpo/refs/heads/main/metpo.json       # unpinned
  url: .../refs/tags/2026-03-24/src/templates/metpo_sheet.tsv       # three releases old
  url: .../refs/tags/2026-03-24/src/templates/metpo-properties.tsv  # three releases old
```

The ontology and the templates it is built from could drift arbitrarily far apart, and which pairing a run got depended on when `kg download` happened to fire.

**They had drifted, and it cost something concrete.** This is how `METPO:2000511` came to carry **706,765 shipped edges** after upstream obsoleted it — filed separately as #909. The obsoletion arrived with a download and changed nothing observable: the constant is hardcoded, the Biolink mapping is hardcoded, and nothing compares emitted predicates against the ontology.

## The fix

All four artifacts pin to `2026-06-12`, the current release.

**Verified safe before moving.** Every id the templates lose on the way from `2026-03-24` is already deprecated upstream:

| template | rows | dropped | of which deprecated upstream | still live |
|---|---|---|---|---|
| `metpo-properties.tsv` | 138 → 115 | 27 | **27** | 0 |
| `metpo_sheet.tsv` | 282 → 292 | 21 | **21** | 0 |

So the move drops only obsolete terms. It also picks up four properties we should already have had — `METPO:2000064 tolerates`, `METPO:2000065 does not tolerate`, `METPO:2000067 isolated from host with quality`, `METPO:2000068 isolated from environment with quality` — our own proposed terms, adopted upstream after the old pin was set and invisible to us since.

`metpo.owl` at the tag has an identical id set to `main` (1,620 either way; 202 lines of content drift), so pinning the ontology loses no terms.

## One version, one place

`kg_microbe/utils/mapping_file_utils.py` kept its own copy of the tag in two hardcoded URLs — which is how one of them fell three releases behind without the other noticing. Both now derive from `METPO_VERSION` in `transform_utils/constants.py`.

`tests/test_metpo_version_pin.py` (4 tests) makes the drift impossible to reintroduce quietly:

- no METPO URL in `download.yaml` points at a branch;
- every METPO URL carries the same tag, and it is `METPO_VERSION`;
- every URL the code uses is one `download.yaml` actually fetches — `download.yaml` cannot import the constant, so the two are checked against each other;
- `mapping_file_utils` contains no `raw.githubusercontent.com/berkeleybop/metpo` literal.

## Canary

All four pinned URLs resolve (200, expected sizes), and the pinned `metpo.json` run through `_load_metpo_binned_ranges` yields exactly the same 15 binned optimum classes (7 temperature, 4 pH, 4 NaCl) as the current cache — so the MetaTraits loader is unaffected by the 1,216 deprecated terms that arrive with the newer release. Done against a scratch copy; `data/raw` was not touched.

## Not fixed here

#909 — the 706,765 edges on the obsoleted predicate. That needs a decision about which live property replaces `has observation`, and upstream declared no successor (`IAO:0000226`, no `IAO:0100001`), so it is not a mechanical migration.

`tox` green apart from the pre-existing `test_ontologies_stubs` failure that also fails on master.