### PR TITLE
fix(download): make a changed pin take effect on the next ordinary run (#911, #929, #930, #931)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,7 @@ poetry run kg merge -y merge.yaml
 make run-summary
 ```
 
-`kg download` skips existing files; `-i` invalidates every selected entry, so
-always combine it with one or more `-t` tags. MediaDive invalidation also clears
+`kg download` skips existing files, but a pin change now takes effect on its own: the URL behind each artifact is recorded in `data/raw/.download_manifest.json`, and a file whose declared URL has moved is re-fetched. A file with no record is left alone — unknown provenance is not wrong provenance (#911). `-i` still invalidates every selected entry, so always combine it with one or more `-t` tags. MediaDive invalidation also clears
 its response cache and can trigger an approximately one-hour crawl.
 
 The normal merge creates `data/merged/merged-kg.tar.gz` and removes the loose

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -84,17 +84,23 @@ def download(
     finally:
         if effective_yaml != yaml_file:
             Path(effective_yaml).unlink(missing_ok=True)
-
-    # Snippet runs write deliberately truncated files; recording a URL against
-    # one would claim it is the real artifact.
-    #
-    # Reads the original config, not the filtered one: the filtered copy is a temp
-    # file already unlinked above. Pending-hosting entries are excluded explicitly
-    # instead — `_report_pending` tells the user to satisfy those by hand, so the
-    # artifact often exists without ever having been downloaded, and recording it
-    # against a REPLACE_ME_ placeholder claims a provenance it never had (#929).
-    if not snippet_only:
-        record(yaml_file, output_dir, tags, skip_names=[_local_name_of(e) for e in pending])
+        # Recorded even when the download raised. kghub-downloader aborts the
+        # whole run on the first bad URL, so waiting for success means one dead
+        # source among 63 leaves the manifest unwritten forever — and #911's fix
+        # silently does nothing (#930). Only files that exist are recorded, so a
+        # partial run records exactly what landed.
+        #
+        # Snippet runs write deliberately truncated files; recording a URL against
+        # one would claim it is the real artifact.
+        #
+        # Reads the original config, not the filtered one: the filtered copy is
+        # unlinked just above. Pending-hosting entries are excluded explicitly
+        # instead — `_report_pending` tells the user to satisfy those by hand, so
+        # the artifact often exists without ever having been downloaded, and
+        # recording it against a REPLACE_ME_ placeholder claims a provenance it
+        # never had (#929).
+        if not snippet_only:
+            record(yaml_file, output_dir, tags, skip_names=[_local_name_of(e) for e in pending])
 
     # Post-download: Trigger MediaDive bulk download if mediadive.json was downloaded
     if snippet_only:  # Skip bulk download in snippet mode

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Sequence, Tuple
 import yaml
 from kghub_downloader.download_utils import download_from_yaml
 
+from kg_microbe.utils.download_manifest import drop_stale, record
 from kg_microbe.utils.mediadive_bulk_download import download_mediadive_bulk
 
 # Tag (in download.yaml) of the entry that pulls the MediaDive media list. A
@@ -65,6 +66,13 @@ def download(
     if pending:
         _report_pending(pending)
 
+    # kghub-downloader decides by asking whether the file exists and records
+    # nothing about where it came from, so a changed pin in download.yaml has no
+    # effect on disk. Remove the artifacts whose declared URL has moved before
+    # handing over, so an ordinary run picks the change up (#911).
+    if not snippet_only and not ignore_cache:
+        drop_stale(effective_yaml, output_dir, tags)
+
     try:
         download_from_yaml(
             yaml_file=effective_yaml,
@@ -76,6 +84,11 @@ def download(
     finally:
         if effective_yaml != yaml_file:
             Path(effective_yaml).unlink(missing_ok=True)
+
+    # Snippet runs write deliberately truncated files; recording a URL against
+    # one would claim it is the real artifact.
+    if not snippet_only:
+        record(effective_yaml if effective_yaml == yaml_file else yaml_file, output_dir, tags)
 
     # Post-download: Trigger MediaDive bulk download if mediadive.json was downloaded
     if snippet_only:  # Skip bulk download in snippet mode

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -100,7 +100,15 @@ def download(
         # recording it against a REPLACE_ME_ placeholder claims a provenance it
         # never had (#929).
         if not snippet_only:
-            record(yaml_file, output_dir, tags, skip_names=[_local_name_of(e) for e in pending])
+            try:
+                record(yaml_file, output_dir, tags, skip_names=[_local_name_of(e) for e in pending])
+            except Exception as exc:  # noqa: BLE001
+                # An exception raised in a finally REPLACES the one propagating
+                # through it, so a failed manifest write would be reported instead
+                # of the upstream 404 that actually stopped the download. The
+                # manifest is bookkeeping about a download; it must never be what a
+                # failed download reports (#931, and #914 for the same argument).
+                print(f"[download] could not record provenance: {exc}")
 
     # Post-download: Trigger MediaDive bulk download if mediadive.json was downloaded
     if snippet_only:  # Skip bulk download in snippet mode

--- a/kg_microbe/download.py
+++ b/kg_microbe/download.py
@@ -87,8 +87,14 @@ def download(
 
     # Snippet runs write deliberately truncated files; recording a URL against
     # one would claim it is the real artifact.
+    #
+    # Reads the original config, not the filtered one: the filtered copy is a temp
+    # file already unlinked above. Pending-hosting entries are excluded explicitly
+    # instead — `_report_pending` tells the user to satisfy those by hand, so the
+    # artifact often exists without ever having been downloaded, and recording it
+    # against a REPLACE_ME_ placeholder claims a provenance it never had (#929).
     if not snippet_only:
-        record(effective_yaml if effective_yaml == yaml_file else yaml_file, output_dir, tags)
+        record(yaml_file, output_dir, tags, skip_names=[_local_name_of(e) for e in pending])
 
     # Post-download: Trigger MediaDive bulk download if mediadive.json was downloaded
     if snippet_only:  # Skip bulk download in snippet mode
@@ -96,6 +102,19 @@ def download(
     if tags and MEDIADIVE_TAG not in tags:
         return
     _post_download_mediadive_bulk(output_dir, ignore_cache)
+
+
+def _local_name_of(entry: dict) -> str:
+    """
+    Return the on-disk name an entry writes to.
+
+    :param entry: A download.yaml entry.
+    :return: Its ``local_name``, or the basename of its URL when absent.
+    """
+    name = entry.get("local_name")
+    if name:
+        return str(name)
+    return (entry.get("url") or "").rsplit("/", 1)[-1]
 
 
 def _without_pending_hosting(yaml_file: str, tags: Optional[Sequence[str]]) -> Tuple[str, List[dict]]:

--- a/kg_microbe/utils/download_manifest.py
+++ b/kg_microbe/utils/download_manifest.py
@@ -1,0 +1,146 @@
+"""
+Record which URL produced each downloaded artifact, and re-fetch when it changes.
+
+``kghub_downloader`` decides whether to download by asking whether the file
+exists, and stores nothing about where it came from. So editing a pinned version
+in ``download.yaml`` changes nothing on disk: the run reports success and the
+pipeline keeps consuming the old artifact, with the declared pin and the cached
+bytes silently disagreeing. That is how a METPO pin moved three releases while
+``data/raw/metpo.json`` stayed on the version before it (#900, #911).
+
+Existence is the wrong cache key. This module makes the URL part of it: a file
+whose recorded URL no longer matches the declared one is removed before the
+download runs, so the next ordinary ``kg download`` picks up the change.
+
+A file with **no** record is left alone. Every artifact predates this manifest,
+so treating "unknown" as "stale" would re-fetch the entire corpus on the first
+run -- including an hour of MediaDive crawling -- to learn what is already known.
+Records accumulate as things are downloaded.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+#: Sits beside the artifacts it describes, under the gitignored data directory.
+MANIFEST_NAME = ".download_manifest.json"
+
+
+def manifest_path(output_dir: str) -> Path:
+    """
+    Return the manifest location for a download directory.
+
+    :param output_dir: Directory downloads are written to.
+    :return: Path to the manifest, which may not exist.
+    """
+    return Path(output_dir) / MANIFEST_NAME
+
+
+def read_manifest(output_dir: str) -> Dict[str, str]:
+    """
+    Return the recorded ``local_name -> url`` map.
+
+    :param output_dir: Directory downloads are written to.
+    :return: Mapping, empty when absent or unreadable. A corrupt manifest is
+        treated as no manifest: it must never be able to block a download.
+    """
+    path = manifest_path(output_dir)
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("[download] ignoring unreadable %s", path)
+        return {}
+    recorded = payload.get("artifacts")
+    return recorded if isinstance(recorded, dict) else {}
+
+
+def _selected_entries(yaml_file: str, tags: Optional[Sequence[str]]) -> List[dict]:
+    with open(yaml_file) as handle:
+        entries = yaml.safe_load(handle) or []
+    return [e for e in entries if isinstance(e, dict) and (not tags or e.get("tag") in tags)]
+
+
+def _local_name(entry: dict) -> Optional[str]:
+    name = entry.get("local_name")
+    if name:
+        return str(name)
+    url = entry.get("url") or ""
+    return url.rsplit("/", 1)[-1] or None
+
+
+def stale_by_url(yaml_file: str, output_dir: str, tags: Optional[Sequence[str]] = None) -> List[Path]:
+    """
+    Return downloaded files whose recorded URL no longer matches the config.
+
+    :param yaml_file: Download config being applied.
+    :param output_dir: Directory downloads are written to.
+    :param tags: Tags this run is restricted to, or None for all.
+    :return: Paths that exist on disk and came from a different URL.
+    """
+    recorded = read_manifest(output_dir)
+    stale = []
+    for entry in _selected_entries(yaml_file, tags):
+        name = _local_name(entry)
+        url = entry.get("url")
+        if not name or not url:
+            continue
+        was = recorded.get(name)
+        if was is None or was == url:
+            # No record means unknown provenance, not wrong provenance.
+            continue
+        path = Path(output_dir) / name
+        if path.exists():
+            stale.append(path)
+    return stale
+
+
+def drop_stale(yaml_file: str, output_dir: str, tags: Optional[Sequence[str]] = None) -> List[Path]:
+    """
+    Remove artifacts whose declared URL has changed, so they are fetched again.
+
+    :param yaml_file: Download config being applied.
+    :param output_dir: Directory downloads are written to.
+    :param tags: Tags this run is restricted to, or None for all.
+    :return: Paths removed.
+    """
+    stale = stale_by_url(yaml_file, output_dir, tags)
+    for path in stale:
+        logger.info("[download] %s came from a different URL than download.yaml declares; re-fetching", path.name)
+        print(f"[download] re-fetching {path.name}: its recorded URL differs from the one declared in the config")
+        path.unlink(missing_ok=True)
+    return stale
+
+
+def record(yaml_file: str, output_dir: str, tags: Optional[Sequence[str]] = None) -> int:
+    """
+    Record the URL behind every artifact this run left on disk.
+
+    Only files that exist are recorded, so a skipped or failed entry does not
+    gain a provenance claim it has not earned.
+
+    :param yaml_file: Download config that was applied.
+    :param output_dir: Directory downloads were written to.
+    :param tags: Tags this run was restricted to, or None for all.
+    :return: Number of artifacts recorded.
+    """
+    from kg_microbe.utils.atomic_io import atomic_write
+
+    recorded = dict(read_manifest(output_dir))
+    for entry in _selected_entries(yaml_file, tags):
+        name = _local_name(entry)
+        url = entry.get("url")
+        if name and url and (Path(output_dir) / name).exists():
+            recorded[name] = url
+    destination = manifest_path(output_dir)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_write(destination) as handle:
+        json.dump({"artifacts": dict(sorted(recorded.items()))}, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return len(recorded)

--- a/kg_microbe/utils/download_manifest.py
+++ b/kg_microbe/utils/download_manifest.py
@@ -118,25 +118,35 @@ def drop_stale(yaml_file: str, output_dir: str, tags: Optional[Sequence[str]] = 
     return stale
 
 
-def record(yaml_file: str, output_dir: str, tags: Optional[Sequence[str]] = None) -> int:
+def record(
+    yaml_file: str,
+    output_dir: str,
+    tags: Optional[Sequence[str]] = None,
+    skip_names: Optional[Sequence[str]] = None,
+) -> int:
     """
     Record the URL behind every artifact this run left on disk.
 
     Only files that exist are recorded, so a skipped or failed entry does not
-    gain a provenance claim it has not earned.
+    gain a provenance claim it has not earned. ``skip_names`` excludes entries
+    the caller knows were never downloaded -- pending-hosting sources are
+    satisfied by hand, so their artifact exists without having come from the
+    placeholder URL in the config (#929).
 
     :param yaml_file: Download config that was applied.
     :param output_dir: Directory downloads were written to.
     :param tags: Tags this run was restricted to, or None for all.
+    :param skip_names: Local names to leave unrecorded.
     :return: Number of artifacts recorded.
     """
     from kg_microbe.utils.atomic_io import atomic_write
 
+    excluded = set(skip_names or ())
     recorded = dict(read_manifest(output_dir))
     for entry in _selected_entries(yaml_file, tags):
         name = _local_name(entry)
         url = entry.get("url")
-        if name and url and (Path(output_dir) / name).exists():
+        if name and name not in excluded and url and (Path(output_dir) / name).exists():
             recorded[name] = url
     destination = manifest_path(output_dir)
     destination.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_download_manifest.py
+++ b/tests/test_download_manifest.py
@@ -1,7 +1,9 @@
 """A changed pin must take effect on the next ordinary download (#911)."""
 
+import importlib
 import json
 
+import pytest
 import yaml
 
 from kg_microbe.utils.download_manifest import (
@@ -193,3 +195,59 @@ def test_download_excludes_pending_entries_when_recording():
     source = inspect.getsource(download)
     assert "skip_names=[_local_name_of(e) for e in pending]" in source
     assert "effective_yaml if effective_yaml == yaml_file else yaml_file" not in source
+
+
+def test_a_partial_download_still_records_what_landed(tmp_path, monkeypatch):
+    """
+    One dead URL must not leave the manifest unwritten forever (#930).
+
+    kghub-downloader aborts the whole run on the first bad URL, so recording only
+    on success means a repo with one persistently broken source never builds a
+    manifest — and #911's fix silently does nothing.
+    """
+    # `from .download import download` in kg_microbe/__init__.py shadows the
+    # submodule with the function, so the module has to be fetched explicitly.
+    download_module = importlib.import_module("kg_microbe.download")
+
+    def boom(**_kwargs):
+        raise RuntimeError("upstream 404")
+
+    monkeypatch.setattr(download_module, "download_from_yaml", boom)
+    monkeypatch.setattr(download_module, "_post_download_mediadive_bulk", lambda *_a: None)
+
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "landed.json", "tag": "t"}])
+    _artifact(tmp_path, "landed.json")
+
+    with pytest.raises(RuntimeError):
+        download_module.download(
+            yaml_file=config,
+            output_dir=str(tmp_path),
+            snippet_only=False,
+            ignore_cache=False,
+            tags=None,
+        )
+
+    assert set(read_manifest(str(tmp_path))) == {"landed.json"}, "a partial run recorded nothing"
+
+
+def test_the_failing_download_still_propagates(tmp_path, monkeypatch):
+    """Recording must not swallow the error it recorded alongside."""
+    # `from .download import download` in kg_microbe/__init__.py shadows the
+    # submodule with the function, so the module has to be fetched explicitly.
+    download_module = importlib.import_module("kg_microbe.download")
+
+    def boom(**_kwargs):
+        raise RuntimeError("upstream 404")
+
+    monkeypatch.setattr(download_module, "download_from_yaml", boom)
+    monkeypatch.setattr(download_module, "_post_download_mediadive_bulk", lambda *_a: None)
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "thing.json", "tag": "t"}])
+
+    with pytest.raises(RuntimeError, match="upstream 404"):
+        download_module.download(
+            yaml_file=config,
+            output_dir=str(tmp_path),
+            snippet_only=False,
+            ignore_cache=False,
+            tags=None,
+        )

--- a/tests/test_download_manifest.py
+++ b/tests/test_download_manifest.py
@@ -1,0 +1,153 @@
+"""A changed pin must take effect on the next ordinary download (#911)."""
+
+import json
+
+import yaml
+
+from kg_microbe.utils.download_manifest import (
+    MANIFEST_NAME,
+    drop_stale,
+    manifest_path,
+    read_manifest,
+    record,
+    stale_by_url,
+)
+
+URL_A = "https://example.org/refs/tags/2026-03-24/thing.json"
+URL_B = "https://example.org/refs/tags/2026-06-12/thing.json"
+
+
+def _config(tmp_path, entries):
+    path = tmp_path / "download.yaml"
+    path.write_text(yaml.safe_dump(entries, sort_keys=False), encoding="utf-8")
+    return str(path)
+
+
+def _artifact(tmp_path, name, text="payload"):
+    (tmp_path / name).write_text(text, encoding="utf-8")
+    return tmp_path / name
+
+
+def test_an_unrecorded_artifact_is_never_treated_as_stale(tmp_path):
+    """
+    Unknown provenance is not wrong provenance.
+
+    Every artifact predates this manifest, so treating "no record" as "stale"
+    would re-fetch the whole corpus on the first run — including an hour of
+    MediaDive crawling — to learn what is already on disk.
+    """
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "thing.json", "tag": "t"}])
+    _artifact(tmp_path, "thing.json")
+    assert stale_by_url(config, str(tmp_path)) == []
+
+
+def test_a_changed_url_makes_the_artifact_stale(tmp_path):
+    """The whole point: the declared pin moved, so the cached bytes are wrong."""
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "thing.json", "tag": "t"}])
+    _artifact(tmp_path, "thing.json")
+    record(config, str(tmp_path))
+    moved = _config(tmp_path, [{"url": URL_B, "local_name": "thing.json", "tag": "t"}])
+    assert [p.name for p in stale_by_url(moved, str(tmp_path))] == ["thing.json"]
+
+
+def test_an_unchanged_url_leaves_the_artifact_alone(tmp_path):
+    """Re-downloading what already matches would undo the cache entirely."""
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "thing.json", "tag": "t"}])
+    _artifact(tmp_path, "thing.json")
+    record(config, str(tmp_path))
+    assert stale_by_url(config, str(tmp_path)) == []
+
+
+def test_dropping_stale_removes_only_the_moved_artifact(tmp_path):
+    """A pin change must not invalidate its neighbours."""
+    entries = [
+        {"url": URL_A, "local_name": "moved.json", "tag": "t"},
+        {"url": URL_A, "local_name": "kept.json", "tag": "t"},
+    ]
+    config = _config(tmp_path, entries)
+    _artifact(tmp_path, "moved.json")
+    _artifact(tmp_path, "kept.json")
+    record(config, str(tmp_path))
+    entries[0]["url"] = URL_B
+    removed = drop_stale(_config(tmp_path, entries), str(tmp_path))
+    assert [p.name for p in removed] == ["moved.json"]
+    assert not (tmp_path / "moved.json").exists()
+    assert (tmp_path / "kept.json").exists()
+
+
+def test_a_tag_filtered_run_only_considers_its_own_entries(tmp_path):
+    """`kg download -t ontologies` must not delete a mediadive artifact."""
+    entries = [
+        {"url": URL_A, "local_name": "onto.json", "tag": "ontologies"},
+        {"url": URL_A, "local_name": "media.json", "tag": "mediadive"},
+    ]
+    config = _config(tmp_path, entries)
+    _artifact(tmp_path, "onto.json")
+    _artifact(tmp_path, "media.json")
+    record(config, str(tmp_path))
+    for entry in entries:
+        entry["url"] = URL_B
+    removed = drop_stale(_config(tmp_path, entries), str(tmp_path), tags=["ontologies"])
+    assert [p.name for p in removed] == ["onto.json"]
+    assert (tmp_path / "media.json").exists()
+
+
+def test_a_missing_artifact_is_not_reported_stale(tmp_path):
+    """There is nothing to invalidate, and the download will fetch it anyway."""
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "thing.json", "tag": "t"}])
+    record(config, str(tmp_path))
+    moved = _config(tmp_path, [{"url": URL_B, "local_name": "thing.json", "tag": "t"}])
+    assert stale_by_url(moved, str(tmp_path)) == []
+
+
+def test_only_artifacts_that_exist_are_recorded(tmp_path):
+    """A skipped or failed entry must not gain a provenance claim it did not earn."""
+    config = _config(
+        tmp_path,
+        [
+            {"url": URL_A, "local_name": "present.json", "tag": "t"},
+            {"url": URL_A, "local_name": "absent.json", "tag": "t"},
+        ],
+    )
+    _artifact(tmp_path, "present.json")
+    record(config, str(tmp_path))
+    recorded = read_manifest(str(tmp_path))
+    assert set(recorded) == {"present.json"}
+
+
+def test_a_corrupt_manifest_never_blocks_a_download(tmp_path):
+    """
+    Provenance is an optimisation; losing it must not stop work.
+
+    A manifest that cannot be parsed is treated as no manifest, which degrades
+    to today's behaviour rather than to an error.
+    """
+    manifest_path(str(tmp_path)).write_text("{not json", encoding="utf-8")
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "thing.json", "tag": "t"}])
+    _artifact(tmp_path, "thing.json")
+    assert read_manifest(str(tmp_path)) == {}
+    assert stale_by_url(config, str(tmp_path)) == []
+
+
+def test_the_manifest_is_written_atomically_and_sorted(tmp_path):
+    """A half-written manifest would claim provenance for artifacts arbitrarily."""
+    config = _config(
+        tmp_path,
+        [
+            {"url": URL_B, "local_name": "b.json", "tag": "t"},
+            {"url": URL_A, "local_name": "a.json", "tag": "t"},
+        ],
+    )
+    _artifact(tmp_path, "a.json")
+    _artifact(tmp_path, "b.json")
+    record(config, str(tmp_path))
+    payload = json.loads((tmp_path / MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert list(payload["artifacts"]) == ["a.json", "b.json"]
+
+
+def test_an_entry_without_local_name_falls_back_to_the_url_basename(tmp_path):
+    """download.yaml does not require local_name; the downloader derives it too."""
+    config = _config(tmp_path, [{"url": URL_A, "tag": "t"}])
+    _artifact(tmp_path, "thing.json")
+    record(config, str(tmp_path))
+    assert set(read_manifest(str(tmp_path))) == {"thing.json"}

--- a/tests/test_download_manifest.py
+++ b/tests/test_download_manifest.py
@@ -251,3 +251,34 @@ def test_the_failing_download_still_propagates(tmp_path, monkeypatch):
             ignore_cache=False,
             tags=None,
         )
+
+
+def test_a_manifest_failure_does_not_mask_the_download_error(tmp_path, monkeypatch):
+    """
+    An exception in a `finally` replaces the one propagating through it (#931).
+
+    The manifest is bookkeeping about a download; a failed write must never be
+    what a failed download reports, or the user chases a disk error instead of
+    the upstream 404 that actually stopped them.
+    """
+    download_module = importlib.import_module("kg_microbe.download")
+
+    def boom(**_kwargs):
+        raise RuntimeError("upstream 404")
+
+    def cannot_record(*_a, **_k):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(download_module, "download_from_yaml", boom)
+    monkeypatch.setattr(download_module, "record", cannot_record)
+    monkeypatch.setattr(download_module, "_post_download_mediadive_bulk", lambda *_a: None)
+    config = _config(tmp_path, [{"url": URL_A, "local_name": "thing.json", "tag": "t"}])
+
+    with pytest.raises(RuntimeError, match="upstream 404"):
+        download_module.download(
+            yaml_file=config,
+            output_dir=str(tmp_path),
+            snippet_only=False,
+            ignore_cache=False,
+            tags=None,
+        )

--- a/tests/test_download_manifest.py
+++ b/tests/test_download_manifest.py
@@ -151,3 +151,45 @@ def test_an_entry_without_local_name_falls_back_to_the_url_basename(tmp_path):
     _artifact(tmp_path, "thing.json")
     record(config, str(tmp_path))
     assert set(read_manifest(str(tmp_path))) == {"thing.json"}
+
+
+def test_a_pending_hosting_entry_gains_no_provenance(tmp_path):
+    """
+    Its artifact is placed by hand, so it never came from the URL in the config (#929).
+
+    `_report_pending` tells the user to copy these from a reference directory, so
+    the file usually exists while the config still holds a `REPLACE_ME_`
+    placeholder. Recording that as its provenance answers "what produced this
+    file" with something that produced nothing — worse than answering nothing,
+    since `stale_by_url` already treats "no record" as "leave alone".
+    """
+    config = _config(
+        tmp_path,
+        [
+            {"url": URL_A, "local_name": "real.json", "tag": "t"},
+            {"url": "REPLACE_ME_pending", "local_name": "handplaced.json", "tag": "t"},
+        ],
+    )
+    _artifact(tmp_path, "real.json")
+    _artifact(tmp_path, "handplaced.json")
+    record(config, str(tmp_path), skip_names=["handplaced.json"])
+    recorded = read_manifest(str(tmp_path))
+    assert set(recorded) == {"real.json"}
+    assert "handplaced.json" not in recorded
+
+
+def test_download_excludes_pending_entries_when_recording():
+    """
+    Pin the wiring, not just the helper.
+
+    The exclusion is only useful if `download()` actually passes the pending
+    names through; the ternary it replaced looked like it chose a config and
+    always returned the same one.
+    """
+    import inspect
+
+    from kg_microbe.download import download
+
+    source = inspect.getsource(download)
+    assert "skip_names=[_local_name_of(e) for e in pending]" in source
+    assert "effective_yaml if effective_yaml == yaml_file else yaml_file" not in source


### PR DESCRIPTION
Closes #911

## Existence is the wrong cache key

`kghub_downloader.download_from_yaml` decides entirely on `outfile_path.exists()`:

```python
if outfile_path.exists():
    if ignore_cache:
        outfile_path.unlink()
    else:
        logging.info("Using cached version of {outfile_path")
        continue
```

It stores nothing about which URL produced the file. So editing a pinned version in `download.yaml` changes nothing on disk — the run reports success and the pipeline keeps consuming the old artifact, with the declared pin and the cached bytes silently disagreeing.

That is not hypothetical. #900 moved METPO from `refs/heads/main` to `refs/tags/2026-06-12`; `data/raw/metpo.json` is still the file fetched on 2026-07-27, three releases behind. #909's guard reads that file, so it skips — a check written to catch retired terms is disabled by a pin change that appeared to succeed.

The library is third-party, so the fix lives in our `download()` wrapper, which already pre-processes the config.

## What it does

Each run records `local_name -> url` in `data/raw/.download_manifest.json`. Before handing over, artifacts whose declared URL has moved are removed, so `kghub_downloader` fetches them again.

**An artifact with no record is left alone.** This is the design decision that matters. Every file predates the manifest, so treating "unknown" as "stale" would re-fetch the entire corpus on first run — including an hour of MediaDive crawling — to learn what is already on disk. Unknown provenance is not wrong provenance; records accumulate as things download.

## Canary

Against the real `download.yaml` and `data/raw`:

```
manifest exists? False   recorded: 0
files stale-by-URL right now: 0        <- landing this re-fetches nothing
entries whose artifact is on disk: 59 / 63
```

Simulating the #900 change end to end:

```
after the pin change, stale: ['metpo.json']
[download] re-fetching metpo.json: its recorded URL differs from the one declared in the config
file gone? True
```

So it is inert on arrival and correct on the case that motivated it.

## Deliberately inert where it would be wrong

- **snippet runs** (`-x`) write truncated files; recording a URL against one would claim it is the real artifact;
- **`-i` runs** invalidate everything already;
- **a corrupt manifest** is treated as no manifest. Provenance is an optimisation and must never be able to block a download, so an unparseable file degrades to today's behaviour rather than to an error.

## Tests

10, weighted toward the ways this could do damage rather than the happy path:

- an unrecorded artifact is never stale — the property that keeps first-run cost at zero;
- a tag-filtered run only considers its own entries, so `kg download -t ontologies` cannot delete a MediaDive artifact;
- dropping stale removes only the moved artifact, not its neighbours;
- only artifacts that exist are recorded, so a skipped or failed entry gains no provenance claim;
- a corrupt manifest never blocks a download;
- the manifest is written atomically and sorted, so a half-written one cannot claim provenance arbitrarily.

`tox` green apart from two known failures that also fail on master: `test_ontologies_stubs` (pre-existing) and `test_no_deprecated_metpo_terms::test_transform_outputs_carry_no_unexpected_deprecated_term`, which is the true positive from #923 — `bacdive/nodes.tsv` still carries `METPO:1001000` until the transform is rerun.

## Follow-on

This unblocks #909's guard: once `kg download -t ontologies` runs, `metpo.json` refreshes to the pinned release on its own and the deprecation checks stop skipping.