### PR TITLE
fix(bacdive): give unresolvable NCBITaxon parents a typed stub node (#895, #919)

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -957,6 +957,75 @@ class BacDiveTransform(Transform):
         self._ncbitaxon_ancestor_cache[ncbitaxon_id] = ancestors
         return ancestors
 
+    def _emit_stubs_for_unresolvable_taxa(self) -> int:
+        """
+        Give every NCBITaxon this run pointed at a typed node, or KGX invents one.
+
+        A ``subclass_of`` edge whose object has no node row anywhere makes KGX
+        synthesize a bare ``biolink:NamedThing`` with no label. #892 saw 1,652 of
+        those in the 20240826 build and asked whether they were still being
+        emitted; 113 were. They are taxids BacDive carries that the pinned
+        NCBITaxon release does not contain -- retired or merged by NCBI, or newer
+        than the release -- and none of them appear anywhere in the extract, not
+        even as an alternative id.
+
+        Dropping the edges instead was measured and rejected: 857 of the 862
+        affected strains have no other parent, so removing the edge orphans them
+        from the taxonomy entirely, which is worse than an unresolvable parent.
+
+        Reads back this run's own edges rather than hooking the ten places that
+        emit a taxon edge, so a path added later is covered without being
+        remembered.
+
+        :return: Number of stub nodes written.
+        """
+        edge_objects: set = set()
+        with open(self.output_edge_file, encoding="utf-8", errors="replace") as handle:
+            handle.readline()
+            for line in handle:
+                fields = line.split("\t")
+                if len(fields) > 2 and fields[2].startswith(NCBITAXON_PREFIX):
+                    edge_objects.add(fields[2])
+        if not edge_objects:
+            return 0
+        node_ids: set = set()
+        with open(self.output_node_file, encoding="utf-8", errors="replace") as handle:
+            handle.readline()
+            for line in handle:
+                node_id = line.split("\t", 1)[0]
+                if node_id.startswith(NCBITAXON_PREFIX):
+                    node_ids.add(node_id)
+        # Ids in the extract get their node row from the ontologies transform at
+        # merge time, so they are not missing even though we did not write them.
+        missing = sorted(edge_objects - node_ids - set(self.ncbitaxon_labels))
+        if not missing:
+            return 0
+        with open(self.output_node_file, "a", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle, delimiter="\t")
+            for curie in missing:
+                label = self._get_ncbitaxon_label(curie)
+                writer.writerow(
+                    self._create_node_row(
+                        curie,
+                        NCBI_CATEGORY,
+                        label or curie,
+                        description=(
+                            "Referenced by BacDive but absent from the pinned NCBITaxon release"
+                            + (
+                                " (label recovered from the ontology adapter)."
+                                if label
+                                else ", including as an alternative id; most likely retired or merged by NCBI."
+                            )
+                        ),
+                    )
+                )
+        logger.info(
+            "[bacdive] %s NCBITaxon parents are not in the pinned release; "
+            "wrote typed stub nodes so they do not become untyped NamedThing (#895)",
+            f"{len(missing):,}",
+        )
+        return len(missing)
+
     def _parse_genus_from_scientific_name(self, scientific_name: str) -> Optional[str]:
         """
         Extract genus name from binomial nomenclature.
@@ -3528,6 +3597,8 @@ class BacDiveTransform(Transform):
             f"{len(self._ncbitaxon_ancestry_failures):,}",
             claims_file,
         )
+
+        self._emit_stubs_for_unresolvable_taxa()
 
         drop_duplicates(
             self.output_node_file,

--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -2156,8 +2156,13 @@ class BacDiveTransform(Transform):
                             ncbitaxon_id = NCBITAXON_PREFIX + str(general_info[NCBITAXON_ID][NCBITAXON_ID])
                         ncbi_description = general_info.get(GENERAL_DESCRIPTION, "")
                         ncbi_label = self._get_ncbitaxon_label(ncbitaxon_id)
-                        if ncbi_label is None:
-                            ncbi_label = ncbi_description
+                        # Deliberately not falling back to ncbi_description here. It is
+                        # a free-text sentence about one strain ("... was isolated from
+                        # wastewater from paper mill."), and using it as a taxon's name
+                        # gave 93 nodes a 130-character sentence for a label -- worse
+                        # than being unlabelled, because it passes every "does this node
+                        # have a name" check while being unusable. The sentence goes to
+                        # the description slot at the write sites instead (#919).
 
                     # If no NCBITaxon ID from BacDive JSON, try searching by name
                     if ncbitaxon_id is None and name_tax_classification:
@@ -2734,7 +2739,12 @@ class BacDiveTransform(Transform):
                             ]
                             if ncbitaxon_id:
                                 nodes_data_to_write.append(
-                                    self._create_node_row(ncbitaxon_id, NCBI_CATEGORY, ncbi_label)
+                                    self._create_node_row(
+                                        ncbitaxon_id,
+                                        NCBI_CATEGORY,
+                                        ncbi_label or ncbitaxon_id,
+                                        description=None if ncbi_label else ncbi_description,
+                                    )
                                 )
 
                             node_writer.writerows(nodes_data_to_write)
@@ -2798,7 +2808,14 @@ class BacDiveTransform(Transform):
                             for _, value in nodes_from_keywords.items()
                         ]
                         if ncbitaxon_id:
-                            nodes_data_to_write.append(self._create_node_row(ncbitaxon_id, NCBI_CATEGORY, ncbi_label))
+                            nodes_data_to_write.append(
+                                self._create_node_row(
+                                    ncbitaxon_id,
+                                    NCBI_CATEGORY,
+                                    ncbi_label or ncbitaxon_id,
+                                    description=None if ncbi_label else ncbi_description,
+                                )
+                            )
 
                         node_writer.writerows(nodes_data_to_write)
 

--- a/tests/test_bacdive_unresolvable_taxa.py
+++ b/tests/test_bacdive_unresolvable_taxa.py
@@ -139,3 +139,33 @@ def test_no_taxon_edges_writes_nothing(tmp_path):
     t = _transform(tmp_path, [["a", "biolink:related_to", "CHEBI:1", "rel", "src"]], [], {})
     assert t._emit_stubs_for_unresolvable_taxa() == 0
     assert len(_written(t)) == 0
+
+
+def test_a_taxon_name_is_never_a_bacdive_description_sentence():
+    """
+    An unlabelled taxon fell back to BacDive's free-text description (#919).
+
+    That gave 93 nodes a 130-character sentence about one strain for a name --
+    worse than being unlabelled, because it passes every "does this node have a
+    name" check while being unusable for lookup, display or matching.
+    """
+    import inspect
+    from pathlib import Path
+
+    source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
+    assert "ncbi_label = ncbi_description" not in source
+
+
+def test_an_unlabelled_taxon_keeps_its_sentence_as_a_description():
+    """
+    The sentence is real information; it just belongs in the description slot.
+
+    Dropping it would lose what BacDive knows about the organism, so both write
+    sites pass it as `description` and fall back to the CURIE for the name.
+    """
+    import inspect
+    from pathlib import Path
+
+    source = Path(inspect.getsourcefile(BacDiveTransform)).read_text()
+    assert source.count("description=None if ncbi_label else ncbi_description") == 2
+    assert source.count("ncbi_label or ncbitaxon_id") == 2

--- a/tests/test_bacdive_unresolvable_taxa.py
+++ b/tests/test_bacdive_unresolvable_taxa.py
@@ -1,0 +1,141 @@
+"""Every NCBITaxon this transform points at must get a typed node (#895)."""
+
+import csv
+
+from kg_microbe.transform_utils.bacdive.bacdive import BacDiveTransform
+from kg_microbe.transform_utils.constants import NCBI_CATEGORY
+
+NODE_HEADER = [
+    "id",
+    "category",
+    "name",
+    "description",
+    "xref",
+    "provided_by",
+    "synonym",
+    "deprecated",
+    "same_as",
+]
+EDGE_HEADER = ["subject", "predicate", "object", "relation", "primary_knowledge_source"]
+
+
+def _transform(tmp_path, edges, nodes, extract_labels, adapter_labels=None):
+    """Build a BacDiveTransform with only the fields the stub pass touches."""
+    t = BacDiveTransform.__new__(BacDiveTransform)
+    t.output_edge_file = tmp_path / "edges.tsv"
+    t.output_node_file = tmp_path / "nodes.tsv"
+    t.knowledge_source = "infores:bacdive"
+    t.node_header = list(NODE_HEADER)
+    t.ncbitaxon_labels = dict(extract_labels)
+    lookup = dict(adapter_labels or {})
+    t._get_ncbitaxon_label = lookup.get  # noqa: SLF001
+    with t.output_edge_file.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(EDGE_HEADER)
+        writer.writerows(edges)
+    with t.output_node_file.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(NODE_HEADER)
+        writer.writerows(nodes)
+    return t
+
+
+def _written(t):
+    rows = list(csv.DictReader(t.output_node_file.open(encoding="utf-8"), delimiter="\t"))
+    return {r["id"]: r for r in rows}
+
+
+def _edge(subject, obj):
+    return [subject, "biolink:subclass_of", obj, "rdfs:subClassOf", "infores:bacdive"]
+
+
+def test_a_taxon_the_pinned_release_lacks_gets_a_typed_stub(tmp_path):
+    """
+    Otherwise KGX synthesizes a bare `biolink:NamedThing` with no label.
+
+    That is what #892 saw 1,652 of in the 20240826 build and asked about.
+    """
+    t = _transform(tmp_path, [_edge("kgmicrobe.strain:X", "NCBITaxon:999")], [], {})
+    assert t._emit_stubs_for_unresolvable_taxa() == 1
+    node = _written(t)["NCBITaxon:999"]
+    assert node["category"] == NCBI_CATEGORY
+    assert "absent from the pinned NCBITaxon release" in node["description"]
+
+
+def test_a_taxon_in_the_pinned_release_gets_no_stub(tmp_path):
+    """
+    The ontologies transform supplies its node row at merge time.
+
+    Writing our own would duplicate 925,220 nodes and override their real labels.
+    """
+    t = _transform(
+        tmp_path,
+        [_edge("kgmicrobe.strain:X", "NCBITaxon:562")],
+        [],
+        {"NCBITaxon:562": "Escherichia coli"},
+    )
+    assert t._emit_stubs_for_unresolvable_taxa() == 0
+    assert "NCBITaxon:562" not in _written(t)
+
+
+def test_a_taxon_this_run_already_wrote_gets_no_second_row(tmp_path):
+    """
+    94 of the 113 unresolvable parents already have a BacDive node row.
+
+    Re-emitting them would replace a real label with a bare CURIE, since
+    `drop_duplicates` keeps one row per id.
+    """
+    t = _transform(
+        tmp_path,
+        [_edge("kgmicrobe.strain:X", "NCBITaxon:999")],
+        [["NCBITaxon:999", NCBI_CATEGORY, "Some taxon", "", "", "infores:bacdive", "", "", ""]],
+        {},
+    )
+    assert t._emit_stubs_for_unresolvable_taxa() == 0
+    assert _written(t)["NCBITaxon:999"]["name"] == "Some taxon"
+
+
+def test_a_recoverable_label_is_used_rather_than_the_bare_curie(tmp_path):
+    """`Moorella` is a real genus the pinned release happens not to carry."""
+    t = _transform(
+        tmp_path,
+        [_edge("kgmicrobe.strain:X", "NCBITaxon:216400")],
+        [],
+        {},
+        adapter_labels={"NCBITaxon:216400": "Moorella"},
+    )
+    assert t._emit_stubs_for_unresolvable_taxa() == 1
+    node = _written(t)["NCBITaxon:216400"]
+    assert node["name"] == "Moorella"
+    assert "label recovered from the ontology adapter" in node["description"]
+
+
+def test_an_unlabelled_stub_says_it_is_probably_retired(tmp_path):
+    """The two cases need different descriptions, or the node misleads."""
+    t = _transform(tmp_path, [_edge("kgmicrobe.strain:X", "NCBITaxon:999")], [], {})
+    t._emit_stubs_for_unresolvable_taxa()
+    node = _written(t)["NCBITaxon:999"]
+    assert node["name"] == "NCBITaxon:999"
+    assert "retired or merged by NCBI" in node["description"]
+
+
+def test_taxa_reached_by_any_predicate_are_covered(tmp_path):
+    """
+    Reading back the edges covers emission paths nobody remembered to hook.
+
+    BacDive writes taxon edges from about ten places; a pass that scanned only
+    the main one would leave the rest to KGX.
+    """
+    edges = [
+        ["kgmicrobe.strain:X", "biolink:related_to", "NCBITaxon:998", "rel", "infores:bacdive"],
+        _edge("kgmicrobe.strain:Y", "NCBITaxon:999"),
+    ]
+    t = _transform(tmp_path, edges, [], {})
+    assert t._emit_stubs_for_unresolvable_taxa() == 2
+
+
+def test_no_taxon_edges_writes_nothing(tmp_path):
+    """An empty result must not append a header or a blank row."""
+    t = _transform(tmp_path, [["a", "biolink:related_to", "CHEBI:1", "rel", "src"]], [], {})
+    assert t._emit_stubs_for_unresolvable_taxa() == 0
+    assert len(_written(t)) == 0


### PR DESCRIPTION
Closes #895

## Correcting the count first

I wrote #895, and its headline number is right about the wrong thing. 113 strain parents are absent from the pinned NCBITaxon extract — but BacDive writes 20,410 NCBITaxon node rows of its own, so most of them already arrive typed:

```
strain subclass_of parents absent from the ontologies extract:   113
  already carrying a BacDive-written node row:                    94
  no node row anywhere -> untyped biolink:NamedThing:             19   (18 bacdive, 1 metatraits)
```

19 is the number that matches what #892 described.

## Why they are unresolvable

All 113 checked against the full NCBITaxon adapter:

| | count | meaning |
|---|---|---|
| adapter does not know the id | 110 | retired or merged by NCBI; BacDive carries a stale taxid |
| adapter knows it, extract does not | 3 | `Bosea`, `Moorella`, `Micromonas sp.` — whole lineage missing, parents included |

None appear anywhere in the extract, in any column, **not even as an alternative id** — so there is no in-repo forwarding table to migrate them with.

## Dropping was measured and rejected

The obvious fix is to refuse an edge whose object will have no node:

```
strains touching a dangling parent:        862
strains that would lose their ONLY parent: 857   (300 record nodes, 557 deposits)
```

Orphaning 857 strains from the taxonomy is worse than an unresolvable parent. The edges stay.

## What this does

Emits a typed stub, the pattern #790 established for isolation-source targets — `biolink:OrganismTaxon`, the adapter's label where recoverable, and a description that distinguishes the two causes:

```
NCBITaxon:216400  biolink:OrganismTaxon  Moorella
    Referenced by BacDive but absent from the pinned NCBITaxon release
    (label recovered from the ontology adapter).

NCBITaxon:2923281 biolink:OrganismTaxon  NCBITaxon:2923281
    Referenced by BacDive but absent from the pinned NCBITaxon release,
    including as an alternative id; most likely retired or merged by NCBI.
```

**Implemented as a pass over the transform's own edge output**, not hooked into the ~10 places that emit a taxon edge. A future emission path is covered without anyone having to remember it — and the test suite pins that by checking a `related_to` edge is covered too, not just `subclass_of`.

## Canary

Driven over the real `data/transformed/bacdive/edges.tsv` (4.2M rows) against a copy of the real `nodes.tsv`:

```
extract labels loaded: 925,220
stubs written: 18   (3s)
  with a recovered label:  1   (NCBITaxon:216400 -> 'Moorella')
  unlabelled:             17
```

18 rather than 19 because the remaining one is referenced only by metatraits, which this transform cannot see.

## Tests

7, including the two that would make this actively harmful if wrong:

- **a taxon already in the pinned release gets no stub** — writing our own would duplicate 925,220 nodes and override their real labels;
- **a taxon this run already wrote gets no second row** — `drop_duplicates` keeps one row per id, so a duplicate would replace a real label with a bare CURIE.

`tox` green apart from the pre-existing `test_ontologies_stubs` failure that also fails on master.

## Not fixed here

The 1 metatraits-sourced untyped taxon. That wants the cross-source check, not a second copy of this pass — filing as a follow-up against the `merge_utils/invariants.py` module added in #913.