### PR TITLE
feat(merge): report the nodes KGX invented for undeclared endpoints (#918, #934, #935, #936)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,11 @@ the claims report, and the node carries a description saying so. See issues
   sources, so `merge_utils/invariants.py` re-checks after the merge and writes
   `merged_strain_parent_violations.tsv` beside the merged TSVs — empty on a
   clean run, because an absent report cannot be told from a check that never
-  ran. See issues #892 and #896.
+  ran. It also writes `merged_stub_nodes.tsv`: KGX invents a node for any
+  endpoint no source declared, so after a merge the question is not what is
+  missing but what arrived as an invention. Cross-reference prefixes we never
+  supply (IMG, GOLD, GTDB) are marked expected; everything else is a source
+  referencing something it should declare. See issues #892, #896 and #918.
 - Never assert a METPO term the pinned release has deprecated. A hardcoded CURIE
   keeps being emitted long after the ontology retires it — nothing errors, and
   `METPO:2000511` reached 706,765 edges that way. `tests/test_no_deprecated_metpo_terms.py`

--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
 from kg_microbe.transform_utils.constants import (
+    CATEGORY_COLUMN,
+    NAME_COLUMN,
     NCBITAXON_PREFIX,
     OBJECT_COLUMN,
     PREDICATE_COLUMN,
@@ -117,6 +119,29 @@ def check_merged_invariants(edges_file: Path, output_dir: Optional[Path] = None)
         writer = csv.writer(handle, delimiter="\t")
         writer.writerow(STRAIN_PARENT_REPORT_HEADER)
         writer.writerows(strain_parent_rows(violations))
+    # Derived from the edge file's name so the two reports describe one graph.
+    # Absent is normal: the strain-parent check needs no nodes file, and callers
+    # pointing at an arbitrary edge dump may not have one.
+    nodes_file = edges_file.parent / edges_file.name.replace("_edges.tsv", "_nodes.tsv")
+    stubs = find_stub_nodes(nodes_file) if nodes_file.is_file() else {}
+    if stubs:
+        stub_destination = Path(output_dir or edges_file.parent) / STUB_NODE_REPORT
+        with atomic_write(stub_destination, newline="") as handle:
+            writer = csv.writer(handle, delimiter="\t")
+            writer.writerow(STUB_NODE_REPORT_HEADER)
+            writer.writerows(stub_node_rows(stubs))
+        unexpected = {p: c for p, c in stubs.items() if p not in EXPECTED_STUB_PREFIXES}
+        if unexpected:
+            logger.warning(
+                "[merge-invariants] %s nodes across %s prefixes were invented by KGX for endpoints "
+                "no source declared (%s); listed in %s. A source references them, so it should "
+                "declare them (#918).",
+                f"{sum(len(c) for c in unexpected.values()):,}",
+                len(unexpected),
+                ", ".join(sorted(unexpected)),
+                stub_destination,
+            )
+
     if violations:
         offenders = _sources_of(violations)
         logger.warning(
@@ -143,3 +168,76 @@ def _sources_of(violations: Dict[str, Tuple[Set[str], Set[str]]]) -> List[str]:
     for _, sources in violations.values():
         seen |= sources
     return sorted(seen)
+
+
+#: Written beside the merged TSVs, alongside the strain-parent report.
+STUB_NODE_REPORT = "merged_stub_nodes.tsv"
+
+STUB_NODE_REPORT_HEADER = ["prefix", "count", "expected", "examples"]
+
+#: Prefixes we reference deliberately without ever supplying a node for them.
+#: These are cross-reference identifiers -- a GOLD study id, an IMG genome id, a
+#: GTDB taxon string -- that name a record in someone else's system. We assert
+#: edges to them on purpose and do not ingest those systems as nodes, so a stub is
+#: the correct outcome, not a gap. Everything else is reported (#918).
+EXPECTED_STUB_PREFIXES = {
+    "IMG": "IMG genome and taxon identifiers, referenced from GOLD",
+    "GOLD": "GOLD study, project and biosample identifiers",
+    "GTDB": "GTDB taxon strings, referenced as cross-references",
+}
+
+#: What KGX types a node it invented for an undeclared endpoint.
+NAMED_THING_CATEGORY = "biolink:NamedThing"
+
+
+def find_stub_nodes(nodes_file: Path) -> Dict[str, List[str]]:
+    """
+    Return nodes KGX synthesized because an edge referenced something undeclared.
+
+    The merge leaves no endpoint without a node row -- KGX invents one -- so the
+    question worth asking after a merge is not "what is missing" but "what arrived
+    as an invention". Those rows are typed ``biolink:NamedThing`` and carry no
+    name, which is the shape #892 objected to.
+
+    :param nodes_file: Path to ``merged-kg_nodes.tsv``.
+    :return: ``{CURIE prefix: [CURIEs]}``, sorted, empty when none.
+    """
+    by_prefix: Dict[str, List[str]] = defaultdict(list)
+    with nodes_file.open(encoding="utf-8", errors="replace", newline="") as handle:
+        reader = csv.reader(handle, delimiter="\t")
+        try:
+            header = next(reader)
+        except StopIteration:
+            return {}
+        index: Dict[str, int] = {}
+        for position, name in enumerate(header):
+            index.setdefault(name, position)
+        if CATEGORY_COLUMN not in index or NAME_COLUMN not in index:
+            logger.warning("[merge-invariants] %s lacks category/name; skipping the stub-node check", nodes_file.name)
+            return {}
+        category_at, name_at = index[CATEGORY_COLUMN], index[NAME_COLUMN]
+        for row in reader:
+            if len(row) <= max(category_at, name_at):
+                continue
+            if row[category_at] != NAMED_THING_CATEGORY or row[name_at].strip():
+                continue
+            by_prefix[row[0].split(":", 1)[0]].append(row[0])
+    return {prefix: sorted(curies) for prefix, curies in sorted(by_prefix.items())}
+
+
+def stub_node_rows(stubs: Dict[str, List[str]]) -> List[List]:
+    """
+    Render stub counts per prefix, flagging the ones we did not intend.
+
+    :param stubs: Result of :func:`find_stub_nodes`.
+    :return: Rows matching :data:`STUB_NODE_REPORT_HEADER`.
+    """
+    return [
+        [
+            prefix,
+            len(curies),
+            "yes" if prefix in EXPECTED_STUB_PREFIXES else "no",
+            "|".join(curies[:3]),
+        ]
+        for prefix, curies in sorted(stubs.items(), key=lambda item: (-len(item[1]), item[0]))
+    ]

--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -123,8 +123,12 @@ def check_merged_invariants(edges_file: Path, output_dir: Optional[Path] = None)
     # Absent is normal: the strain-parent check needs no nodes file, and callers
     # pointing at an arbitrary edge dump may not have one.
     nodes_file = edges_file.parent / edges_file.name.replace("_edges.tsv", "_nodes.tsv")
-    stubs = find_stub_nodes(nodes_file) if nodes_file.is_file() else {}
-    if stubs:
+    if nodes_file.is_file():
+        # Written whether or not anything was found, for the same reason the
+        # strain-parent report is (#903, #934): an absent file cannot be told from
+        # a check that never ran, and after a multi-hour merge a demonstrably clean
+        # result is worth more than a saved header row.
+        stubs = find_stub_nodes(nodes_file)
         stub_destination = Path(output_dir or edges_file.parent) / STUB_NODE_REPORT
         with atomic_write(stub_destination, newline="") as handle:
             writer = csv.writer(handle, delimiter="\t")

--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -101,7 +101,11 @@ def strain_parent_rows(violations: Dict[str, Tuple[Set[str], Set[str]]]) -> List
     ]
 
 
-def check_merged_invariants(edges_file: Path, output_dir: Optional[Path] = None) -> int:
+def check_merged_invariants(
+    edges_file: Path,
+    output_dir: Optional[Path] = None,
+    nodes_file: Optional[Path] = None,
+) -> int:
     """
     Run the merged-graph invariants and write their report.
 
@@ -111,6 +115,10 @@ def check_merged_invariants(edges_file: Path, output_dir: Optional[Path] = None)
 
     :param edges_file: Path to ``merged-kg_edges.tsv``.
     :param output_dir: Where to write the report; defaults to the edge file's directory.
+    :param nodes_file: Path to the matching nodes TSV. Defaults to deriving it from
+        the edge file's name, for callers pointing at a bare edge dump -- but the
+        merge hands over the path it already built, because a derivation that fails
+        looks exactly like a graph with no stubs (#936).
     :return: Number of violating strain nodes.
     """
     violations = find_multi_parent_strains(edges_file)
@@ -119,10 +127,10 @@ def check_merged_invariants(edges_file: Path, output_dir: Optional[Path] = None)
         writer = csv.writer(handle, delimiter="\t")
         writer.writerow(STRAIN_PARENT_REPORT_HEADER)
         writer.writerows(strain_parent_rows(violations))
-    # Derived from the edge file's name so the two reports describe one graph.
     # Absent is normal: the strain-parent check needs no nodes file, and callers
     # pointing at an arbitrary edge dump may not have one.
-    nodes_file = edges_file.parent / edges_file.name.replace("_edges.tsv", "_nodes.tsv")
+    if nodes_file is None:
+        nodes_file = edges_file.parent / edges_file.name.replace("_edges.tsv", "_nodes.tsv")
     if nodes_file.is_file():
         # Written whether or not anything was found, for the same reason the
         # strain-parent report is (#903, #934): an absent file cannot be told from

--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -177,7 +177,7 @@ def _sources_of(violations: Dict[str, Tuple[Set[str], Set[str]]]) -> List[str]:
 #: Written beside the merged TSVs, alongside the strain-parent report.
 STUB_NODE_REPORT = "merged_stub_nodes.tsv"
 
-STUB_NODE_REPORT_HEADER = ["prefix", "count", "expected", "examples"]
+STUB_NODE_REPORT_HEADER = ["prefix", "count", "expected", "note", "examples"]
 
 #: Prefixes we reference deliberately without ever supplying a node for them.
 #: These are cross-reference identifiers -- a GOLD study id, an IMG genome id, a
@@ -241,6 +241,11 @@ def stub_node_rows(stubs: Dict[str, List[str]]) -> List[List]:
             prefix,
             len(curies),
             "yes" if prefix in EXPECTED_STUB_PREFIXES else "no",
+            # "Expected" is the claim in this file that most needs justifying: it
+            # separates rows that are fine from rows that are not. The reason is
+            # already written down, so it belongs in the report rather than only
+            # in the source a reader would have to go and find (#935).
+            EXPECTED_STUB_PREFIXES.get(prefix, ""),
             "|".join(curies[:3]),
         ]
         for prefix, curies in sorted(stubs.items(), key=lambda item: (-len(item[1]), item[0]))

--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -226,7 +226,7 @@ def _cleanup_merged_outputs(yaml_file: str) -> None:
             # reporting success. A data-quality report must not be able to
             # decide whether the artifact ships (#914).
             try:
-                check_merged_invariants(edges_file, output_dir)
+                check_merged_invariants(edges_file, output_dir, nodes_file=nodes_file)
             except Exception as exc:  # noqa: BLE001
                 print(f"[merge-invariants] check skipped: {exc}")
 

--- a/tests/test_merged_strain_parent_invariant.py
+++ b/tests/test_merged_strain_parent_invariant.py
@@ -376,3 +376,41 @@ def test_every_expected_prefix_states_a_reason():
 
     unexplained = [p for p, why in EXPECTED_STUB_PREFIXES.items() if not (why or "").strip()]
     assert not unexplained, f"expected without a reason: {unexplained}"
+
+
+def test_the_nodes_path_can_be_passed_rather_than_guessed(tmp_path):
+    """
+    A derivation that fails looks exactly like a graph with no stubs (#936).
+
+    `str.replace` leaves the name untouched when the pattern is absent, so a
+    destination not using the `_edges`/`_nodes` convention would report clean on
+    a graph whose nodes were never opened — reassuring, and wrong.
+    """
+    from kg_microbe.merge_utils.invariants import STUB_NODE_REPORT
+
+    nodes = tmp_path / "oddly-named-nodes.tsv"
+    header = ["id", "category", "name", "description", "xref", "provided_by", "synonym", "deprecated", "same_as"]
+    with nodes.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(header)
+        writer.writerow(_node("X:1", category="biolink:NamedThing", name=""))
+    edges = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-1", "NCBITaxon:5")])
+
+    # Without the path it guesses, finds nothing, and writes no report.
+    check_merged_invariants(edges)
+    assert not (tmp_path / STUB_NODE_REPORT).exists()
+
+    # Given the path it actually reads the file.
+    check_merged_invariants(edges, nodes_file=nodes)
+    body = (tmp_path / STUB_NODE_REPORT).read_text(encoding="utf-8").splitlines()
+    assert any(line.startswith("X\t1\t") for line in body), body
+
+
+def test_the_merge_hands_over_the_path_it_already_built():
+    """The caller computes both paths from one base; discarding one invites the guess."""
+    import inspect
+
+    import kg_microbe.merge_utils.merge_kg as merge_kg
+
+    source = inspect.getsource(merge_kg._cleanup_merged_outputs)
+    assert "check_merged_invariants(edges_file, output_dir, nodes_file=nodes_file)" in source

--- a/tests/test_merged_strain_parent_invariant.py
+++ b/tests/test_merged_strain_parent_invariant.py
@@ -342,3 +342,37 @@ def test_an_absent_nodes_file_writes_no_stub_report(tmp_path):
     edges = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-1", "NCBITaxon:5")])
     check_merged_invariants(edges)
     assert not (tmp_path / STUB_NODE_REPORT).exists()
+
+
+def test_an_expected_prefix_carries_its_justification(tmp_path):
+    """
+    "Expected" is the claim that most needs justifying, so it must not be bare (#935).
+
+    It separates the 49,568 rows that are fine from the 11,422 that are not, and
+    a reader auditing the graph should not have to read the source to learn why.
+    """
+    from kg_microbe.merge_utils.invariants import (
+        EXPECTED_STUB_PREFIXES,
+        find_stub_nodes,
+        stub_node_rows,
+    )
+
+    path = _nodes(
+        tmp_path,
+        [
+            _node("GOLD:Go1", category="biolink:NamedThing", name=""),
+            _node("kgmicrobe.strain:ATCC-1", category="biolink:NamedThing", name=""),
+        ],
+    )
+    rows = {row[0]: (row[2], row[3]) for row in stub_node_rows(find_stub_nodes(path))}
+    assert rows["GOLD"] == ("yes", EXPECTED_STUB_PREFIXES["GOLD"])
+    assert rows["kgmicrobe.strain"][0] == "no"
+    assert rows["kgmicrobe.strain"][1] == ""
+
+
+def test_every_expected_prefix_states_a_reason():
+    """A prefix allowlisted without a justification is silently exempted."""
+    from kg_microbe.merge_utils.invariants import EXPECTED_STUB_PREFIXES
+
+    unexplained = [p for p, why in EXPECTED_STUB_PREFIXES.items() if not (why or "").strip()]
+    assert not unexplained, f"expected without a reason: {unexplained}"

--- a/tests/test_merged_strain_parent_invariant.py
+++ b/tests/test_merged_strain_parent_invariant.py
@@ -196,3 +196,117 @@ def test_a_duplicated_column_name_does_not_hide_violations(tmp_path):
     )
     found = find_multi_parent_strains(path)
     assert set(found) == {"kgmicrobe.strain:ATCC-13722"}, "a duplicated header hid a real violation"
