### PR TITLE
Put scripts/ in the lint gate, and make convergence visible (#948, #950)

### DIFF
--- a/mappings/README.md
+++ b/mappings/README.md
@@ -105,8 +105,16 @@ Note that step 1 seeds from the script's own previous output, so the artifact is
 not a pure function of its inputs: a run can derive names that the previous run
 created, and re-running immediately may add a handful of rows. This converges
 rather than growing without bound — in the #947 refresh, run 2 added 2 rows over
-run 1 and run 3 was byte-identical to run 2. If you need the fixed point, run
-until the output hash stops changing; `md5 mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz`
+run 1 and run 3 was byte-identical to run 2.
+
+**The run now tells you which state you are in** (#948). It ends with either
+`Converged: identical to the seed (N triples). This is the fixed point.` or
+`Not yet converged: N added, M removed ... re-run to reach the fixed point
+before committing.` Before that, regenerating to check a committed artifact
+produced a non-empty diff that looked exactly like non-determinism, and nothing
+said whether what had been committed was the fixed point or one step short.
+
+If you need the fixed point, run until the message says converged; `md5 mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz`
 is now a valid way to check that, and was not before (#953).
 
 Everything else in the artifact is a pure function of its inputs. Each row keeps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,16 +114,28 @@ select = [
 "kg_microbe/query_utils/*" = ["S608"]  # DuckDB queries use database CURIEs, not user input
 # scripts/ entered the lint gate with 405 findings (#950). The three that could
 # bite were fixed outright -- two undefined names and an f-string that was a
-# SyntaxError on 3.10 and 3.11 -- and 274 more were auto-fixed. What is left is
-# style and bandit noise on local analysis scripts, grandfathered per rule so
-# the gate protects against new findings today rather than after a cleanup that
-# may never happen. Burn these down in place; do not add to the list.
-"scripts/*" = [
-    "B023",  # closures over loop variables, each called inside the same iteration
-    "D100", "D103", "D205", "D400", "D401", "D415",  # docstring style
-    "E501", "E701", "E702",  # long lines, compound statements
-    "S108", "S110", "S311", "S603", "S607",  # bandit: /tmp paths, subprocess, random
-]
+# SyntaxError on 3.10 and 3.11 -- and 274 more were auto-fixed. What remains is
+# style and bandit noise, grandfathered PER FILE rather than for the directory:
+# the other 18 scripts are already clean and stay strict, and so does every new
+# one (#968). Each entry disappears when its file is cleaned; do not add to the
+# list, and `tests/test_scripts_lint_debt.py` fails if an entry stops firing.
+"scripts/analyze_custom_metpo_mappings.py" = ["D401", "E501"]
+"scripts/analyze_gtdb_metatraits_overlap.py" = ["D401", "E501"]
+"scripts/consolidate_chemical_mappings.py" = ["B023", "D205", "D401", "E501", "S110", "S603", "S607"]
+"scripts/download_kegg_bulk.py" = ["D401"]
+"scripts/download_kegg_minimal.py" = ["D401"]
+"scripts/examples/visualization/create_1hop_full_labels.py" = ["D100", "D400", "D415", "E501"]
+"scripts/examples/visualization/create_1hop_subgraph.py" = ["D100", "D103", "D400", "D415", "E501"]
+"scripts/examples/visualization/create_2hop_full_labels.py" = ["D100", "D400", "D415"]
+"scripts/examples/visualization/create_full_label_visualizations.py" = ["D100", "D103", "D400", "D415", "E501"]
+"scripts/extract_metpo_proposals.py" = ["E501", "S603", "S607"]
+"scripts/mediadive_coverage_check.py" = ["E501"]
+"scripts/prego_validation/build_assay_gold.py" = ["S108"]
+"scripts/prego_validation/build_uniprot_gold.py" = ["D103", "E701", "E702", "S108"]
+"scripts/prego_validation/fold_enrichment_go.py" = ["E701", "E702", "S108"]
+"scripts/prego_validation/precision_assay_go.py" = ["D400", "E701", "E702", "S108"]
+"scripts/prego_validation/predicate_interaction.py" = ["D400", "E501", "S108", "S311"]
+"scripts/validate_knowledge_sources.py" = ["E501"]
 
 [tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,18 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]  # Allow assert in test files
 "kg_microbe/query_utils/*" = ["S608"]  # DuckDB queries use database CURIEs, not user input
+# scripts/ entered the lint gate with 405 findings (#950). The three that could
+# bite were fixed outright -- two undefined names and an f-string that was a
+# SyntaxError on 3.10 and 3.11 -- and 274 more were auto-fixed. What is left is
+# style and bandit noise on local analysis scripts, grandfathered per rule so
+# the gate protects against new findings today rather than after a cleanup that
+# may never happen. Burn these down in place; do not add to the list.
+"scripts/*" = [
+    "B023",  # closures over loop variables, each called inside the same iteration
+    "D100", "D103", "D205", "D400", "D401", "D415",  # docstring style
+    "E501", "E701", "E702",  # long lines, compound statements
+    "S108", "S110", "S311", "S603", "S607",  # bandit: /tmp paths, subprocess, random
+]
 
 [tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/scripts/analyze_custom_metpo_mappings.py
+++ b/scripts/analyze_custom_metpo_mappings.py
@@ -11,9 +11,8 @@ This script:
 """
 
 import csv
-import re
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Tuple
 
 import requests
 

--- a/scripts/analyze_gtdb_metatraits_overlap.py
+++ b/scripts/analyze_gtdb_metatraits_overlap.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Analyze overlap between GTDB and NCBITaxon metatraits data.
+"""
+Analyze overlap between GTDB and NCBITaxon metatraits data.
 
 This script determines how much new coverage GTDB metatraits would provide
 compared to existing NCBITaxon metatraits data in the knowledge graph.
@@ -13,13 +14,15 @@ from typing import Dict, Set
 
 
 def load_ncbi_taxa_with_traits(edges_file: Path) -> Set[str]:
-    """Load NCBITaxon IDs that already have trait data.
+    """
+    Load NCBITaxon IDs that already have trait data.
 
     Args:
         edges_file: Path to metatraits edges.tsv file
 
     Returns:
         Set of NCBITaxon IDs (e.g., 'NCBITaxon:562')
+
     """
     taxa_with_traits = set()
 
@@ -41,13 +44,15 @@ def load_ncbi_taxa_with_traits(edges_file: Path) -> Set[str]:
 
 
 def load_gtdb_taxa_with_traits(data_dir: Path) -> Dict[str, dict]:
-    """Load GTDB taxa that have trait data.
+    """
+    Load GTDB taxa that have trait data.
 
     Args:
         data_dir: Path to data/raw/ directory
 
     Returns:
         Dict mapping GTDB tax_name to trait summary stats
+
     """
     gtdb_taxa = {}
 
@@ -79,13 +84,15 @@ def load_gtdb_taxa_with_traits(data_dir: Path) -> Dict[str, dict]:
 
 
 def load_gtdb_to_ncbi_mapping(gtdb_dir: Path) -> Dict[str, Set[str]]:
-    """Load GTDB to NCBITaxon mapping from GTDB metadata files.
+    """
+    Load GTDB to NCBITaxon mapping from GTDB metadata files.
 
     Args:
         gtdb_dir: Path to directory containing GTDB metadata files
 
     Returns:
         Dict mapping GTDB species name to set of NCBITaxon IDs
+
     """
     mapping = defaultdict(set)
 
@@ -135,7 +142,8 @@ def analyze_overlap(
     gtdb_to_ncbi: Dict[str, Set[str]],
     ncbi_taxa_with_traits: Set[str]
 ) -> Dict:
-    """Analyze overlap between GTDB and NCBITaxon metatraits.
+    """
+    Analyze overlap between GTDB and NCBITaxon metatraits.
 
     Args:
         gtdb_taxa: GTDB taxa with trait data
@@ -144,6 +152,7 @@ def analyze_overlap(
 
     Returns:
         Dict with analysis results
+
     """
     redundant_taxa = set()
     new_coverage_taxa = set()
@@ -193,11 +202,13 @@ def analyze_overlap(
 
 
 def print_report(results: Dict, ncbi_taxa_count: int):
-    """Print overlap analysis report.
+    """
+    Print overlap analysis report.
 
     Args:
         results: Analysis results dict
         ncbi_taxa_count: Number of NCBITaxon taxa with existing traits
+
     """
     print("\n" + "="*70)
     print("GTDB MetaTraits Overlap Analysis")
@@ -213,15 +224,15 @@ def print_report(results: Dict, ncbi_taxa_count: int):
 
     total = results['total_taxa']
 
-    print(f"\n1. Redundant (NCBITaxon already has traits):")
+    print("\n1. Redundant (NCBITaxon already has traits):")
     print(f"   Taxa: {results['redundant_taxa']:,} ({results['redundant_taxa']/total*100:.1f}%)")
     print(f"   Observations: {results['redundant_obs']:,} ({results['redundant_obs']/results['total_observations']*100:.1f}%)")
 
-    print(f"\n2. New coverage (NCBITaxon exists, no traits):")
+    print("\n2. New coverage (NCBITaxon exists, no traits):")
     print(f"   Taxa: {results['new_coverage_taxa']:,} ({results['new_coverage_taxa']/total*100:.1f}%)")
     print(f"   Observations: {results['new_coverage_obs']:,} ({results['new_coverage_obs']/results['total_observations']*100:.1f}%)")
 
-    print(f"\n3. GTDB-only (no NCBITaxon mapping):")
+    print("\n3. GTDB-only (no NCBITaxon mapping):")
     print(f"   Taxa: {results['gtdb_only_taxa']:,} ({results['gtdb_only_taxa']/total*100:.1f}%)")
     print(f"   Observations: {results['gtdb_only_obs']:,} ({results['gtdb_only_obs']/results['total_observations']*100:.1f}%)")
 

--- a/scripts/consolidate_chemical_mappings.py
+++ b/scripts/consolidate_chemical_mappings.py
@@ -368,17 +368,29 @@ def _sssom_triples(path: Path) -> set:
     return triples
 
 
-def _report_export_delta(candidate: Path, published: Path) -> None:
+def _report_export_delta(candidate: Path, published: Path, before=None) -> None:
     """
     Print what promoting ``candidate`` over ``published`` would change.
 
     A row count alone hides the shape of a change: the refresh that prompted
-    this preview was +1,812 net, which was 2,091 added against 279 removed.
+    this preview was +1,814 net, which was 2,093 added against 279 removed.
+
+    ``before`` is the caller's already-parsed view of ``published``. Re-reading
+    it here made a preview decompress and parse 609,975 rows twice for a value
+    it had in hand, and left room for the two reports to disagree about what the
+    seed was (#969).
+
+    :param candidate: The artifact just written to a scratch path.
+    :param published: The artifact it would replace.
+    :param before: Triples already read from ``published``, if the caller has them.
+    :return: None.
     """
     if not published.exists():
         print(f"[dry-run] no published artifact at {published}; would create it")
         return
-    before, after = _sssom_triples(published), _sssom_triples(candidate)
+    if before is None:
+        before = _sssom_triples(published)
+    after = _sssom_triples(candidate)
     added, removed = after - before, before - after
     print(f"\n[dry-run] would write {candidate.name} over {published}")
     print(f"  triples   {len(before):,} -> {len(after):,}  ({len(after) - len(before):+,})")
@@ -2893,6 +2905,9 @@ def main(argv=None):
     sssom_output_path = base_dir / "mappings" / "kgmicrobe_unified_entity_mappings.sssom.tsv.gz"
     # Read before anything can overwrite it: the export writes in place, so this
     # is the only chance to compare the result against what seeded it (#948).
+    # The preview and the apply share this one read, so they cannot disagree
+    # about what the seed was -- and the preview no longer parses 609,975 rows
+    # twice to throw one copy away (#969).
     seed_triples = _sssom_triples(sssom_output_path) if sssom_output_path.exists() else None
 
     # Seed from the existing unified SSSOM (single source of truth). Each
@@ -3022,7 +3037,7 @@ def main(argv=None):
             # mapping dates live -- without this the preview would restamp
             # every row and report a delta the apply would never produce.
             consolidator.export_unified_sssom(candidate, published_path=sssom_output_path)
-            _report_export_delta(candidate, sssom_output_path)
+            _report_export_delta(candidate, sssom_output_path, before=seed_triples)
         return
 
     consolidator.export_unified_sssom(sssom_output_path)

--- a/scripts/consolidate_chemical_mappings.py
+++ b/scripts/consolidate_chemical_mappings.py
@@ -73,7 +73,7 @@ import shutil
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 import pandas as pd
 
@@ -336,7 +336,7 @@ def published_mapping_dates(path: Path) -> Dict[tuple, str]:
                 if header is None:
                     header = parts
                     continue
-                row = dict(zip(header, parts))
+                row = dict(zip(header, parts, strict=False))
                 recorded = (row.get("mapping_date") or "").strip()
                 if not _ISO_DATE.fullmatch(recorded):
                     continue
@@ -363,13 +363,14 @@ def _sssom_triples(path: Path) -> set:
             if header is None:
                 header = parts
                 continue
-            row = dict(zip(header, parts))
+            row = dict(zip(header, parts, strict=False))
             triples.add((row.get("subject_id"), row.get("predicate_id"), row.get("object_id")))
     return triples
 
 
 def _report_export_delta(candidate: Path, published: Path) -> None:
-    """Print what promoting ``candidate`` over ``published`` would change.
+    """
+    Print what promoting ``candidate`` over ``published`` would change.
 
     A row count alone hides the shape of a change: the refresh that prompted
     this preview was +1,812 net, which was 2,091 added against 279 removed.
@@ -387,6 +388,41 @@ def _report_export_delta(candidate: Path, published: Path) -> None:
         for subject, predicate, obj in list(sample)[:5]:
             print(f"    {label[:1]} {subject}  {predicate}  {obj}")
     print("  Nothing was written. Re-run without --dry-run to apply.")
+
+
+def _report_convergence(seed_triples, written: Path) -> None:
+    """
+    Say whether the run reached the fixed point, or how far it moved.
+
+    ``main()`` seeds from this script's own previous output, so run *N*'s input
+    includes run *N-1*'s output: a name one run derives can seed another row on
+    the next. The artifact therefore depends on how many times the script has
+    been run, not only on the source data (#948).
+
+    The seeding is load-bearing -- it is how the absent legacy priority-1/2
+    inputs survive their own absence -- so this reports the property rather than
+    removing it. Without the report, a reviewer regenerating to check the
+    committed artifact sees a non-empty diff that looks exactly like
+    non-determinism, and nothing says whether what was committed is the fixed
+    point or one step short.
+
+    :param seed_triples: Triples read before the export, or None on a first run.
+    :param written: The artifact just written.
+    :return: None.
+    """
+    if seed_triples is None:
+        print("\n  First run: no previous artifact to converge against.")
+        return
+    after = _sssom_triples(written)
+    added, removed = after - seed_triples, seed_triples - after
+    if not added and not removed:
+        print(f"\n  Converged: identical to the seed ({len(after):,} triples). This is the fixed point.")
+        return
+    print(
+        f"\n  Not yet converged: {len(added):,} added, {len(removed):,} removed "
+        f"({len(seed_triples):,} -> {len(after):,}). The seeding is intentional, but the "
+        "output is one step ahead of its input -- re-run to reach the fixed point before committing."
+    )
 
 
 def _sync_vendored_from_sibling(
@@ -1843,12 +1879,11 @@ class ChemicalMappingConsolidator:
         added = 0
         with _gzip.open(filepath, "rt", encoding="utf-8") as f:
             header = f.readline().rstrip("\n").split("\t")
-            col = {name: i for i, name in enumerate(header)}
             for raw in f:
                 parts = raw.rstrip("\n").split("\t")
                 if len(parts) < len(header):
                     parts += [""] * (len(header) - len(parts))
-                row = dict(zip(header, parts))
+                row = dict(zip(header, parts, strict=False))
                 primary = (row.get("id") or "").strip()
                 if not primary or not is_accepted_primary(primary):
                     continue
@@ -2856,6 +2891,9 @@ def main(argv=None):
     consolidator = ChemicalMappingConsolidator()
 
     sssom_output_path = base_dir / "mappings" / "kgmicrobe_unified_entity_mappings.sssom.tsv.gz"
+    # Read before anything can overwrite it: the export writes in place, so this
+    # is the only chance to compare the result against what seeded it (#948).
+    seed_triples = _sssom_triples(sssom_output_path) if sssom_output_path.exists() else None
 
     # Seed from the existing unified SSSOM (single source of truth). Each
     # row's sources contribute to the accumulated per-entity source set;
@@ -2988,6 +3026,7 @@ def main(argv=None):
         return
 
     consolidator.export_unified_sssom(sssom_output_path)
+    _report_convergence(seed_triples, sssom_output_path)
 
     print(f"\n✓ Unified SSSOM created: {sssom_output_path}")
     print(f"  To inspect: gunzip -c {sssom_output_path.name} | head")

--- a/scripts/create_test_bacdive.py
+++ b/scripts/create_test_bacdive.py
@@ -128,7 +128,7 @@ def main():
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    print(f"Test dataset locations:")
+    print("Test dataset locations:")
     print(f"  TSV/YAML: {TEST_DIR}")
     print(f"  JSON: {TEST_RAW_DIR / 'bacdive_strains.json'}")
     print(f"\nNumber of taxa: {N_TAXA}")
@@ -137,7 +137,7 @@ def main():
     print(f"JSON records: {len(test_records) if 'test_records' in locals() else 'N/A'}")
     print("\nTo run transform on test data:")
     print(f"  cp {TEST_RAW_DIR / 'bacdive_strains.json'} data/raw/bacdive_strains_test.json")
-    print(f"  # Modify BacDive transform to read from bacdive_strains_test.json")
+    print("  # Modify BacDive transform to read from bacdive_strains_test.json")
     print("=" * 60)
 
 

--- a/scripts/dump_unmapped_microbedecoder_labels.py
+++ b/scripts/dump_unmapped_microbedecoder_labels.py
@@ -1,4 +1,5 @@
-r"""Dump MicrobeDecoder unmapped labels as a tracked curation queue.
+r"""
+Dump MicrobeDecoder unmapped labels as a tracked curation queue.
 
 Reads the per-run ``data/transformed/microbedecoder/unmapped_labels.tsv``
 that ``MicrobeDecoderTransform`` emits and writes a *tracked* curation

--- a/scripts/examples/visualization/create_1hop_full_labels.py
+++ b/scripts/examples/visualization/create_1hop_full_labels.py
@@ -1,46 +1,48 @@
 #!/usr/bin/env python3
-import os
-import pandas as pd
-import networkx as nx
-import matplotlib.pyplot as plt
 import math
+import os
+
+import matplotlib.pyplot as plt
+import networkx as nx
+import pandas as pd
+
 from config import CATEGORY_COLORS
+
 
 def create_1hop_full_labels():
     """Create 1-hop visualization with full node labels"""
-
     # Get script directory for relative paths
     script_dir = os.path.dirname(os.path.abspath(__file__))
 
     # Load data
     nodes_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_1hop_subgraph_nodes.csv'))
     edges_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_1hop_subgraph_edges.csv'))
-    
+
     center_id = "NCBITaxon:1718"
-    
+
     # Create NetworkX graph
     G = nx.Graph()
-    
+
     # Add nodes
     for _, node in nodes_df.iterrows():
-        G.add_node(node['id'], 
-                  name=node['name'], 
-                  category=node['category'], 
+        G.add_node(node['id'],
+                  name=node['name'],
+                  category=node['category'],
                   hop=node['hop'])
-    
+
     # Add edges
     for _, edge in edges_df.iterrows():
         if edge['subject'] in G.nodes and edge['object'] in G.nodes:
             G.add_edge(edge['subject'], edge['object'])
-    
+
     # Create layout optimized for 1-hop with multiple rings
     pos = {}
     center_pos = (0, 0)
     pos[center_id] = center_pos
-    
+
     # Get neighbors and organize them by category for better layout
     neighbors = [n for n in G.nodes() if G.nodes[n]['hop'] == 1]
-    
+
     # Organize neighbors by category
     category_groups = {}
     for neighbor in neighbors:
@@ -49,21 +51,21 @@ def create_1hop_full_labels():
         if primary_category not in category_groups:
             category_groups[primary_category] = []
         category_groups[primary_category].append(neighbor)
-    
+
     # Arrange in concentric rings by category
     radius_start = 6
     radius_increment = 3
     current_radius = radius_start
-    
-    for category, nodes_in_category in category_groups.items():
+
+    for nodes_in_category in category_groups.values():
         nodes_count = len(nodes_in_category)
-        
+
         for i, neighbor in enumerate(nodes_in_category):
             angle = 2 * math.pi * i / nodes_count
             pos[neighbor] = (current_radius * math.cos(angle), current_radius * math.sin(angle))
-        
+
         current_radius += radius_increment
-    
+
     # Create very large figure to accommodate full labels
     plt.figure(figsize=(40, 40))
 
@@ -73,71 +75,71 @@ def create_1hop_full_labels():
     # Draw center node
     center_categories = str(G.nodes[center_id]['category']).split('|') if G.nodes[center_id]['category'] else ['unknown']
     center_color = category_colors.get(center_categories[0], '#CCCCCC')
-    
-    nx.draw_networkx_nodes(G, pos, nodelist=[center_id], 
-                          node_color=[center_color], 
+
+    nx.draw_networkx_nodes(G, pos, nodelist=[center_id],
+                          node_color=[center_color],
                           node_size=[12000],
                           alpha=0.9,
                           edgecolors='black',
                           linewidths=4)
-    
+
     # Draw 1-hop neighbors by category
     for category, nodes_in_category in category_groups.items():
         color = category_colors.get(category, '#CCCCCC')
-        nx.draw_networkx_nodes(G, pos, nodelist=nodes_in_category, 
-                              node_color=[color] * len(nodes_in_category), 
+        nx.draw_networkx_nodes(G, pos, nodelist=nodes_in_category,
+                              node_color=[color] * len(nodes_in_category),
                               node_size=[6000] * len(nodes_in_category),
                               alpha=0.8,
                               edgecolors='black',
                               linewidths=2)
-    
+
     # Draw edges with different styles
     nx.draw_networkx_edges(G, pos, alpha=0.4, width=3, edge_color='gray')
-    
+
     # Create FULL labels for ALL nodes - no truncation at all
     labels = {}
-    
+
     # Center node label
     center_name = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
     labels[center_id] = center_name
-    
+
     # ALL 1-hop neighbors with COMPLETELY FULL names
     for neighbor in neighbors:
         name = str(G.nodes[neighbor]['name']) if G.nodes[neighbor]['name'] else neighbor
         # Show the COMPLETE name with no truncation whatsoever
         labels[neighbor] = name
-    
+
     # Draw labels with enhanced formatting
-    nx.draw_networkx_labels(G, pos, labels, font_size=10, font_weight='bold', 
-                           font_color='black', 
-                           bbox=dict(boxstyle='round,pad=0.5', 
+    nx.draw_networkx_labels(G, pos, labels, font_size=10, font_weight='bold',
+                           font_color='black',
+                           bbox=dict(boxstyle='round,pad=0.5',
                            facecolor='white', alpha=0.95, edgecolor='gray', linewidth=1))
-    
+
     # Add title
-    plt.title(f'1-Hop Subgraph: {center_name} - COMPLETE FULL LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)', 
+    plt.title(f'1-Hop Subgraph: {center_name} - COMPLETE FULL LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)',
               fontsize=28, fontweight='bold', pad=80)
-    
+
     # Add comprehensive legend
     legend_elements = []
     for category, color in category_colors.items():
         if category in category_groups:
             count = len(category_groups[category])
-            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                            markerfacecolor=color, markersize=18, 
+            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                            markerfacecolor=color, markersize=18,
                                             label=f'{category.replace("biolink:", "")} ({count})'))
-    
+
     # Add hop legend
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=25, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=25,
                                     label='Center (Corynebacterium glutamicum)'))
-    
-    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1), 
-              fontsize=16, frameon=True, fancybox=True, shadow=True, 
+
+    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1),
+              fontsize=16, frameon=True, fancybox=True, shadow=True,
               title='Node Categories', title_fontsize=18)
-    
+
     # Remove axes
     plt.axis('off')
-    
+
     # Adjust layout and save
     plt.tight_layout()
     output_file = os.path.join(script_dir, 'corynebacterium_glutamicum_1hop_subgraph_full_labels.png')

--- a/scripts/examples/visualization/create_1hop_subgraph.py
+++ b/scripts/examples/visualization/create_1hop_subgraph.py
@@ -1,35 +1,37 @@
 #!/usr/bin/env python3
+import argparse
+import json
 import os
 import sys
-import argparse
-import pandas as pd
-import networkx as nx
+
 import matplotlib.pyplot as plt
-import json
+import networkx as nx
+import pandas as pd
+
 from config import CATEGORY_COLORS
+
 
 def load_data(nodes_file, edges_file):
     """Load nodes and edges from TSV files"""
     print("Loading nodes...")
     nodes_df = pd.read_csv(nodes_file, sep='\t', low_memory=False)
-    
+
     print("Loading edges...")
     edges_df = pd.read_csv(edges_file, sep='\t', low_memory=False)
-    
+
     return nodes_df, edges_df
 
 def find_1hop_subgraph(nodes_df, edges_df, center_id):
     """Find 1-hop subgraph around center node"""
-    
     # Find center node
     center_node = nodes_df[nodes_df['id'] == center_id]
     if center_node.empty:
         print(f"Center node {center_id} not found")
         return None, None
-    
+
     # Get all edges involving the center node
     center_edges = edges_df[(edges_df['subject'] == center_id) | (edges_df['object'] == center_id)]
-    
+
     # Get 1-hop neighbors
     hop1_ids = set()
     for _, edge in center_edges.iterrows():
@@ -37,50 +39,49 @@ def find_1hop_subgraph(nodes_df, edges_df, center_id):
             hop1_ids.add(edge['object'])
         else:
             hop1_ids.add(edge['subject'])
-    
+
     print(f"Found {len(hop1_ids)} 1-hop neighbors")
-    
+
     # Get all relevant node IDs
     all_node_ids = {center_id} | hop1_ids
-    
+
     # Get subgraph nodes
     subgraph_nodes = nodes_df[nodes_df['id'].isin(all_node_ids)].copy()
-    
+
     # Add hop information
     subgraph_nodes.loc[subgraph_nodes['id'] == center_id, 'hop'] = 0
     subgraph_nodes.loc[subgraph_nodes['id'].isin(hop1_ids), 'hop'] = 1
-    
+
     # Get subgraph edges (only direct connections to center)
     subgraph_edges = center_edges.copy()
-    
+
     print(f"1-hop Subgraph: {len(subgraph_nodes)} nodes, {len(subgraph_edges)} edges")
-    
+
     return subgraph_nodes, subgraph_edges
 
 def create_1hop_visualization(nodes_df, edges_df, center_id, output_file):
     """Create 1-hop network visualization with comprehensive labels"""
-    
     # Create NetworkX graph
     G = nx.Graph()
-    
+
     # Add nodes
     for _, node in nodes_df.iterrows():
-        G.add_node(node['id'], 
-                  name=node['name'], 
-                  category=node['category'], 
+        G.add_node(node['id'],
+                  name=node['name'],
+                  category=node['category'],
                   hop=node['hop'])
-    
+
     # Add edges
     for _, edge in edges_df.iterrows():
         if edge['subject'] in G.nodes and edge['object'] in G.nodes:
-            G.add_edge(edge['subject'], edge['object'], 
+            G.add_edge(edge['subject'], edge['object'],
                       predicate=edge['predicate'])
-    
+
     # Create layout optimized for 1-hop (star pattern)
     pos = {}
     center_pos = (0, 0)
     pos[center_id] = center_pos
-    
+
     # Arrange 1-hop neighbors in a circle around center
     neighbors = [n for n in G.nodes() if G.nodes[n]['hop'] == 1]
     import math
@@ -88,7 +89,7 @@ def create_1hop_visualization(nodes_df, edges_df, center_id, output_file):
         angle = 2 * math.pi * i / len(neighbors)
         radius = 3
         pos[neighbor] = (radius * math.cos(angle), radius * math.sin(angle))
-    
+
     # Create figure
     plt.figure(figsize=(20, 20))
 
@@ -98,14 +99,14 @@ def create_1hop_visualization(nodes_df, edges_df, center_id, output_file):
     # Draw center node
     center_categories = str(G.nodes[center_id]['category']).split('|') if G.nodes[center_id]['category'] else ['unknown']
     center_color = category_colors.get(center_categories[0], '#CCCCCC')
-    
-    nx.draw_networkx_nodes(G, pos, nodelist=[center_id], 
-                          node_color=[center_color], 
+
+    nx.draw_networkx_nodes(G, pos, nodelist=[center_id],
+                          node_color=[center_color],
                           node_size=[6000],
                           alpha=0.9,
                           edgecolors='black',
                           linewidths=2)
-    
+
     # Draw 1-hop neighbors
     neighbor_nodes = [node for node, data in G.nodes(data=True) if data.get('hop') == 1]
     neighbor_colors = []
@@ -114,24 +115,24 @@ def create_1hop_visualization(nodes_df, edges_df, center_id, output_file):
         primary_category = categories[0]
         color = category_colors.get(primary_category, '#CCCCCC')
         neighbor_colors.append(color)
-    
-    nx.draw_networkx_nodes(G, pos, nodelist=neighbor_nodes, 
-                          node_color=neighbor_colors, 
+
+    nx.draw_networkx_nodes(G, pos, nodelist=neighbor_nodes,
+                          node_color=neighbor_colors,
                           node_size=[3000 for _ in neighbor_nodes],
                           alpha=0.8,
                           edgecolors='black',
                           linewidths=1.5)
-    
+
     # Draw edges
     nx.draw_networkx_edges(G, pos, alpha=0.5, width=2, edge_color='gray')
-    
+
     # Create comprehensive labels for ALL nodes
     labels = {}
-    
+
     # Center node label
     center_name = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
     labels[center_id] = center_name
-    
+
     # ALL 1-hop neighbors (since there are fewer, we can label them all)
     for neighbor in neighbor_nodes:
         name = str(G.nodes[neighbor]['name']) if G.nodes[neighbor]['name'] else neighbor
@@ -139,44 +140,44 @@ def create_1hop_visualization(nodes_df, edges_df, center_id, output_file):
         if len(name) > 30:
             name = name[:30] + "..."
         labels[neighbor] = name
-    
+
     # Draw labels with better formatting
-    nx.draw_networkx_labels(G, pos, labels, font_size=10, font_weight='bold', 
-                           font_color='black', bbox=dict(boxstyle='round,pad=0.3', 
+    nx.draw_networkx_labels(G, pos, labels, font_size=10, font_weight='bold',
+                           font_color='black', bbox=dict(boxstyle='round,pad=0.3',
                            facecolor='white', alpha=0.9, edgecolor='gray'))
-    
+
     # Add title
     center_name_full = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
     plt.title(f'1-Hop Subgraph around {center_name_full}\n({len(G.nodes)} nodes, {len(G.edges)} edges)',
               fontsize=20, fontweight='bold', pad=40)
-    
+
     # Add legend with better positioning
     legend_elements = []
     for category, color in category_colors.items():
         if any(category in str(data.get('category', '')) for _, data in G.nodes(data=True)):
-            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                            markerfacecolor=color, markersize=12, 
+            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                            markerfacecolor=color, markersize=12,
                                             label=category.replace('biolink:', '')))
-    
+
     # Add hop legend
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=18, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=18,
                                     label='Center (Hop 0)'))
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=12, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=12,
                                     label='1-Hop Neighbors'))
-    
-    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1), 
+
+    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1),
               fontsize=12, frameon=True, fancybox=True, shadow=True)
-    
+
     # Remove axes
     plt.axis('off')
-    
+
     # Adjust layout and save
     plt.tight_layout()
     plt.savefig(output_file, dpi=300, bbox_inches='tight', facecolor='white')
     plt.show()
-    
+
     print(f"1-hop visualization saved to {output_file}")
 
 def main():
@@ -224,14 +225,14 @@ def main():
     else:
         center_name_safe = center_id.replace(':', '_')
         output_prefix = os.path.join(script_dir, f"{center_name_safe}_1hop")
-    
+
     subgraph_nodes.to_csv(f"{output_prefix}_subgraph_nodes.csv", index=False)
     subgraph_edges.to_csv(f"{output_prefix}_subgraph_edges.csv", index=False)
-    
+
     # Create visualization
     visualization_file = f"{output_prefix}_subgraph.png"
     create_1hop_visualization(subgraph_nodes, subgraph_edges, center_id, visualization_file)
-    
+
     # Print summary
     print("\n1-Hop Subgraph Summary:")
     print(f"Center node: {center_id}")
@@ -239,7 +240,7 @@ def main():
     print(f"Center name: {center_name}")
     print(f"Total nodes: {len(subgraph_nodes)}")
     print(f"Total edges: {len(subgraph_edges)}")
-    
+
     # Print nodes by hop
     for hop in [0, 1]:
         hop_count = len(subgraph_nodes[subgraph_nodes['hop'] == hop])
@@ -250,7 +251,7 @@ def main():
     categories = subgraph_nodes['category'].value_counts().head(10)
     for category, count in categories.items():
         print(f"  {category}: {count}")
-    
+
     # Export summary stats
     stats = {
         'center_id': center_id,
@@ -261,11 +262,11 @@ def main():
         'hop_1_nodes': len(subgraph_nodes[subgraph_nodes['hop'] == 1]),
         'top_categories': categories.to_dict()
     }
-    
+
     with open(f"{output_prefix}_stats.json", 'w') as f:
         json.dump(stats, f, indent=2)
 
-    print(f"\nFiles created:")
+    print("\nFiles created:")
     print(f"- {output_prefix}_subgraph_nodes.csv")
     print(f"- {output_prefix}_subgraph_edges.csv")
     print(f"- {output_prefix}_subgraph.png")

--- a/scripts/examples/visualization/create_2hop_full_labels.py
+++ b/scripts/examples/visualization/create_2hop_full_labels.py
@@ -1,32 +1,34 @@
 #!/usr/bin/env python3
 import os
-import pandas as pd
-import networkx as nx
+
 import matplotlib.pyplot as plt
+import networkx as nx
+import pandas as pd
+
 from config import CATEGORY_COLORS, FIGURE_SIZE_2HOP
+
 
 def create_2hop_full_labels():
     """Create 2-hop visualization with full labels for 1-hop neighbors"""
-
     # Get script directory for relative paths
     script_dir = os.path.dirname(os.path.abspath(__file__))
 
     # Load data
     nodes_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_2hop_subgraph_nodes.csv'))
     edges_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_2hop_subgraph_edges.csv'))
-    
+
     center_id = "NCBITaxon:1718"
-    
+
     # Create NetworkX graph
     G = nx.Graph()
-    
+
     # Add nodes
     for _, node in nodes_df.iterrows():
-        G.add_node(node['id'], 
-                  name=node['name'], 
-                  category=node['category'], 
+        G.add_node(node['id'],
+                  name=node['name'],
+                  category=node['category'],
                   hop=node['hop'])
-    
+
     # Add edges (limit for performance)
     edge_count = 0
     for _, edge in edges_df.iterrows():
@@ -35,10 +37,10 @@ def create_2hop_full_labels():
         if edge['subject'] in G.nodes and edge['object'] in G.nodes:
             G.add_edge(edge['subject'], edge['object'])
             edge_count += 1
-    
+
     # Create layout with good spacing
     pos = nx.spring_layout(G, k=5, iterations=100, seed=42)
-    
+
     # Create large figure
     plt.figure(figsize=FIGURE_SIZE_2HOP)
 
@@ -50,83 +52,83 @@ def create_2hop_full_labels():
         hop_nodes = [node for node, data in G.nodes(data=True) if data.get('hop') == hop]
         if not hop_nodes:
             continue
-            
+
         node_colors = []
         for node in hop_nodes:
             categories = str(G.nodes[node]['category']).split('|') if G.nodes[node]['category'] else ['unknown']
             primary_category = categories[0]
             color = category_colors.get(primary_category, '#CCCCCC')
             node_colors.append(color)
-        
+
         node_sizes = [10000 if hop == 0 else 5000 if hop == 1 else 2500 for _ in hop_nodes]
-        
-        nx.draw_networkx_nodes(G, pos, nodelist=hop_nodes, 
-                              node_color=node_colors, 
+
+        nx.draw_networkx_nodes(G, pos, nodelist=hop_nodes,
+                              node_color=node_colors,
                               node_size=node_sizes,
                               alpha=0.8,
                               edgecolors='black',
                               linewidths=2)
-    
+
     # Draw edges
     nx.draw_networkx_edges(G, pos, alpha=0.2, width=1, edge_color='gray')
-    
+
     # Create labels with FULL names for 1-hop neighbors
     labels = {}
-    
+
     # Center node label (FULL)
     center_name = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
     labels[center_id] = center_name
-    
+
     # ALL 1-hop neighbors with COMPLETE FULL names
     neighbors = list(G.neighbors(center_id))
     for neighbor in neighbors:
         name = str(G.nodes[neighbor]['name']) if G.nodes[neighbor]['name'] else neighbor
         # Show COMPLETE full names for all 1-hop neighbors
         labels[neighbor] = name
-    
+
     # For 2-hop, only show the top 20 most connected ones with shorter names
     hop2_nodes = [node for node, data in G.nodes(data=True) if data.get('hop') == 2]
     degree_cent = nx.degree_centrality(G)
     important_hop2 = sorted(hop2_nodes, key=lambda x: degree_cent.get(x, 0), reverse=True)[:20]
-    
+
     for node in important_hop2:
         name = str(G.nodes[node]['name']) if G.nodes[node]['name'] else node
         # Limit 2-hop names to avoid overcrowding
         if len(name) > 25:
             name = name[:25] + "..."
         labels[node] = name
-    
+
     # Draw labels
-    nx.draw_networkx_labels(G, pos, labels, font_size=8, font_weight='bold', 
-                           font_color='black', 
-                           bbox=dict(boxstyle='round,pad=0.3', 
+    nx.draw_networkx_labels(G, pos, labels, font_size=8, font_weight='bold',
+                           font_color='black',
+                           bbox=dict(boxstyle='round,pad=0.3',
                            facecolor='white', alpha=0.9, edgecolor='gray'))
-    
+
     # Add title
-    plt.title(f'2-Hop Subgraph: {center_name} - FULL 1-HOP LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)', 
+    plt.title(f'2-Hop Subgraph: {center_name} - FULL 1-HOP LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)',
               fontsize=26, fontweight='bold', pad=60)
-    
+
     # Add legend
     legend_elements = []
     for category, color in category_colors.items():
         if any(category in str(data.get('category', '')) for _, data in G.nodes(data=True)):
-            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                            markerfacecolor=color, markersize=15, 
+            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                            markerfacecolor=color, markersize=15,
                                             label=category.replace('biolink:', '')))
-    
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=20, 
+
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=20,
                                     label='Center (Hop 0)'))
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=15, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=15,
                                     label='1-Hop (Full Labels)'))
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=10, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=10,
                                     label='2-Hop (Top 20)'))
-    
-    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1), 
+
+    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1),
               fontsize=14, frameon=True, fancybox=True, shadow=True)
-    
+
     plt.axis('off')
     plt.tight_layout()
 

--- a/scripts/examples/visualization/create_full_label_visualizations.py
+++ b/scripts/examples/visualization/create_full_label_visualizations.py
@@ -1,47 +1,49 @@
 #!/usr/bin/env python3
 import os
-import pandas as pd
-import networkx as nx
+
 import matplotlib.pyplot as plt
+import networkx as nx
+import pandas as pd
+
 from config import CATEGORY_COLORS, FIGURE_SIZE_1HOP, FIGURE_SIZE_2HOP
+
 
 def create_1hop_full_labels():
     """Create 1-hop visualization with full node labels"""
-
     # Get script directory for relative paths
     script_dir = os.path.dirname(os.path.abspath(__file__))
 
     # Load data
     nodes_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_1hop_subgraph_nodes.csv'))
     edges_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_1hop_subgraph_edges.csv'))
-    
+
     center_id = "NCBITaxon:1718"
-    
+
     # Create NetworkX graph
     G = nx.Graph()
-    
+
     # Add nodes
     for _, node in nodes_df.iterrows():
-        G.add_node(node['id'], 
-                  name=node['name'], 
-                  category=node['category'], 
+        G.add_node(node['id'],
+                  name=node['name'],
+                  category=node['category'],
                   hop=node['hop'])
-    
+
     # Add edges
     for _, edge in edges_df.iterrows():
         if edge['subject'] in G.nodes and edge['object'] in G.nodes:
-            G.add_edge(edge['subject'], edge['object'], 
+            G.add_edge(edge['subject'], edge['object'],
                       predicate=edge['predicate'])
-    
+
     # Create layout optimized for 1-hop (star pattern with more space)
     pos = {}
     center_pos = (0, 0)
     pos[center_id] = center_pos
-    
+
     # Arrange 1-hop neighbors in multiple concentric circles if needed
     neighbors = [n for n in G.nodes() if G.nodes[n]['hop'] == 1]
     import math
-    
+
     # Use multiple rings if there are many neighbors
     total_neighbors = len(neighbors)
     if total_neighbors <= 20:
@@ -54,15 +56,15 @@ def create_1hop_full_labels():
         # Multiple rings
         neighbors_per_ring = 20
         ring_count = math.ceil(total_neighbors / neighbors_per_ring)
-        
+
         for ring in range(ring_count):
             ring_neighbors = neighbors[ring * neighbors_per_ring:(ring + 1) * neighbors_per_ring]
             radius = 4 + ring * 2.5  # Increasing radius for each ring
-            
+
             for i, neighbor in enumerate(ring_neighbors):
                 angle = 2 * math.pi * i / len(ring_neighbors)
                 pos[neighbor] = (radius * math.cos(angle), radius * math.sin(angle))
-    
+
     # Create larger figure to accommodate full labels
     plt.figure(figsize=FIGURE_SIZE_1HOP)
 
@@ -72,14 +74,14 @@ def create_1hop_full_labels():
     # Draw center node
     center_categories = str(G.nodes[center_id]['category']).split('|') if G.nodes[center_id]['category'] else ['unknown']
     center_color = category_colors.get(center_categories[0], '#CCCCCC')
-    
-    nx.draw_networkx_nodes(G, pos, nodelist=[center_id], 
-                          node_color=[center_color], 
+
+    nx.draw_networkx_nodes(G, pos, nodelist=[center_id],
+                          node_color=[center_color],
                           node_size=[8000],
                           alpha=0.9,
                           edgecolors='black',
                           linewidths=3)
-    
+
     # Draw 1-hop neighbors
     neighbor_nodes = [node for node, data in G.nodes(data=True) if data.get('hop') == 1]
     neighbor_colors = []
@@ -88,62 +90,62 @@ def create_1hop_full_labels():
         primary_category = categories[0]
         color = category_colors.get(primary_category, '#CCCCCC')
         neighbor_colors.append(color)
-    
-    nx.draw_networkx_nodes(G, pos, nodelist=neighbor_nodes, 
-                          node_color=neighbor_colors, 
+
+    nx.draw_networkx_nodes(G, pos, nodelist=neighbor_nodes,
+                          node_color=neighbor_colors,
                           node_size=[4000 for _ in neighbor_nodes],
                           alpha=0.8,
                           edgecolors='black',
                           linewidths=2)
-    
+
     # Draw edges
     nx.draw_networkx_edges(G, pos, alpha=0.3, width=2, edge_color='gray')
-    
+
     # Create FULL labels for ALL nodes - no truncation
     labels = {}
-    
+
     # Center node label
     center_name = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
     labels[center_id] = center_name
-    
+
     # ALL 1-hop neighbors with FULL names
     for neighbor in neighbor_nodes:
         name = str(G.nodes[neighbor]['name']) if G.nodes[neighbor]['name'] else neighbor
         # NO TRUNCATION - show full names
         labels[neighbor] = name
-    
+
     # Draw labels with better formatting for readability
-    nx.draw_networkx_labels(G, pos, labels, font_size=8, font_weight='bold', 
-                           font_color='black', bbox=dict(boxstyle='round,pad=0.4', 
+    nx.draw_networkx_labels(G, pos, labels, font_size=8, font_weight='bold',
+                           font_color='black', bbox=dict(boxstyle='round,pad=0.4',
                            facecolor='white', alpha=0.9, edgecolor='gray'))
-    
+
     # Add title
     center_name_full = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
-    plt.title(f'1-Hop Subgraph around {center_name_full} - FULL LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)', 
+    plt.title(f'1-Hop Subgraph around {center_name_full} - FULL LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)',
               fontsize=24, fontweight='bold', pad=50)
-    
+
     # Add legend
     legend_elements = []
     for category, color in category_colors.items():
         if any(category in str(data.get('category', '')) for _, data in G.nodes(data=True)):
-            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                            markerfacecolor=color, markersize=15, 
+            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                            markerfacecolor=color, markersize=15,
                                             label=category.replace('biolink:', '')))
-    
+
     # Add hop legend
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=20, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=20,
                                     label='Center (Hop 0)'))
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=15, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=15,
                                     label='1-Hop Neighbors'))
-    
-    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1), 
+
+    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1),
               fontsize=14, frameon=True, fancybox=True, shadow=True)
-    
+
     # Remove axes
     plt.axis('off')
-    
+
     # Adjust layout and save
     plt.tight_layout()
     output_file = os.path.join(script_dir, 'corynebacterium_glutamicum_1hop_subgraph_full_labels.png')
@@ -154,35 +156,34 @@ def create_1hop_full_labels():
 
 def create_2hop_full_labels():
     """Create 2-hop visualization with full node labels for important nodes"""
-
     # Get script directory for relative paths
     script_dir = os.path.dirname(os.path.abspath(__file__))
 
     # Load data
     nodes_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_2hop_subgraph_nodes.csv'))
     edges_df = pd.read_csv(os.path.join(script_dir, 'corynebacterium_glutamicum_2hop_subgraph_edges.csv'))
-    
+
     center_id = "NCBITaxon:1718"
-    
+
     # Create NetworkX graph
     G = nx.Graph()
-    
+
     # Add nodes
     for _, node in nodes_df.iterrows():
-        G.add_node(node['id'], 
-                  name=node['name'], 
-                  category=node['category'], 
+        G.add_node(node['id'],
+                  name=node['name'],
+                  category=node['category'],
                   hop=node['hop'])
-    
+
     # Add edges
     for _, edge in edges_df.iterrows():
         if edge['subject'] in G.nodes and edge['object'] in G.nodes:
-            G.add_edge(edge['subject'], edge['object'], 
+            G.add_edge(edge['subject'], edge['object'],
                       predicate=edge['predicate'])
-    
+
     # Create layout with more spacing
     pos = nx.spring_layout(G, k=4, iterations=150, seed=42)
-    
+
     # Create larger figure
     plt.figure(figsize=FIGURE_SIZE_2HOP)
 
@@ -194,7 +195,7 @@ def create_2hop_full_labels():
         hop_nodes = [node for node, data in G.nodes(data=True) if data.get('hop') == hop]
         if not hop_nodes:
             continue
-            
+
         # Get colors for this hop
         node_colors = []
         for node in hop_nodes:
@@ -202,81 +203,81 @@ def create_2hop_full_labels():
             primary_category = categories[0]
             color = category_colors.get(primary_category, '#CCCCCC')
             node_colors.append(color)
-        
+
         # Set node size based on hop
         node_sizes = [8000 if hop == 0 else 4000 if hop == 1 else 2000 for _ in hop_nodes]
-        
+
         # Draw nodes
-        nx.draw_networkx_nodes(G, pos, nodelist=hop_nodes, 
-                              node_color=node_colors, 
+        nx.draw_networkx_nodes(G, pos, nodelist=hop_nodes,
+                              node_color=node_colors,
                               node_size=node_sizes,
                               alpha=0.8,
                               edgecolors='black',
                               linewidths=2)
-    
+
     # Draw edges
     nx.draw_networkx_edges(G, pos, alpha=0.2, width=1, edge_color='gray')
-    
+
     # Create comprehensive labels with FULL names
     labels = {}
-    
+
     # Center node label (FULL)
     center_name = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
     labels[center_id] = center_name
-    
+
     # ALL 1-hop neighbors (FULL names)
     neighbors = list(G.neighbors(center_id))
     for neighbor in neighbors:
         name = str(G.nodes[neighbor]['name']) if G.nodes[neighbor]['name'] else neighbor
         # NO TRUNCATION for 1-hop neighbors
         labels[neighbor] = name
-    
+
     # For 2-hop neighbors, show full names for the most important ones
     hop2_nodes = [node for node, data in G.nodes(data=True) if data.get('hop') == 2]
     # Get degree centrality to identify important 2-hop nodes
     degree_cent = nx.degree_centrality(G)
     important_hop2 = sorted(hop2_nodes, key=lambda x: degree_cent.get(x, 0), reverse=True)[:30]  # Top 30
-    
+
     for node in important_hop2:
         name = str(G.nodes[node]['name']) if G.nodes[node]['name'] else node
         # FULL names for important 2-hop neighbors too
         labels[node] = name
-    
+
     # Draw labels with adjusted formatting for full names
-    nx.draw_networkx_labels(G, pos, labels, font_size=7, font_weight='bold', 
-                           font_color='black', bbox=dict(boxstyle='round,pad=0.3', 
+    nx.draw_networkx_labels(G, pos, labels, font_size=7, font_weight='bold',
+                           font_color='black', bbox=dict(boxstyle='round,pad=0.3',
                            facecolor='white', alpha=0.9, edgecolor='gray'))
-    
+
     # Add title
     center_name_full = str(G.nodes[center_id]['name']) if G.nodes[center_id]['name'] else center_id
-    plt.title(f'2-Hop Subgraph around {center_name_full} - FULL LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)', 
+    plt.title(f'2-Hop Subgraph around {center_name_full} - FULL LABELS\n({len(G.nodes)} nodes, {len(G.edges)} edges)',
               fontsize=26, fontweight='bold', pad=60)
-    
+
     # Add legend
     legend_elements = []
     for category, color in category_colors.items():
         if any(category in str(data.get('category', '')) for _, data in G.nodes(data=True)):
-            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                            markerfacecolor=color, markersize=15, 
+            legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                            markerfacecolor=color, markersize=15,
                                             label=category.replace('biolink:', '')))
-    
+
     # Add hop legend
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=20, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=20,
                                     label='Center (Hop 0)'))
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=15, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=15,
                                     label='1-Hop Neighbors'))
-    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w', 
-                                    markerfacecolor='black', markersize=10, 
+    legend_elements.append(plt.Line2D([0], [0], marker='o', color='w',
+                                    markerfacecolor='black', markersize=10,
                                     label='2-Hop Neighbors'))
-    
-    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1), 
+
+    plt.legend(handles=legend_elements, loc='upper left', bbox_to_anchor=(1.02, 1),
               fontsize=14, frameon=True, fancybox=True, shadow=True)
-    
+
     # Remove axes
     plt.axis('off')
-    
+
     # Adjust layout and save
     plt.tight_layout()
     output_file = os.path.join(script_dir, 'corynebacterium_glutamicum_2hop_subgraph_full_labels.png')
@@ -293,7 +294,7 @@ def main():
     create_2hop_full_labels()
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    print(f"\nBoth visualizations with full labels have been created!")
+    print("\nBoth visualizations with full labels have been created!")
     print(f"Files saved to: {script_dir}/")
 
 if __name__ == "__main__":

--- a/scripts/generate_coverage_report.py
+++ b/scripts/generate_coverage_report.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Generate mapping-coverage report for a transform.
+"""
+Generate mapping-coverage report for a transform.
 
 Reads the transform's ``edges.tsv`` (for predicate + object-ontology
 distributions) and its per-source unmapped queue (for the still-to-map

--- a/scripts/prego_validation/build_assay_gold.py
+++ b/scripts/prego_validation/build_assay_gold.py
@@ -1,4 +1,5 @@
-"""Build a taxon->GO gold standard WITH NEGATIVES from BacDive assay results.
+"""
+Build a taxon->GO gold standard WITH NEGATIVES from BacDive assay results.
 
 BacDive records assay outcomes with polarity — METPO:2000302 "shows activity of"
 and METPO:2000303 "does not show activity of" — so chaining

--- a/scripts/prego_validation/fold_enrichment_bto.py
+++ b/scripts/prego_validation/fold_enrichment_bto.py
@@ -1,4 +1,5 @@
-"""Fold enrichment of PREGO BTO -location_of-> NCBITaxon vs BacDive host anatomy.
+"""
+Fold enrichment of PREGO BTO -location_of-> NCBITaxon vs BacDive host anatomy.
 
 BacDive records host/tissue isolation against UBERON and CL, not BTO. The
 crosswalk is already in-repo: 1,645 anatomy terms in the ontologies output carry

--- a/scripts/prego_validation/precision_assay_go.py
+++ b/scripts/prego_validation/precision_assay_go.py
@@ -9,6 +9,8 @@ BacDive phenotype assays are also provenance-disjoint from both UniProt
 import pickle
 from collections import defaultdict
 
+from channel_compat import assert_non_empty, continuous_predicate
+
 tri = pickle.load(open("/tmp/assay_gold.pkl", "rb"))
 # Unanimous labels only; conflicting strain-level evidence is excluded.
 label = {}

--- a/scripts/prego_validation/predicate_interaction.py
+++ b/scripts/prego_validation/predicate_interaction.py
@@ -1,4 +1,5 @@
-"""Does the score behave differently for location_of vs capable_of, on matched taxa?
+"""
+Does the score behave differently for location_of vs capable_of, on matched taxa?
 
 The headline verdict — score discriminates on `location_of`, not on `capable_of` —
 was measured with a different gold standard per predicate, so predicate was

--- a/scripts/test_bacdive_transform.py
+++ b/scripts/test_bacdive_transform.py
@@ -13,7 +13,6 @@ def main():
 
     # Paths
     test_json = Path("tests/resources/raw/bacdive_strains.json")
-    test_tmp_dir = Path("kg_microbe/transform_utils/bacdive/tmp_test")
     output_dir = Path("data/transformed_test/bacdive")
 
     # Validate test data exists
@@ -23,7 +22,7 @@ def main():
         return 1
 
     # Copy test JSON to data/raw for transform to find
-    print(f"\nCopying test JSON to data/raw/bacdive_strains.json...")
+    print("\nCopying test JSON to data/raw/bacdive_strains.json...")
     backup_json = Path("data/raw/bacdive_strains.json.backup")
     original_json = Path("data/raw/bacdive_strains.json")
 
@@ -34,15 +33,15 @@ def main():
 
     # Copy test JSON
     shutil.copy(test_json, original_json)
-    print(f"  ✅ Test JSON in place (20 records)")
+    print("  ✅ Test JSON in place (20 records)")
 
     try:
         # Create test output directory
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Run transform
-        print(f"\nRunning BacDive transform...")
-        print(f"  Input directory: data/raw")
+        print("\nRunning BacDive transform...")
+        print("  Input directory: data/raw")
         print(f"  Output directory: {output_dir}")
         transform = BacDiveTransform(input_dir=Path("data/raw"), output_dir=output_dir)
         transform.run(show_status=True)
@@ -59,12 +58,12 @@ def main():
             with open(edges_file) as f:
                 edge_count = sum(1 for _ in f) - 1  # subtract header
 
-            print(f"\n✅ Transform completed successfully!")
+            print("\n✅ Transform completed successfully!")
             print(f"   Nodes: {node_count}")
             print(f"   Edges: {edge_count}")
 
             # Check for empty relations
-            print(f"\nChecking for empty relation values...")
+            print("\nChecking for empty relation values...")
             empty_count = 0
             with open(edges_file) as f:
                 header = f.readline().strip().split("\t")
@@ -77,30 +76,30 @@ def main():
                             empty_count += 1
 
             if empty_count == 0:
-                print(f"   ✅ No empty relations found!")
+                print("   ✅ No empty relations found!")
             else:
                 print(f"   ❌ Found {empty_count} empty relations")
 
-            print(f"\nOutput files:")
+            print("\nOutput files:")
             print(f"   {nodes_file}")
             print(f"   {edges_file}")
 
             return 0
         else:
-            print(f"\n❌ Transform failed - output files not created")
+            print("\n❌ Transform failed - output files not created")
             return 1
 
     finally:
         # Restore original JSON
-        print(f"\nRestoring original bacdive_strains.json...")
+        print("\nRestoring original bacdive_strains.json...")
         if backup_json.exists():
             shutil.move(backup_json, original_json)
-            print(f"  ✅ Restored from backup")
+            print("  ✅ Restored from backup")
         else:
             # Remove test JSON if no backup existed
             if original_json.exists():
                 original_json.unlink()
-            print(f"  ✅ Removed test JSON (no original existed)")
+            print("  ✅ Removed test JSON (no original existed)")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_knowledge_sources.py
+++ b/scripts/validate_knowledge_sources.py
@@ -6,13 +6,15 @@ from pathlib import Path
 
 
 def validate_edges_file(edges_file: Path) -> dict:
-    """Check knowledge source column in edges file.
+    """
+    Check knowledge source column in edges file.
 
     Args:
         edges_file: Path to the edges.tsv file
 
     Returns:
         Dictionary with validation results
+
     """
     issues = []
     valid_count = 0
@@ -115,8 +117,13 @@ def main():
             total_valid_edges += result['valid_count']
             total_invalid_edges += result['invalid_count']
 
-            print(f"  Total edges: {result['total_edges']}")
-            print(f"  Valid: {result['valid_count']} ({'100.0' if result['total_edges'] == 0 else f'{result['valid_count']/result['total_edges']*100:.1f}'}%)")
+            total = result['total_edges']
+            # Computed rather than nested inside the f-string: reusing the same
+            # quote character inside a replacement field is PEP 701 syntax, valid
+            # only on 3.12+, and this repo supports 3.10 (#966).
+            valid_pct = 100.0 if total == 0 else result['valid_count'] / total * 100
+            print(f"  Total edges: {total}")
+            print(f"  Valid: {result['valid_count']} ({valid_pct:.1f}%)")
 
             if result['total_issues'] > 0:
                 print(f"  Issues: {result['total_issues']}")
@@ -126,7 +133,7 @@ def main():
                     print(f"    - {issue}")
                 all_valid = False
             else:
-                print(f"  ✓ All edges have valid infores: knowledge sources")
+                print("  ✓ All edges have valid infores: knowledge sources")
 
         print()
 

--- a/scripts/validate_ro_relations.py
+++ b/scripts/validate_ro_relations.py
@@ -16,6 +16,7 @@ def extract_ro_terms_from_owl(owl_path: Path) -> Set[str]:
 
     Returns:
         Set of valid RO term IDs (e.g., "RO:0000052", "RO:HOM0000017")
+
     """
     ro_terms = set()
 
@@ -43,6 +44,7 @@ def validate_edge_files(transformed_dir: Path, valid_ro_terms: Set[str]) -> dict
 
     Returns:
         Dictionary mapping source names to lists of issues found
+
     """
     results = {}
 

--- a/tests/test_consolidator_convergence.py
+++ b/tests/test_consolidator_convergence.py
@@ -1,0 +1,93 @@
+"""The consolidator must say whether a run reached its fixed point (#948)."""
+
+import importlib.util
+import io
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "consolidate_chemical_mappings.py"
+
+_spec = importlib.util.spec_from_file_location("consolidate_chemical_mappings", SCRIPT)
+ccm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ccm)
+
+
+def _write(path, triples):
+    """
+    Write a minimal SSSOM set containing ``triples``.
+
+    :param path: Destination ``.gz`` path.
+    :param triples: ``(subject, predicate, object)`` tuples.
+    :return: None.
+    """
+    with ccm.open_deterministic_gzip(path) as handle:
+        handle.write("# curie_map:\n")
+        handle.write("subject_id\tpredicate_id\tobject_id\tmapping_date\n")
+        for subject, predicate, obj in triples:
+            handle.write(f"{subject}\t{predicate}\t{obj}\t2026-01-01\n")
+
+
+def _report(seed, written):
+    """
+    Run the reporter and capture what it printed.
+
+    :param seed: Seed triples, or None.
+    :param written: Path of the artifact just written.
+    :return: Captured stdout.
+    """
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        ccm._report_convergence(seed, written)
+    return buffer.getvalue()
+
+
+class ConvergenceReportTests(unittest.TestCase):
+    """A reviewer must be able to tell a fixed point from one step short."""
+
+    def test_a_fixed_point_says_so(self):
+        """The seeding makes an empty diff the exception, so name it when it happens."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "out.sssom.tsv.gz"
+            triples = {("A:1", "skos:exactMatch", "B:1"), ("A:2", "skos:closeMatch", "B:2")}
+            _write(out, triples)
+            output = _report(set(triples), out)
+            self.assertIn("Converged", output)
+            self.assertIn("2 triples", output)
+
+    def test_a_moved_artifact_reports_both_directions_and_says_to_re_run(self):
+        """
+        A net count hides the shape, and the operator needs the instruction.
+
+        Committing one step short is the failure this exists to prevent, and
+        nothing else in the run surfaces which state the output is in.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "out.sssom.tsv.gz"
+            _write(out, [("A:1", "skos:exactMatch", "B:1"), ("A:3", "skos:exactMatch", "B:3")])
+            seed = {("A:1", "skos:exactMatch", "B:1"), ("A:2", "skos:exactMatch", "B:2")}
+            output = _report(seed, out)
+            self.assertIn("Not yet converged", output)
+            self.assertIn("1 added", output)
+            self.assertIn("1 removed", output)
+            self.assertIn("re-run", output)
+
+    def test_a_first_run_has_nothing_to_converge_against(self):
+        """No previous artifact is not a failure to converge, and must not read as one."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "out.sssom.tsv.gz"
+            _write(out, [("A:1", "skos:exactMatch", "B:1")])
+            output = _report(None, out)
+            self.assertIn("First run", output)
+            self.assertNotIn("Not yet converged", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scripts_lint_debt.py
+++ b/tests/test_scripts_lint_debt.py
@@ -1,0 +1,104 @@
+"""Grandfathered lint debt in scripts/ must stay honest (#950, #968)."""
+
+import re
+import shutil
+import subprocess
+import unittest
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+REPO = Path(__file__).resolve().parent.parent
+
+#: Ruff needs its own config ignored, or the per-file-ignores under test would
+#: suppress the very findings this asks it to report.
+ISOLATED = ["--isolated", "--line-length", "120", "--target-version", "py310"]
+
+
+def _debt():
+    """
+    Return the per-file ignores declared for ``scripts/``.
+
+    :return: ``{path: {rule, ...}}``.
+    """
+    config = tomllib.loads((REPO / "pyproject.toml").read_text())
+    ignores = config["tool"]["ruff"]["lint"]["per-file-ignores"]
+    return {path: set(rules) for path, rules in ignores.items() if path.startswith("scripts/")}
+
+
+def _findings(rules):
+    """
+    Run ruff over ``scripts/`` for ``rules``, bypassing the repo config.
+
+    :param rules: Rule codes to select.
+    :return: ``{path: {rule, ...}}`` actually reported.
+    """
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [
+            shutil.which("ruff") or "ruff",
+            "check",
+            "scripts/",
+            *ISOLATED,
+            "--select",
+            ",".join(sorted(rules)),
+            "--no-cache",
+            "--output-format",
+            "concise",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    found = defaultdict(set)
+    for line in result.stdout.splitlines():
+        match = re.match(r"(scripts/\S+?):\d+:\d+: ([A-Z]+\d{3})", line)
+        if match:
+            found[match.group(1)].add(match.group(2))
+    return found
+
+
+class ScriptsLintDebtTests(unittest.TestCase):
+    """An exemption nobody needs is permission nobody asked for."""
+
+    def test_no_exemption_is_dead(self):
+        """
+        Every grandfathered rule must still fire on the file that claims it.
+
+        Otherwise the list only grows: a rule fixed in passing keeps its
+        exemption, nothing distinguishes real debt from long-paid debt, and the
+        block reads as load-bearing forever. Checking it by hand is exactly the
+        kind of check that stops being run (#968).
+        """
+        if shutil.which("ruff") is None:
+            self.skipTest("ruff not on PATH")
+        debt = _debt()
+        self.assertTrue(debt, "no scripts/ entries found; this guard needs rewriting")
+        found = _findings({rule for rules in debt.values() for rule in rules})
+        dead = {path: sorted(rules - found.get(path, set())) for path, rules in debt.items()}
+        dead = {path: rules for path, rules in dead.items() if rules}
+        self.assertEqual(dead, {}, f"exemptions that no longer fire — delete them: {dead}")
+
+    def test_the_debt_is_scoped_per_file_not_to_the_directory(self):
+        """
+        A `scripts/*` entry would exempt the clean scripts and every future one.
+
+        That is the difference between grandfathering the debt and abandoning
+        the directory, and it is invisible once written (#968).
+        """
+        config = tomllib.loads((REPO / "pyproject.toml").read_text())
+        ignores = config["tool"]["ruff"]["lint"]["per-file-ignores"]
+        wildcards = [path for path in ignores if path.startswith("scripts/") and "*" in path]
+        self.assertEqual(wildcards, [], f"scripts/ debt must be listed per file, not as {wildcards}")
+
+    def test_every_listed_file_exists(self):
+        """A path that no longer exists is debt recorded against nothing."""
+        missing = [path for path in _debt() if not (REPO / path).is_file()]
+        self.assertEqual(missing, [], f"per-file-ignores name files that are gone: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,10 @@ deps =
 skip_install = true
 commands =
     ruff format kg_microbe/ tests/
+# scripts/ is linted and spell-checked (see [testenv:lint] and [testenv:codespell])
+# but deliberately not formatted yet: `ruff format` over its ~8,500 lines would
+# be a diff reviewable only as noise. Adopting the formatter there is its own
+# change; see #950.
     ruff check --fix kg_microbe/ tests/
 description = Run formatters and auto-fix lints.
 
@@ -47,7 +51,7 @@ deps =
     ruff
 skip_install = true
 commands =
-    ruff check kg_microbe/ tests/
+    ruff check kg_microbe/ tests/ scripts/
 description = Run linters.
 
 [testenv:doclint]
@@ -64,7 +68,7 @@ skip_install = true
 deps =
     codespell
     tomli  # required for getting config from pyproject.toml
-commands = codespell kg_microbe/ tests/ \
+commands = codespell kg_microbe/ tests/ scripts/ \
             -S kg_microbe/transform_utils/*/tmp/* \
             -S kg_microbe/transform_utils/bacdive/metabolite_mapping.json \
             -S kg_microbe/transform_utils/ontologies/xrefs/* \
@@ -75,7 +79,8 @@ commands = codespell kg_microbe/ tests/ \
             -S tests/resources/nlp/stopwords/stopWords.txt \
             -S tests/resources/bacdive/* \
             -S tests/resources/raw/* \
-            -S 'kg_microbe/utils/bacdive*.json*'
+            -S 'kg_microbe/utils/bacdive*.json*' \
+            -S 'scripts/examples/visualization/*.csv'
 
 [testenv:codespell-write]
 description = Run spell checker and write corrections.
@@ -83,7 +88,7 @@ skip_install = true
 deps =
     codespell
     tomli
-commands = codespell kg_microbe/ tests/ --write-changes \
+commands = codespell kg_microbe/ tests/ scripts/ --write-changes \
             -S kg_microbe/transform_utils/*/tmp/* \
             -S kg_microbe/transform_utils/bacdive/metabolite_mapping.json \
             -S kg_microbe/transform_utils/ontologies/xrefs/* \
@@ -94,7 +99,8 @@ commands = codespell kg_microbe/ tests/ --write-changes \
             -S tests/resources/nlp/stopwords/stopWords.txt \
             -S tests/resources/bacdive/* \
             -S tests/resources/raw/* \
-            -S 'kg_microbe/utils/bacdive*.json*'
+            -S 'kg_microbe/utils/bacdive*.json*' \
+            -S 'scripts/examples/visualization/*.csv'
 
 [testenv:docstr-coverage]
 skip_install = true


### PR DESCRIPTION
## `scripts/` was in no quality gate (#950)

`tox -e lint` and `tox -e codespell` — the two things CI runs — covered `kg_microbe/` and `tests/` only. So the 2,800-line writer of two tracked artifacts, one a 13 MB binary every transform reads through `chemical_mapping_utils`, was the one file class nothing checked. **405 ruff findings** across 20 modules and 8,573 lines.

Three of them could bite, and they are the argument for the whole change:

**`scripts/validate_knowledge_sources.py:119` has been a SyntaxError on Python 3.10 and 3.11** — two of the three supported versions.

```
SyntaxError line 119: f-string: unmatched '['
```

It nests an f-string reusing the same quote character inside a replacement field: PEP 701 syntax, valid only on 3.12+. The file is unimportable and unrunnable on the repo's own minimum, and nothing noticed.

**`scripts/prego_validation/precision_assay_go.py` calls two functions it never imports.** `continuous_predicate` and `assert_non_empty` — a `NameError` on the first real line of work. Its three sibling scripts all do `from channel_compat import assert_non_empty, continuous_predicate`; this one was missed.

**`consolidate_chemical_mappings.py` annotates `Set[Tuple[str, str]]` with `Tuple` never imported.** Latent only because attribute annotations are not evaluated at runtime — confirmed by constructing the class — but it breaks `get_type_hints` and is an undefined name regardless.

### What was done with the rest

- **274 auto-fixed** (whitespace, f-strings without placeholders, import order).
- **Remaining bug-class findings fixed outright**: an unused `col` dict a later `dict(zip(...))` had superseded, an unused loop variable, an unused path, and three unchecked `zip()` lengths made explicit.
- **The rest grandfathered per rule** in `pyproject.toml` — style (`D*`, `E501`, `E701`, `E702`), bandit noise on local analysis scripts (`S108`, `S110`, `S311`, `S603`, `S607`), and `B023` closures that are all called inside their own iteration. Each with a reason, and an instruction not to add to the list. The gate protects against *new* findings today rather than after a cleanup that may never happen — which is what #950 asked for.
- **`ruff format` deliberately not extended** to `scripts/`. Over 8,573 lines it would be a diff reviewable only as noise; adopting it there is its own change, and `tox.ini` says so at the point where someone would otherwise assume an oversight.
- **`codespell-write` widened alongside the gate**, so the fixer and the checker scan the same tree. Its six findings were all `URE` in two exported CSV node dumps — excluded the same way the existing data-file exclusions are.

## The run now says which state its output is in (#948)

`main()` seeds from this script's own previous output, so run *N*'s input includes run *N−1*'s output, and a name one run derives can seed another row on the next. The seeding is **load-bearing** — it is how the absent legacy priority-1/2 inputs survive their own absence — so this reports the property rather than removing it.

A run now ends with one of:

```
  Converged: identical to the seed (609,975 triples). This is the fixed point.

  Not yet converged: N added, M removed (X -> Y). The seeding is intentional,
  but the output is one step ahead of its input -- re-run to reach the fixed
  point before committing.
```

That addresses both consequences the issue names: a reviewer regenerating to check a committed artifact previously saw a non-empty diff indistinguishable from non-determinism (the issue's author lost a cycle to exactly this), and nothing said whether what was committed was the fixed point or one step short.

**Not done:** iterating internally until stable. #948 marks it optional, and re-running the full pipeline in a loop changes the run contract rather than its reporting — worth its own decision.

## Verification

```
tox -e lint       OK   (kg_microbe/ tests/ scripts/)
tox -e codespell  OK   (same three)
--dry-run         triples 609,975 -> 609,975 (+0), added 0, removed 0
full run          Converged: identical to the seed (609,975 triples)
3.10 parse sweep  every file under scripts/ parses; none did before
```

Three tests for the reporter: a fixed point says so, a moved artifact reports both directions and the instruction to re-run, and a first run is not mistaken for a failure to converge.

Suite: **1,344 passed**. The two failures — `test_transform_outputs_carry_no_unexpected_deprecated_term` and `test_every_referenced_curie_has_stub_node` — are the known stale-transform-output pair, unrelated and cleared by the pending rerun.

The artifact itself is unchanged: this is not a data refresh, so the regenerated `.gz` was restored after using it to verify the convergence message.

Closes #948, closes #950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E