### PR TITLE
feat(merge): check the strain-parent invariant where sources actually meet (#896, #914, #915, #916)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,12 @@ the claims report, and the node carries a description saying so. See issues
 - Cache existence must imply completeness. Use `atomic_write` from
   `kg_microbe.utils.atomic_io`, including completion markers where the helper
   requires them; never publish a partially written cache path.
+- The merge checks invariants that no single transform can. A transform only
+  polices the edges it writes, and `kgmicrobe.strain:*` is minted by several
+  sources, so `merge_utils/invariants.py` re-checks after the merge and writes
+  `merged_strain_parent_violations.tsv` beside the merged TSVs — empty on a
+  clean run, because an absent report cannot be told from a check that never
+  ran. See issues #892 and #896.
 - Ontology acquisition or adapter failures abort the run. Do not catch them as
   per-row lookup failures, and construct/resolve adapters in the parent process
   before creating a `Pool`; adapters are large and generally not picklable.

--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -1,0 +1,139 @@
+"""
+Invariants checked against the merged graph, where sources actually meet.
+
+Each transform can only police the edges it writes itself. ``kgmicrobe.strain:*``
+is a deliberately shared namespace -- LPSN mints the same CURIEs BacDive does so
+the merge reconciles them -- so a rule about those nodes is only really enforced
+after the merge. #892 fixed multi-parent strains inside the BacDive transform;
+this module is the check that notices if another source reintroduces them (#896).
+"""
+
+import csv
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from kg_microbe.transform_utils.constants import (
+    NCBITAXON_PREFIX,
+    OBJECT_COLUMN,
+    PREDICATE_COLUMN,
+    PRIMARY_KNOWLEDGE_SOURCE_COLUMN,
+    STRAIN_PREFIX,
+    SUBCLASS_PREDICATE,
+    SUBJECT_COLUMN,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Written beside merged-kg_nodes.tsv / merged-kg_edges.tsv.
+STRAIN_PARENT_REPORT = "merged_strain_parent_violations.tsv"
+
+STRAIN_PARENT_REPORT_HEADER = ["strain_id", "parent_count", "parents", "knowledge_sources"]
+
+
+def find_multi_parent_strains(
+    edges_file: Path,
+) -> Dict[str, Tuple[Set[str], Set[str]]]:
+    """
+    Return strain nodes carrying more than one NCBITaxon parent in the merged graph.
+
+    Streams the edge file rather than loading it: the merged graph is tens of
+    millions of rows, and only the strain rows are retained.
+
+    :param edges_file: Path to ``merged-kg_edges.tsv``.
+    :return: ``{strain CURIE: (parent CURIEs, knowledge sources)}`` for every strain
+        with more than one distinct parent. Empty when the invariant holds.
+    """
+    parents: Dict[str, Set[str]] = defaultdict(set)
+    sources: Dict[str, Set[str]] = defaultdict(set)
+    with edges_file.open(encoding="utf-8", errors="replace", newline="") as handle:
+        reader = csv.reader(handle, delimiter="\t")
+        try:
+            header = next(reader)
+        except StopIteration:
+            return {}
+        index = {name: i for i, name in enumerate(header)}
+        needed = (SUBJECT_COLUMN, PREDICATE_COLUMN, OBJECT_COLUMN)
+        if any(column not in index for column in needed):
+            logger.warning(
+                "[merge-invariants] %s lacks %s; skipping the strain-parent check",
+                edges_file.name,
+                [c for c in needed if c not in index],
+            )
+            return {}
+        subject_at, predicate_at, object_at = (index[c] for c in needed)
+        source_at = index.get(PRIMARY_KNOWLEDGE_SOURCE_COLUMN)
+        for row in reader:
+            if len(row) <= object_at:
+                continue
+            if row[predicate_at] != SUBCLASS_PREDICATE:
+                continue
+            subject, obj = row[subject_at], row[object_at]
+            if not subject.startswith(STRAIN_PREFIX) or not obj.startswith(NCBITAXON_PREFIX):
+                continue
+            parents[subject].add(obj)
+            if source_at is not None and len(row) > source_at and row[source_at]:
+                sources[subject].add(row[source_at])
+    return {s: (p, sources.get(s, set())) for s, p in parents.items() if len(p) > 1}
+
+
+def strain_parent_rows(violations: Dict[str, Tuple[Set[str], Set[str]]]) -> List[List]:
+    """
+    Render violations as report rows, sorted so a diff between runs is readable.
+
+    :param violations: Result of :func:`find_multi_parent_strains`.
+    :return: Rows matching :data:`STRAIN_PARENT_REPORT_HEADER`.
+    """
+    return [
+        [strain, len(parents), "|".join(sorted(parents)), "|".join(sorted(sources))]
+        for strain, (parents, sources) in sorted(violations.items())
+    ]
+
+
+def check_merged_invariants(edges_file: Path, output_dir: Optional[Path] = None) -> int:
+    """
+    Run the merged-graph invariants and write their report.
+
+    The report is written whether or not anything was found: an absent file would
+    be indistinguishable from a clean run, and a clean run is the thing worth
+    being able to demonstrate.
+
+    :param edges_file: Path to ``merged-kg_edges.tsv``.
+    :param output_dir: Where to write the report; defaults to the edge file's directory.
+    :return: Number of violating strain nodes.
+    """
+    from kg_microbe.utils.atomic_io import atomic_write
+
+    violations = find_multi_parent_strains(edges_file)
+    destination = Path(output_dir or edges_file.parent) / STRAIN_PARENT_REPORT
+    with atomic_write(destination, newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(STRAIN_PARENT_REPORT_HEADER)
+        writer.writerows(strain_parent_rows(violations))
+    if violations:
+        offenders = _sources_of(violations)
+        logger.warning(
+            "[merge-invariants] %s strain nodes carry more than one NCBITaxon parent "
+            "(sources: %s); listed in %s. A consumer taking 'the' parent gets one "
+            "decided by file order (#892, #896).",
+            f"{len(violations):,}",
+            ", ".join(offenders) or "unattributed",
+            destination,
+        )
+    else:
+        logger.info("[merge-invariants] no strain node carries more than one NCBITaxon parent")
+    return len(violations)
+
+
+def _sources_of(violations: Dict[str, Tuple[Set[str], Set[str]]]) -> List[str]:
+    """
+    Name the knowledge sources implicated, so the report says who to go and fix.
+
+    :param violations: Result of :func:`find_multi_parent_strains`.
+    :return: Sorted knowledge-source strings.
+    """
+    seen: Set[str] = set()
+    for _, sources in violations.values():
+        seen |= sources
+    return sorted(seen)

--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -23,6 +23,7 @@ from kg_microbe.transform_utils.constants import (
     SUBCLASS_PREDICATE,
     SUBJECT_COLUMN,
 )
+from kg_microbe.utils.atomic_io import atomic_write
 
 logger = logging.getLogger(__name__)
 
@@ -110,8 +111,6 @@ def check_merged_invariants(edges_file: Path, output_dir: Optional[Path] = None)
     :param output_dir: Where to write the report; defaults to the edge file's directory.
     :return: Number of violating strain nodes.
     """
-    from kg_microbe.utils.atomic_io import atomic_write
-
     violations = find_multi_parent_strains(edges_file)
     destination = Path(output_dir or edges_file.parent) / STRAIN_PARENT_REPORT
     with atomic_write(destination, newline="") as handle:

--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -53,7 +53,14 @@ def find_multi_parent_strains(
             header = next(reader)
         except StopIteration:
             return {}
-        index = {name: i for i, name in enumerate(header)}
+        # First occurrence, matching `merge_kg._first_index`. A merged header can
+        # carry a repeated column name -- KGX takes the column union across sources
+        # -- and a last-wins lookup would read the wrong column, find no strain
+        # subjects, and report a clean graph. Silent, and in the reassuring
+        # direction, which is the worst way for a check like this to fail (#915).
+        index = {}
+        for position, name in enumerate(header):
+            index.setdefault(name, position)
         needed = (SUBJECT_COLUMN, PREDICATE_COLUMN, OBJECT_COLUMN)
         if any(column not in index for column in needed):
             logger.warning(

--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional
 import networkx as nx  # type: ignore
 import yaml
 
+from kg_microbe.merge_utils.invariants import check_merged_invariants
 from kg_microbe.transform_utils.constants import (
     AGENT_TYPE_COLUMN,
     CATEGORY_COLUMN,
@@ -214,6 +215,10 @@ def _cleanup_merged_outputs(yaml_file: str) -> None:
             _normalize_nodes_tsv(nodes_file)
         if edges_file.is_file():
             _normalize_edges_tsv(edges_file)
+            # Checked here rather than in each transform: a transform can only
+            # police the edges it writes, and kgmicrobe.strain is a namespace
+            # several sources mint into (#896).
+            check_merged_invariants(edges_file, output_dir)
 
         if dest.get("compression") == "tar.gz":
             if nodes_file.is_file() and edges_file.is_file():

--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -218,7 +218,17 @@ def _cleanup_merged_outputs(yaml_file: str) -> None:
             # Checked here rather than in each transform: a transform can only
             # police the edges it writes, and kgmicrobe.strain is a namespace
             # several sources mint into (#896).
-            check_merged_invariants(edges_file, output_dir)
+            #
+            # Isolated from the steps around it. `_cleanup_merged_outputs` is
+            # wrapped by a blanket handler in `load_and_merge`, so an exception
+            # raised here would skip `_rewrite_tarball` below and leave the
+            # normalized TSVs beside a stale archive, with the merge still
+            # reporting success. A data-quality report must not be able to
+            # decide whether the artifact ships (#914).
+            try:
+                check_merged_invariants(edges_file, output_dir)
+            except Exception as exc:  # noqa: BLE001
+                print(f"[merge-invariants] check skipped: {exc}")
 
         if dest.get("compression") == "tar.gz":
             if nodes_file.is_file() and edges_file.is_file():

--- a/tests/test_merged_strain_parent_invariant.py
+++ b/tests/test_merged_strain_parent_invariant.py
@@ -137,3 +137,41 @@ def test_an_empty_edge_file_is_survivable(tmp_path):
     path = tmp_path / "merged-kg_edges.tsv"
     path.write_text("", encoding="utf-8")
     assert find_multi_parent_strains(path) == {}
+
+
+def test_a_failing_check_cannot_stop_the_tarball_being_rewritten(monkeypatch, tmp_path):
+    """
+    A data-quality report must not decide whether the artifact ships (#914).
+
+    `_cleanup_merged_outputs` is wrapped by a blanket handler in `load_and_merge`,
+    so an exception raised by the check would skip `_rewrite_tarball` and leave
+    normalized TSVs beside a stale archive while the merge reported success.
+    """
+    import kg_microbe.merge_utils.merge_kg as merge_kg
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated check failure")
+
+    monkeypatch.setattr(merge_kg, "check_merged_invariants", boom)
+
+    rewritten = []
+    monkeypatch.setattr(merge_kg, "_rewrite_tarball", lambda archive, files: rewritten.append(archive))
+    monkeypatch.setattr(merge_kg, "_normalize_nodes_tsv", lambda _p: None)
+    monkeypatch.setattr(merge_kg, "_normalize_edges_tsv", lambda _p: None)
+    monkeypatch.setattr(merge_kg, "_warn_about_stale_siblings", lambda *_a: None)
+
+    (tmp_path / "merged-kg_nodes.tsv").write_text("id\n", encoding="utf-8")
+    (tmp_path / "merged-kg_edges.tsv").write_text("subject\n", encoding="utf-8")
+    config = tmp_path / "merge.yaml"
+    config.write_text(
+        "merged_graph:\n"
+        "  destination:\n"
+        "    merged-kg-tsv:\n"
+        "      format: tsv\n"
+        "      compression: tar.gz\n"
+        f"      filename: {tmp_path / 'merged-kg'}\n",
+        encoding="utf-8",
+    )
+
+    merge_kg._cleanup_merged_outputs(str(config))
+    assert rewritten, "a failing invariant check suppressed the tarball rewrite"

--- a/tests/test_merged_strain_parent_invariant.py
+++ b/tests/test_merged_strain_parent_invariant.py
@@ -175,3 +175,24 @@ def test_a_failing_check_cannot_stop_the_tarball_being_rewritten(monkeypatch, tm
 
     merge_kg._cleanup_merged_outputs(str(config))
     assert rewritten, "a failing invariant check suppressed the tarball rewrite"
+
+
+def test_a_duplicated_column_name_does_not_hide_violations(tmp_path):
+    """
+    A merged header can repeat a column, and last-wins would read the wrong one (#915).
+
+    KGX takes the column union across sources, which is why `merge_kg` has
+    `_first_index`. Resolving last-wins here would find no strain subjects and
+    report a clean graph — silent, and in the reassuring direction.
+    """
+    header = HEADER + ["subject"]
+    path = _edges(
+        tmp_path,
+        [
+            _row("kgmicrobe.strain:ATCC-13722", "NCBITaxon:272240") + ["something-else"],
+            _row("kgmicrobe.strain:ATCC-13722", "NCBITaxon:1915061") + ["something-else"],
+        ],
+        header=header,
+    )
+    found = find_multi_parent_strains(path)
+    assert set(found) == {"kgmicrobe.strain:ATCC-13722"}, "a duplicated header hid a real violation"

--- a/tests/test_merged_strain_parent_invariant.py
+++ b/tests/test_merged_strain_parent_invariant.py
@@ -1,0 +1,139 @@
+"""The merged graph is where a shared namespace can be policed (#896)."""
+
+import csv
+from pathlib import Path
+
+from kg_microbe.merge_utils.invariants import (
+    STRAIN_PARENT_REPORT,
+    STRAIN_PARENT_REPORT_HEADER,
+    check_merged_invariants,
+    find_multi_parent_strains,
+    strain_parent_rows,
+)
+
+HEADER = [
+    "subject",
+    "predicate",
+    "object",
+    "relation",
+    "primary_knowledge_source",
+    "knowledge_level",
+    "agent_type",
+]
+
+
+def _edges(tmp_path: Path, rows, header=HEADER) -> Path:
+    path = tmp_path / "merged-kg_edges.tsv"
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(header)
+        writer.writerows(rows)
+    return path
+
+
+def _row(subject, obj, predicate="biolink:subclass_of", source="infores:bacdive"):
+    return [subject, predicate, obj, "rdfs:subClassOf", source, "observation", "manual_agent"]
+
+
+def test_one_parent_per_strain_is_not_a_violation(tmp_path):
+    """The ordinary case must stay silent, or the report is noise."""
+    path = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-20154", "NCBITaxon:272240")])
+    assert find_multi_parent_strains(path) == {}
+
+
+def test_two_parents_on_one_strain_is_caught(tmp_path):
+    """`ATCC 13722` carried two genera in the 20260815 build; that is the shape."""
+    path = _edges(
+        tmp_path,
+        [
+            _row("kgmicrobe.strain:ATCC-13722", "NCBITaxon:272240"),
+            _row("kgmicrobe.strain:ATCC-13722", "NCBITaxon:1915061"),
+        ],
+    )
+    found = find_multi_parent_strains(path)
+    assert set(found) == {"kgmicrobe.strain:ATCC-13722"}
+    parents, _ = found["kgmicrobe.strain:ATCC-13722"]
+    assert parents == {"NCBITaxon:272240", "NCBITaxon:1915061"}
+
+
+def test_the_same_parent_asserted_twice_is_not_a_violation(tmp_path):
+    """
+    Two sources agreeing is the merge working, not a conflict.
+
+    The rule is about *distinct* parents; counting rows would fire on every
+    strain BacDive and a future source both describe correctly.
+    """
+    path = _edges(
+        tmp_path,
+        [
+            _row("kgmicrobe.strain:DSM-1", "NCBITaxon:5", source="infores:bacdive"),
+            _row("kgmicrobe.strain:DSM-1", "NCBITaxon:5", source="infores:lpsn"),
+        ],
+    )
+    assert find_multi_parent_strains(path) == {}
+
+
+def test_the_report_names_which_sources_to_go_and_fix(tmp_path):
+    """
+    A count alone does not say who reintroduced it.
+
+    The check exists because a *future* source could add a competing parent, so
+    the report has to point at the source rather than just the node.
+    """
+    path = _edges(
+        tmp_path,
+        [
+            _row("kgmicrobe.strain:X-1", "NCBITaxon:1", source="infores:bacdive"),
+            _row("kgmicrobe.strain:X-1", "NCBITaxon:2", source="infores:somewhere-new"),
+        ],
+    )
+    rows = strain_parent_rows(find_multi_parent_strains(path))
+    assert rows == [["kgmicrobe.strain:X-1", 2, "NCBITaxon:1|NCBITaxon:2", "infores:bacdive|infores:somewhere-new"]]
+    assert len(rows[0]) == len(STRAIN_PARENT_REPORT_HEADER)
+
+
+def test_only_subclass_of_to_ncbitaxon_counts(tmp_path):
+    """
+    `close_match` to a deposit and `subclass_of` to an LPSN record are not parents.
+
+    Counting every edge out of a strain node would fire on the record-to-deposit
+    links (#894) and on microbedecoder's strain -> lpsn edges, neither of which
+    is a taxonomic parent.
+    """
+    path = _edges(
+        tmp_path,
+        [
+            _row("kgmicrobe.strain:bacdive_1", "NCBITaxon:5"),
+            _row("kgmicrobe.strain:bacdive_1", "kgmicrobe.strain:ATCC-1", predicate="biolink:close_match"),
+            _row("kgmicrobe.strain:bacdive_1", "lpsn:12345"),
+        ],
+    )
+    assert find_multi_parent_strains(path) == {}
+
+
+def test_a_clean_run_still_writes_the_report(tmp_path):
+    """
+    An absent report is indistinguishable from a check that never ran.
+
+    A clean merge is the thing worth being able to demonstrate, so the file is
+    written empty rather than skipped.
+    """
+    path = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-1", "NCBITaxon:5")])
+    assert check_merged_invariants(path) == 0
+    report = tmp_path / STRAIN_PARENT_REPORT
+    assert report.is_file()
+    lines = report.read_text(encoding="utf-8").splitlines()
+    assert lines == ["\t".join(STRAIN_PARENT_REPORT_HEADER)]
+
+
+def test_an_edge_file_without_the_expected_columns_is_skipped_not_crashed(tmp_path):
+    """A merge that took hours must not die on a header this check did not expect."""
+    path = _edges(tmp_path, [["a", "b"]], header=["something", "else"])
+    assert find_multi_parent_strains(path) == {}
+
+
+def test_an_empty_edge_file_is_survivable(tmp_path):
+    """No header at all should not raise."""
+    path = tmp_path / "merged-kg_edges.tsv"
+    path.write_text("", encoding="utf-8")
+    assert find_multi_parent_strains(path) == {}


### PR DESCRIPTION
Closes #896

## Why the merge and not the transform

#892 stopped BacDive giving a strain node several NCBITaxon parents. That guard buffers claims inside the transform, so it can only see claims BacDive itself makes. `kgmicrobe.strain:*` is a namespace several sources mint into — LPSN's `_extract_strain_curies` mints the same CURIEs precisely so the merge reconciles both sides — so the rule is only really enforced after the merge.

Today nothing else emits a competing parent:

```
subclass_of edges with a kgmicrobe.strain subject and an NCBITaxon object
  bacdive         251,916
  metatraits           58   (Genus_species_STRAIN shape, 0 overlap with bacdive)
  lpsn / lpsn_api / mediadive   0
  microbedecoder   19,114   (lpsn: objects, not NCBITaxon)
```

But that is a property of the current source set, not something enforced. A future transform reintroduces #892 silently, and #892's own guard cannot see it.

## What it does

`kg_microbe/merge_utils/invariants.py` streams the merged edge file and reports any `kgmicrobe.strain:*` node carrying more than one **distinct** `NCBITaxon:*` `subclass_of` parent, naming the knowledge sources involved — so the report says who to go and fix, not only what broke. It runs from `_cleanup_merged_outputs`, alongside the TSV normalization that already happens there.

`merged_strain_parent_violations.tsv` is written beside the merged TSVs, atomically, **and written even when empty** — an absent report cannot be told from a check that never ran, and a clean merge is the thing worth being able to demonstrate.

**Warns rather than aborts.** The merge is a multi-hour operation and this finding is about data quality, not a corrupt artifact; failing at the end would cost the run and fix nothing.

## Canary

Run against the shipped `data/merged/20260815` graph:

```
strains with >1 NCBITaxon parent: 524   (18s over a 2 GB edge file)
  kgmicrobe.strain:AJ-1378     2  NCBITaxon:43767|NCBITaxon:698417    infores:bacdive
  kgmicrobe.strain:AS-1        2  NCBITaxon:1122236|NCBITaxon:398036  infores:bacdive
  kgmicrobe.strain:AS-1.2123   2  NCBITaxon:1114856|NCBITaxon:1227500 infores:bacdive
knowledge sources implicated: ['infores:bacdive']
```

**524 is exactly the number #892 reported for that build**, and the check attributes all of them to the source that caused it. So it demonstrably finds the historical bug on the historical graph, which is the only way to know it would catch a new one.

## Tests

8, covering the cases that would make it useless rather than merely absent:

- one parent is not a violation, or the report is noise;
- **the same parent asserted by two sources is not a violation** — two sources agreeing is the merge working, and counting rows rather than distinct parents would fire on every strain a future source correctly corroborates;
- only `subclass_of` to `NCBITaxon` counts — not `close_match` to a deposit (#894) or microbedecoder's `strain → lpsn:` edges, neither of which is a taxonomic parent;
- the report names sources, not just nodes;
- a clean run still writes the report;
- an unexpected header is skipped, not crashed — a merge that took hours must not die on a header this check did not expect;
- an empty file does not raise.

`tox` green apart from the pre-existing `test_ontologies_stubs` failure that also fails on master.