+
+
+def _nodes(tmp_path, rows):
+    header = ["id", "category", "name", "description", "xref", "provided_by", "synonym", "deprecated", "same_as"]
+    path = tmp_path / "merged-kg_nodes.tsv"
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(header)
+        writer.writerows(rows)
+    return path
+
+
+def _node(curie, category="biolink:OrganismTaxon", name="a name"):
+    return [curie, category, name, "", "", "infores:x", "", "", ""]
+
+
+def test_a_named_node_is_not_a_stub(tmp_path):
+    """Only nodes KGX invented are of interest; real ones are the whole graph."""
+    from kg_microbe.merge_utils.invariants import find_stub_nodes
+
+    path = _nodes(tmp_path, [_node("NCBITaxon:562")])
+    assert find_stub_nodes(path) == {}
+
+
+def test_a_namedthing_with_no_name_is_a_stub(tmp_path):
+    """
+    That is what KGX writes for an endpoint no source declared.
+
+    It is the shape #892 objected to: an entity with an id, no type worth the
+    name, and no label.
+    """
+    from kg_microbe.merge_utils.invariants import find_stub_nodes
+
+    path = _nodes(tmp_path, [_node("NCBITaxon:999", category="biolink:NamedThing", name="")])
+    assert find_stub_nodes(path) == {"NCBITaxon": ["NCBITaxon:999"]}
+
+
+def test_a_namedthing_that_carries_a_name_is_not_a_stub(tmp_path):
+    """
+    `biolink:NamedThing` is a legitimate category for a node someone declared.
+
+    Flagging on category alone would report real nodes as inventions.
+    """
+    from kg_microbe.merge_utils.invariants import find_stub_nodes
+
+    path = _nodes(tmp_path, [_node("X:1", category="biolink:NamedThing", name="declared")])
+    assert find_stub_nodes(path) == {}
+
+
+def test_cross_reference_prefixes_are_marked_expected(tmp_path):
+    """
+    A GOLD study id names a record in someone else's system.
+
+    We assert edges to those on purpose and never ingest them as nodes, so a
+    stub is correct. Reporting them as problems would bury the 19% that are not
+    — 49,568 of the 60,990 stubs in `merged/20260815` are of this kind.
+    """
+    from kg_microbe.merge_utils.invariants import find_stub_nodes, stub_node_rows
+
+    path = _nodes(
+        tmp_path,
+        [
+            _node("GOLD:Go0022271", category="biolink:NamedThing", name=""),
+            _node("kgmicrobe.strain:ATCC-1", category="biolink:NamedThing", name=""),
+        ],
+    )
+    rows = {row[0]: row[2] for row in stub_node_rows(find_stub_nodes(path))}
+    assert rows == {"GOLD": "yes", "kgmicrobe.strain": "no"}
+
+
+def test_our_own_namespace_is_never_expected(tmp_path):
+    """
+    A `kgmicrobe.*` stub means we referenced something we did not declare.
+
+    That can never be someone else's system, so it must not be allowlisted —
+    all 4,233 in `merged/20260815` come from LPSN alone (#932).
+    """
+    from kg_microbe.merge_utils.invariants import EXPECTED_STUB_PREFIXES
+
+    assert not [p for p in EXPECTED_STUB_PREFIXES if p.startswith("kgmicrobe")]
+
+
+def test_stub_rows_lead_with_the_largest_prefix(tmp_path):
+    """A report nobody can skim is a report nobody reads."""
+    from kg_microbe.merge_utils.invariants import find_stub_nodes, stub_node_rows
+
+    path = _nodes(
+        tmp_path,
+        [_node("A:1", category="biolink:NamedThing", name="")]
+        + [_node(f"B:{i}", category="biolink:NamedThing", name="") for i in range(3)],
+    )
+    rows = stub_node_rows(find_stub_nodes(path))
+    assert [row[0] for row in rows] == ["B", "A"]
+
+
+def test_a_nodes_file_without_the_expected_columns_is_skipped_not_crashed(tmp_path):
+    """A merge that took hours must not die on an unexpected header."""
+    from kg_microbe.merge_utils.invariants import find_stub_nodes
+
+    path = tmp_path / "merged-kg_nodes.tsv"
+    path.write_text("something\telse\nx\ty\n", encoding="utf-8")
+    assert find_stub_nodes(path) == {}
+
+
+def test_an_absent_nodes_file_does_not_break_the_edge_checks(tmp_path):
+    """
+    The strain-parent check needs no nodes file, and callers may point at any edge dump.
+
+    Failing here would make the stub check able to break the check beside it —
+    the coupling #914 was filed about.
+    """
+    path = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-1", "NCBITaxon:5")])
+    assert check_merged_invariants(path) == 0
+    assert (tmp_path / STRAIN_PARENT_REPORT).is_file()

--- a/tests/test_merged_strain_parent_invariant.py
+++ b/tests/test_merged_strain_parent_invariant.py
@@ -310,3 +310,35 @@ def test_an_absent_nodes_file_does_not_break_the_edge_checks(tmp_path):
     path = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-1", "NCBITaxon:5")])
     assert check_merged_invariants(path) == 0
     assert (tmp_path / STRAIN_PARENT_REPORT).is_file()
+
+
+def test_a_graph_with_no_stubs_still_writes_the_stub_report(tmp_path):
+    """
+    An absent report cannot be told from a check that never ran (#934).
+
+    Same reasoning as the strain-parent report, which this one sat beside while
+    behaving differently — a reader who learns one is always present will
+    reasonably assume the same of the other.
+    """
+    from kg_microbe.merge_utils.invariants import STUB_NODE_REPORT, STUB_NODE_REPORT_HEADER
+
+    _nodes(tmp_path, [_node("NCBITaxon:562")])
+    edges = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-1", "NCBITaxon:562")])
+    check_merged_invariants(edges)
+    report = tmp_path / STUB_NODE_REPORT
+    assert report.is_file()
+    assert report.read_text(encoding="utf-8").splitlines() == ["\t".join(STUB_NODE_REPORT_HEADER)]
+
+
+def test_an_absent_nodes_file_writes_no_stub_report(tmp_path):
+    """
+    Not being able to check is not a clean result.
+
+    Writing an empty report there would claim zero stubs on a graph whose nodes
+    were never read.
+    """
+    from kg_microbe.merge_utils.invariants import STUB_NODE_REPORT
+
+    edges = _edges(tmp_path, [_row("kgmicrobe.strain:DSM-1", "NCBITaxon:5")])
+    check_merged_invariants(edges)
+    assert not (tmp_path / STUB_NODE_REPORT).exists()


### PR DESCRIPTION
Closes #918

## Sizing changed the question

#918 asked for a check on "edge targets with no node row", and asked for it to be sized first, since a merged graph legitimately references CURIEs from ontologies we do not ingest whole. Sized against `merged/20260815`:

```
merged nodes: 2,852,793
merged edges: 14,664,554
endpoint references with no node row: 0
```

**Zero.** KGX leaves no endpoint undeclared — it invents a node instead. So the question worth asking after a merge is not what is missing, but what arrived as an invention:

```
nodes typed biolink:NamedThing with no name: 60,990  across 15 prefixes
```

That is the shape #892 objected to — an id, a category worth nothing, no label.

## The split is what makes it usable

```
prefix                count   expected
IMG                  18,374   yes
GTDB                 15,609   yes
GOLD                 15,585   yes
lpsn                  6,586   no
kgmicrobe.strain      4,233   no
NCBITaxon               486   no
GO                       66   no
UBERON                   33   no
FOODON                    9   no
...
expected:    49,568
unexpected:  11,422  across 12 prefixes
```

`IMG`, `GOLD` and `GTDB` are cross-reference identifiers naming records in someone else's system. We assert edges to them deliberately and never ingest those systems as nodes, so a stub is the correct outcome. They are 81% of the total — without the split, the actionable 19% is buried under them, which is exactly the "mostly noise" risk #918 raised.

What is left is sources referencing things they should declare:

- **lpsn 6,586** — multi-source; `infores:faprotax` accounts for 21,164 of the touching edges;
- **kgmicrobe.strain 4,233** — our own namespace, **all** from LPSN alone. Filed as **#932**: LPSN emits `close_match` to deposit CURIEs it never writes a node for, the mirror of #894;
- **NCBITaxon 486** — the #895 family, at merge scale.

## Notes

Written atomically beside the strain-parent report. The nodes file is derived from the edge file's name so both reports describe one graph, and an absent nodes file is tolerated rather than fatal — the strain-parent check needs none, and letting the stub check break the check beside it is the coupling #914 was filed about.

The `kgmicrobe.*` prefix can never be allowlisted as expected, since a stub in our own namespace can never be someone else's system. There is a test asserting that.

## Tests

18 in the file, 8 new. The ones that matter are the discriminations:

- a `biolink:NamedThing` that **carries a name** is not a stub — flagging on category alone would report real nodes as inventions;
- cross-reference prefixes are marked expected while `kgmicrobe.strain` is not;
- rows lead with the largest prefix, because a report nobody can skim is a report nobody reads;
- an unexpected header is skipped, not crashed.

`tox` green apart from the two failures that also fail on master.