### PR TITLE
Rebuild prep: LPSN deposit nodes, atomic LPSN writes, honest output summary, schema in the fingerprint (#932, #820, #949, #943)

### DIFF
--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Freshness check for KG-Microbe transform / merge outputs vs origin/master.
+"""
+Freshness check for KG-Microbe transform / merge outputs vs origin/master.
 
 For every transform directory under kg_microbe/transform_utils/<source>/,
 compare:
@@ -13,6 +14,7 @@ Also report:
 
 Per-source status codes:
   FRESH             — output mtime > latest code commit AND no local changes
+  STALE_VS_SCHEMA   — the recorded Biolink schema differs from the pinned one (#943)
   STALE_VS_CODE     — output mtime < latest code commit on origin/master
   LOCAL_CHANGES     — working tree diverges from origin/master for this dir
                      (in that case, "current relative to master" is not
@@ -38,11 +40,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
+import re
 import subprocess
 import sys
-from dataclasses import dataclass, asdict, field
-import re
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -329,6 +330,7 @@ def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
             code_fingerprint,
             data_fingerprint,
             read_fingerprint,
+            schema_fingerprint,
             upstream_fingerprint,
         )
     except ImportError:
@@ -343,6 +345,17 @@ def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
         upstream_stale = recorded.get("upstream") != upstream_fingerprint(
             TRANSFORMED_DIR, _declared_transform_inputs(source)
         )
+        # Only judged when the marker recorded a schema. A marker written before
+        # the field existed says nothing about the schema, and unknown provenance
+        # is not wrong provenance (#911, #943).
+        recorded_schema = recorded.get("schema")
+        if recorded_schema is not None and recorded_schema != schema_fingerprint(REPO):
+            current = schema_fingerprint(REPO) or {}
+            return (
+                "STALE_VS_SCHEMA",
+                f"built against Biolink {recorded_schema.get('version', '?')}, pinned model is now "
+                f"{current.get('version', 'absent')}; rerun `poetry run kg transform -s {source}`",
+            )
         if upstream_stale and not (code_stale or data_stale):
             upstreams = ", ".join(_declared_transform_inputs(source)) or "an upstream"
             return (
@@ -641,6 +654,7 @@ def main() -> int:
             "STALE_VS_CODE",
             "STALE_VS_DATA",
             "STALE_VS_CODE_AND_DATA",
+            "STALE_VS_SCHEMA",
             "LOCAL_CHANGES",
             "MISSING_OUTPUT",
             "NO_CODE",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,9 @@ three move together — half a schema at one version is worse than either versio
 alone — and `tests/test_biolink_schema_pin.py` checks that `download.yaml`
 fetches every file the shipped model imports, at one pinned tag. Updating the
 Biolink version requires changing `download.yaml`, the lock file, fixtures, and
-tests together.
+tests together. Each transform's `source_fingerprint.json` records the schema
+it was built against, and `kgm-freshness-check` reports `STALE_VS_SCHEMA` when
+the pinned model has moved since (#943).
 
 A pin bump alone does not refresh `data/raw`. The 4.4.2 bump landed in August
 2026 and the 4.3.6 file already on disk was never replaced, so every run since

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -206,16 +206,27 @@ def _describe_output(transform_obj, source: str) -> str:
     out_dir = getattr(transform_obj, "output_dir", None)
     if out_dir is None:
         return f"no output_dir attribute on {source} transform"
+    # Every `*nodes.tsv` / `*edges.tsv`, not the two literal names: the
+    # ontologies transform writes `<ontology>_nodes.tsv` per ontology and the
+    # stub transform does the same, so the literal check reported a successful
+    # 415 MB, 28-file run as "wrote no nodes.tsv/edges.tsv" -- the inverse of
+    # what the guard is for (#949).
     parts = []
-    for name in ("nodes.tsv", "edges.tsv"):
-        path = Path(out_dir) / name
-        if not path.is_file():
+    for kind in ("nodes", "edges"):
+        files = sorted(Path(out_dir).glob(f"*{kind}.tsv"))
+        if not files:
             continue
-        try:
-            with path.open("r", encoding="utf-8") as handle:
-                rows = max(sum(1 for _ in handle) - 1, 0)
-        except OSError as exc:  # pragma: no cover - unreadable output is rare
-            parts.append(f"{name} unreadable ({exc})")
-            continue
-        parts.append(f"{name}: {rows:,} rows")
-    return "; ".join(parts) if parts else f"wrote no nodes.tsv/edges.tsv in {out_dir}"
+        counted = []
+        for path in files:
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    counted.append((path.name, max(sum(1 for _ in handle) - 1, 0)))
+            except OSError as exc:  # pragma: no cover - unreadable output is rare
+                parts.append(f"{path.name} unreadable ({exc})")
+        if len(counted) == 1:
+            name, rows = counted[0]
+            parts.append(f"{name}: {rows:,} rows")
+        elif counted:
+            total = sum(rows for _, rows in counted)
+            parts.append(f"{len(counted)} {kind} files: {total:,} rows")
+    return "; ".join(parts) if parts else f"wrote no *nodes.tsv/*edges.tsv in {out_dir}"

--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -59,6 +59,7 @@ from kg_microbe.transform_utils.constants import (
     SUBCLASS_PREDICATE,
 )
 from kg_microbe.transform_utils.transform import Transform
+from kg_microbe.utils.atomic_io import atomic_write
 
 LPSN_PREFIX = "lpsn:"
 LPSN_KNOWLEDGE_SOURCE = "infores:lpsn"
@@ -425,9 +426,14 @@ class LPSNTransform(Transform):
         parent_lookup = self._build_parent_lookup(rows_by_id)
 
         # Emit nodes + edges.
+        # Atomic: lpsn_api, microbedecoder and bacdive read these files back,
+        # and their fail-safes key on absence. A plain open() that died
+        # mid-write left a truncated file that read as "lpsn has run" with a
+        # partial id set, which is worse than no file at all (#820).
+        deposits: Dict[str, str] = {}
         with (
-            open(self.output_node_file, "w", newline="") as node_fh,
-            open(self.output_edge_file, "w", newline="") as edge_fh,
+            atomic_write(self.output_node_file, newline="") as node_fh,
+            atomic_write(self.output_edge_file, newline="") as edge_fh,
         ):
             node_writer = csv.writer(node_fh, delimiter="\t")
             edge_writer = csv.writer(edge_fh, delimiter="\t")
@@ -454,8 +460,12 @@ class LPSNTransform(Transform):
                 # (a numeric link within the table, not a strain deposit) and
                 # is skipped.
                 if (row.get(COL_SP_EPITHET) or "").strip():
-                    for strain_curie in self._extract_strain_curies(row):
+                    for strain_curie, deposit_label in self._extract_strain_deposits(row):
                         edge_writer.writerow(self._make_close_match_edge(record_no, strain_curie))
+                        # Buffered, not written here: several records can cite
+                        # one deposit, and a node row belongs to the deposit,
+                        # not to the citation.
+                        deposits.setdefault(strain_curie, deposit_label)
                 # NCBITaxon cross-ref: every rank (genus / species /
                 # subspecies) is attempted because the index is filtered to
                 # the bacterial + archaeal subtree, so multi-kingdom
@@ -480,6 +490,14 @@ class LPSNTransform(Transform):
                 gtdb_curie = self._lookup_gtdb(row)
                 if gtdb_curie:
                     edge_writer.writerow(self._make_close_match_edge(record_no, gtdb_curie))
+
+            # Every deposit this file references gets a node row. Without one,
+            # KGX invents a bare `biolink:NamedThing` with no label for each of
+            # them at merge time -- 4,233 in the 20260815 graph, all LPSN's
+            # (#932). Same shape BacDive emits for the deposits it cites, so
+            # the merge collapses the shared ones onto one node.
+            for strain_curie, deposit_label in sorted(deposits.items()):
+                node_writer.writerow(self._make_deposit_node_row(strain_curie, deposit_label))
 
         # End-of-run summary — useful diff signal when NCBI / GTDB
         # dumps are refreshed and match rates shift.
@@ -632,6 +650,15 @@ class LPSNTransform(Transform):
         """
         Turn ``row[nomenclatural_type]`` into a list of ``kgmicrobe.strain:*`` CURIEs.
 
+        :param row: One GSS row.
+        :return: The CURIEs from :meth:`_extract_strain_deposits`, in order.
+        """
+        return [curie for curie, _label in self._extract_strain_deposits(row)]
+
+    def _extract_strain_deposits(self, row: dict) -> list:
+        """
+        Turn ``row[nomenclatural_type]`` into ``(kgmicrobe.strain:* CURIE, label)`` pairs.
+
         LPSN's ``nomenclatural_type`` for a species / subspecies row is one or
         more culture-collection deposits separated by ``=`` / ``;`` / ``,``,
         e.g. ``"ATCC 11775 = DSM 30083 = JCM 1649"``. Each deposit is
@@ -666,7 +693,9 @@ class LPSNTransform(Transform):
                 if curie in seen:
                     continue
                 seen.add(curie)
-                curies.append(curie)
+                # The label is the deposit code as written ("ATCC 11775"),
+                # the same choice BacDive makes for the node it emits.
+                curies.append((curie, token))
         return curies
 
     def _lookup_ncbi(self, row: dict) -> Optional[str]:
@@ -773,6 +802,26 @@ class LPSNTransform(Transform):
             "object": f"{LPSN_PREFIX}{correct_record_no}",
             "relation": EXACT_MATCH,
             "primary_knowledge_source": LPSN_KNOWLEDGE_SOURCE,
+        }.items():
+            if col in headers:
+                row_out[headers.index(col)] = val
+        return row_out
+
+    def _make_deposit_node_row(self, strain_curie: str, label: str) -> list:
+        """
+        Build one nodes.tsv row for a culture-collection deposit this file cites.
+
+        :param strain_curie: ``kgmicrobe.strain:<code>``.
+        :param label: The deposit code as LPSN wrote it.
+        :return: A row aligned to ``node_header``.
+        """
+        headers = self.node_header
+        row_out = [""] * len(headers)
+        for col, val in {
+            "id": strain_curie,
+            "category": NCBI_CATEGORY,
+            "name": label,
+            "provided_by": LPSN_KNOWLEDGE_SOURCE,
         }.items():
             if col in headers:
                 row_out[headers.index(col)] = val

--- a/kg_microbe/utils/transform_fingerprint.py
+++ b/kg_microbe/utils/transform_fingerprint.py
@@ -219,7 +219,7 @@ def schema_fingerprint(repo_root: Path) -> Optional[dict]:
     :return: ``{"version": ..., "digest": ...}``, or None when no schema file
         is on disk -- unknown provenance is recorded as unknown, not invented.
     """
-    present = [repo_root / rel for rel in SCHEMA_FILES if (repo_root / rel).is_file()]
+    present = [rel for rel in SCHEMA_FILES if (repo_root / rel).is_file()]
     if not present:
         return None
     version = "unknown"
@@ -231,7 +231,16 @@ def schema_fingerprint(repo_root: Path) -> Optional[dict]:
                 if match:
                     version = match.group(1)
                     break
-    return {"version": version, "digest": _hash_files(present)}
+    # Folded in by repo-relative name, not by absolute path: the same schema
+    # in a different checkout is the same schema, and a marker carried to
+    # another machine must not read as a schema change.
+    digest = hashlib.sha256()
+    for rel in present:
+        digest.update(rel.as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256((repo_root / rel).read_bytes()).digest())
+        digest.update(b"\0")
+    return {"version": version, "digest": digest.hexdigest()}
 
 
 def write_fingerprint(

--- a/kg_microbe/utils/transform_fingerprint.py
+++ b/kg_microbe/utils/transform_fingerprint.py
@@ -24,6 +24,7 @@ versus ``STALE_VS_DATA``.
 import ast
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -193,6 +194,46 @@ def data_fingerprint(repo_root: Path, data_inputs: Iterable[str]) -> str:
     return _hash_files(repo_root / rel for rel in data_inputs)
 
 
+#: The pinned Biolink schema every transform validates against, relative to
+#: the repository root. All three move together (see CLAUDE.md).
+SCHEMA_FILES = (
+    Path("data") / "raw" / "biolink-model.yaml",
+    Path("data") / "raw" / "attributes.yaml",
+    Path("data") / "raw" / "predicate_mapping.yaml",
+)
+
+_SCHEMA_VERSION_LINE = re.compile(r"^version:\s*['\"]?([^'\"\s]+)")
+
+
+def schema_fingerprint(repo_root: Path) -> Optional[dict]:
+    """
+    Identify the Biolink schema a transform ran against.
+
+    The pinned model is a real pipeline input -- ``prepare_kgx`` makes it the
+    default schema for every KGX ``Toolkit`` -- but no transform declares it,
+    so swapping it (as #941 did, 4.3.6 -> 4.4.2) marked nothing stale and a
+    partial rerun could mix schema versions in one merged graph (#943). Record
+    it in the marker so the artifact says which schema produced it.
+
+    :param repo_root: Repository root.
+    :return: ``{"version": ..., "digest": ...}``, or None when no schema file
+        is on disk -- unknown provenance is recorded as unknown, not invented.
+    """
+    present = [repo_root / rel for rel in SCHEMA_FILES if (repo_root / rel).is_file()]
+    if not present:
+        return None
+    version = "unknown"
+    model = repo_root / SCHEMA_FILES[0]
+    if model.is_file():
+        with model.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                match = _SCHEMA_VERSION_LINE.match(line)
+                if match:
+                    version = match.group(1)
+                    break
+    return {"version": version, "digest": _hash_files(present)}
+
+
 def write_fingerprint(
     output_dir: Path,
     code_dir: Path,
@@ -221,6 +262,8 @@ def write_fingerprint(
         # Recorded separately so a stale output says which of the three moved:
         # its code, its curation data, or something it reads (#845).
         "upstream": upstream_fingerprint(output_dir.parent, transform_inputs),
+        # Which Biolink schema this output was validated against (#943).
+        "schema": schema_fingerprint(repo_root),
     }
     with atomic_write(output_dir / FINGERPRINT_FILE, encoding="utf-8") as handle:
         handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")

--- a/tests/test_lpsn_transform.py
+++ b/tests/test_lpsn_transform.py
@@ -76,8 +76,9 @@ def test_nodes_emitted_for_every_valid_row(lpsn_transform):
     """One node per LPSN record (fixture has 6 rows, all with record_no)."""
     lpsn_transform.run()
     nodes = _read_tsv(lpsn_transform.output_node_file)
-    assert len(nodes) == 6
-    ids = {n["id"] for n in nodes}
+    # Deposit nodes (#932) live in the same file; this test is about records.
+    ids = {n["id"] for n in nodes if n["id"].startswith(LPSN_PREFIX)}
+    assert len(ids) == 6
     assert ids == {
         f"{LPSN_PREFIX}1001",
         f"{LPSN_PREFIX}1002",
@@ -478,3 +479,58 @@ def test_gtdb_disabled_when_index_absent(lpsn_transform):
     edges = _read_tsv(lpsn_transform.output_edge_file)
     gtdb_edges = [e for e in edges if e["object"].startswith("GTDB:")]
     assert gtdb_edges == []
+
+
+def test_every_cited_deposit_gets_a_node_row(lpsn_transform):
+    """
+    A close_match edge to a deposit nobody declares is a stub at merge time.
+
+    KGX invents a bare ``biolink:NamedThing`` with no label for each
+    undeclared endpoint -- 4,233 of them in the 20260815 graph, every one
+    LPSN's (#932). The node row is the same shape BacDive emits for the
+    deposits it cites, so the merge collapses shared ones.
+    """
+    lpsn_transform.run()
+    nodes = {n["id"]: n for n in _read_tsv(lpsn_transform.output_node_file)}
+    edges = _read_tsv(lpsn_transform.output_edge_file)
+    cited = {e["object"] for e in edges if e["object"].startswith("kgmicrobe.strain:")}
+    assert cited, "fixture should cite at least one deposit"
+    missing = cited - set(nodes)
+    assert not missing, f"deposits cited without a node row: {sorted(missing)}"
+    deposit = nodes["kgmicrobe.strain:ATCC-11775"]
+    assert deposit["category"] == "biolink:OrganismTaxon"
+    assert deposit["name"] == "ATCC 11775"  # the code as written, not the slug
+    assert deposit["provided_by"] == LPSN_KNOWLEDGE_SOURCE
+
+
+def test_a_deposit_cited_by_two_records_gets_one_node_row(lpsn_transform, tmp_path):
+    """The node belongs to the deposit, not to the citation."""
+    lpsn_transform.run()
+    ids = [n["id"] for n in _read_tsv(lpsn_transform.output_node_file)]
+    deposits = [i for i in ids if i.startswith("kgmicrobe.strain:")]
+    assert len(deposits) == len(set(deposits))
+
+
+def test_a_run_that_dies_midway_leaves_no_output_file(lpsn_transform, monkeypatch):
+    """
+    A truncated nodes.tsv is worse than none (#820).
+
+    microbedecoder treats an empty id set as "lpsn has not run" and stubs
+    accordingly; a partial set reads as a complete one, so the ids that were
+    cut off look unsupplied. Absence is the state the fail-safes understand.
+    """
+    calls = {"n": 0}
+
+    def explode(self_, record_no, row):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated crash after the first record")
+        return original(record_no, row)
+
+    original = lpsn_transform._make_node_row
+    monkeypatch.setattr(type(lpsn_transform), "_make_node_row", explode)
+    with pytest.raises(RuntimeError):
+        lpsn_transform.run()
+    assert not lpsn_transform.output_node_file.exists()
+    assert not lpsn_transform.output_edge_file.exists()
+    assert not list(Path(lpsn_transform.output_dir).glob("*.partial"))

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -192,3 +192,54 @@ class FreshnessDataStalenessTest(TestCase):
         ):
             report = self.mod.check_source("bacdive", "origin/master")
         self.assertEqual(report.status, "STALE_VS_CODE_AND_DATA")
+
+
+class FreshnessSchemaTest(TestCase):
+    """A schema change must mark output stale, once the marker records one (#943)."""
+
+    def setUp(self):
+        """Import the standalone freshness script."""
+        spec = importlib.util.spec_from_file_location(
+            "kgm_freshness_check",
+            REPO_ROOT / ".claude" / "skills" / "kgm-freshness-check" / "kgm_freshness_check.py",
+        )
+        self.mod = importlib.util.module_from_spec(spec)
+        sys.modules["kgm_freshness_check"] = self.mod
+        spec.loader.exec_module(self.mod)
+
+    def _verdict(self, recorded_schema):
+        """
+        Run ``_fingerprint_verdict`` over a marker whose other fields all match.
+
+        :param recorded_schema: The ``schema`` value in the marker.
+        :return: ``(status, note)``.
+        """
+        import kg_microbe.utils.transform_fingerprint as fp
+
+        marker = {"version": fp.FINGERPRINT_VERSION, "code": "c", "data": "d", "upstream": "u"}
+        if recorded_schema is not None:
+            marker["schema"] = recorded_schema
+        with (
+            mock.patch.object(fp, "read_fingerprint", return_value=marker),
+            mock.patch.object(fp, "code_fingerprint", return_value="c"),
+            mock.patch.object(fp, "data_fingerprint", return_value="d"),
+            mock.patch.object(fp, "upstream_fingerprint", return_value="u"),
+            mock.patch.object(fp, "schema_fingerprint", return_value={"version": "4.4.2", "digest": "new"}),
+        ):
+            code_dir = REPO_ROOT / "kg_microbe" / "transform_utils" / "bactotraits"
+            return self.mod._fingerprint_verdict("bactotraits", code_dir)
+
+    def test_a_recorded_schema_that_moved_is_stale(self):
+        """The #941 case: pin moved 4.3.6 -> 4.4.2, code and data untouched."""
+        status, note = self._verdict({"version": "4.3.6", "digest": "old"})
+        self.assertEqual(status, "STALE_VS_SCHEMA")
+        self.assertIn("4.3.6", note)
+        self.assertIn("4.4.2", note)
+
+    def test_a_matching_schema_is_fresh(self):
+        """Recording the schema must not invent staleness."""
+        self.assertEqual(self._verdict({"version": "4.4.2", "digest": "new"})[0], "FRESH")
+
+    def test_a_marker_without_a_schema_is_not_judged_on_it(self):
+        """Unknown provenance is not wrong provenance (#911)."""
+        self.assertEqual(self._verdict(None)[0], "FRESH")

--- a/tests/test_transform_fingerprint.py
+++ b/tests/test_transform_fingerprint.py
@@ -152,6 +152,16 @@ class SchemaFingerprintTests(TestCase):
         self.assertEqual(a["version"], b["version"])
         self.assertNotEqual(a["digest"], b["digest"])
 
+    def test_the_same_schema_in_two_checkouts_is_one_schema(self):
+        """
+        The digest must not fold in the absolute path.
+
+        A marker travels with its output directory; comparing it from another
+        checkout, or on another machine, must not read as a schema change.
+        """
+        with tempfile.TemporaryDirectory() as td_a, tempfile.TemporaryDirectory() as td_b:
+            self.assertEqual(schema_fingerprint(self._root(td_a)), schema_fingerprint(self._root(td_b)))
+
     def test_no_schema_on_disk_records_none_rather_than_inventing_one(self):
         """Unknown provenance is recorded as unknown (#911)."""
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_transform_fingerprint.py
+++ b/tests/test_transform_fingerprint.py
@@ -10,6 +10,7 @@ from kg_microbe.utils.transform_fingerprint import (
     code_fingerprint,
     data_fingerprint,
     read_fingerprint,
+    schema_fingerprint,
     write_fingerprint,
 )
 
@@ -114,3 +115,58 @@ class FingerprintTest(TestCase):
     def test_an_absent_marker_reads_as_absent(self):
         """Fresh checkouts and pre-existing outputs have none; that is not an error."""
         self.assertIsNone(read_fingerprint(self.tmp / "nowhere"))
+
+
+class SchemaFingerprintTests(TestCase):
+    """The marker must say which Biolink schema produced the output (#943)."""
+
+    def _root(self, td, version="4.4.2", extra=""):
+        """
+        Lay out a repo root with a pinned model.
+
+        :param td: Temp directory.
+        :param version: The ``version:`` line to write.
+        :param extra: Extra text appended to the model.
+        :return: The root path.
+        """
+        root = Path(td)
+        raw = root / "data" / "raw"
+        raw.mkdir(parents=True)
+        (raw / "biolink-model.yaml").write_text(
+            f"id: https://w3id.org/biolink/biolink-model\nname: Biolink-Model\nversion: {version}\n{extra}",
+            encoding="utf-8",
+        )
+        (raw / "attributes.yaml").write_text("id: attributes\n", encoding="utf-8")
+        return root
+
+    def test_the_version_is_read_from_the_model(self):
+        """The human-readable half of the record."""
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(schema_fingerprint(self._root(td))["version"], "4.4.2")
+
+    def test_editing_the_model_changes_the_digest_even_at_the_same_version(self):
+        """Two files claiming one version are still two schemas."""
+        with tempfile.TemporaryDirectory() as td_a, tempfile.TemporaryDirectory() as td_b:
+            a = schema_fingerprint(self._root(td_a))
+            b = schema_fingerprint(self._root(td_b, extra="classes:\n  thing: {}\n"))
+        self.assertEqual(a["version"], b["version"])
+        self.assertNotEqual(a["digest"], b["digest"])
+
+    def test_no_schema_on_disk_records_none_rather_than_inventing_one(self):
+        """Unknown provenance is recorded as unknown (#911)."""
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(schema_fingerprint(Path(td)))
+
+    def test_the_marker_carries_the_schema(self):
+        """Wired into ``write_fingerprint``, not just available beside it."""
+        with tempfile.TemporaryDirectory() as td:
+            root = self._root(td)
+            code = root / "pkg"
+            code.mkdir()
+            (code / "t.py").write_text("x = 1\n", encoding="utf-8")
+            out = root / "out"
+            out.mkdir()
+            payload = write_fingerprint(out, code, root, data_inputs=())
+            recorded = read_fingerprint(out)
+        self.assertEqual(payload["schema"]["version"], "4.4.2")
+        self.assertEqual(recorded["schema"], payload["schema"])

--- a/tests/test_transform_output_summary.py
+++ b/tests/test_transform_output_summary.py
@@ -1,0 +1,63 @@
+"""The completion line must describe what a transform actually wrote (#813, #949)."""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from kg_microbe.transform import _describe_output
+
+
+def _write(path: Path, rows: int) -> None:
+    """
+    Write a header plus ``rows`` data lines.
+
+    :param path: File to write.
+    :param rows: Number of data rows.
+    :return: None.
+    """
+    path.write_text("a\tb\n" + "".join(f"{i}\tx\n" for i in range(rows)), encoding="utf-8")
+
+
+class DescribeOutputTests(unittest.TestCase):
+    """A run that produced nothing must be told apart from one that did."""
+
+    def test_the_plain_pair_is_reported_by_name(self):
+        """The common case keeps its familiar shape."""
+        with TemporaryDirectory() as td:
+            _write(Path(td) / "nodes.tsv", 3)
+            _write(Path(td) / "edges.tsv", 5)
+            line = _describe_output(SimpleNamespace(output_dir=Path(td)), "x")
+        self.assertEqual(line, "nodes.tsv: 3 rows; edges.tsv: 5 rows")
+
+    def test_per_ontology_files_are_counted_not_ignored(self):
+        """
+        The #949 inversion.
+
+        The ontologies transform writes ``<ontology>_nodes.tsv`` per ontology.
+        The literal-name check saw none of them and printed "wrote no
+        nodes.tsv/edges.tsv" after a successful 415 MB run.
+        """
+        with TemporaryDirectory() as td:
+            for name, rows in (("chebi_nodes.tsv", 10), ("ncbitaxon_nodes.tsv", 20), ("chebi_edges.tsv", 7)):
+                _write(Path(td) / name, rows)
+            line = _describe_output(SimpleNamespace(output_dir=Path(td)), "ontologies")
+        self.assertEqual(line, "2 nodes files: 30 rows; chebi_edges.tsv: 7 rows")
+
+    def test_nothing_written_still_says_so(self):
+        """The guard the function exists for has to keep firing."""
+        with TemporaryDirectory() as td:
+            (Path(td) / "unrelated.txt").write_text("x", encoding="utf-8")
+            line = _describe_output(SimpleNamespace(output_dir=Path(td)), "x")
+        self.assertTrue(line.startswith("wrote no *nodes.tsv/*edges.tsv"))
+
+    def test_a_header_only_file_counts_as_zero_rows(self):
+        """Zero rows is the signal, not an absent file."""
+        with TemporaryDirectory() as td:
+            _write(Path(td) / "nodes.tsv", 0)
+            line = _describe_output(SimpleNamespace(output_dir=Path(td)), "x")
+        self.assertEqual(line, "nodes.tsv: 0 rows")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #932. Closes #820. Closes #949. Closes #943.

Four small fixes from the triage sequence, all cheaper to land before the transform rebuild than to find in the merged graph afterwards. `lpsn` feeds `lpsn_api` and `microbedecoder`, so #932/#820 need to be in before it reruns.

## #932 — LPSN declares the deposits it references

LPSN emitted `lpsn:<record> --close_match--> kgmicrobe.strain:<deposit>` for every culture-collection deposit in `nomenclatural_type` and never a node row, so KGX invented a bare `biolink:NamedThing` with no label for each — 4,233 in the `20260815` graph, all LPSN's. Every referenced deposit now gets a node row of the same shape BacDive emits for the deposits *it* cites (`biolink:OrganismTaxon`, name = the code as written, `provided_by infores:lpsn`), so the merge collapses shared deposits onto one node. Buffered across records: one row per deposit, not per citation.

## #820 — LPSN output is written atomically

`nodes.tsv`/`edges.tsv` went through a plain `open()`. A run that died mid-write left a truncated file, and every downstream fail-safe keys on *absence*: `microbedecoder._lpsn_supplied_ids` read a partial set as "lpsn has run" and treated the cut-off ids as unsupplied. Both files now go through `atomic_write`; the test crashes the run on the second record and asserts no output and no `.partial` remains.

## #949 — the completion line counts what was actually written

`_describe_output` checked two literal filenames, so `kg transform -s ontologies` printed `wrote no nodes.tsv/edges.tsv` after writing 28 files / 415 MB — the inverse of the #813 guard on the most expensive transform. It now counts every `*nodes.tsv` / `*edges.tsv` (`14 nodes files: 1,234,567 rows; …`); the plain pair keeps its familiar line; nothing written still says so.

## #943 — the Biolink schema is in the fingerprint

`source_fingerprint.json` now records `schema: {version, digest}` over `biolink-model.yaml`, `attributes.yaml` and `predicate_mapping.yaml`, and `kgm-freshness-check` reports **`STALE_VS_SCHEMA`** (`built against Biolink 4.3.6, pinned model is now 4.4.2`) when a recorded schema differs from the pinned one. A marker written before the field existed is not judged on it — unknown provenance is not wrong provenance (#911) — so nothing flips spuriously today; verified by running the check on the current tree (`ontologies` stays FRESH, `STALE_VS_SCHEMA 0`).

## Verification

- `tests/test_lpsn_transform.py`: every cited deposit has a node row; one row per deposit; a mid-run crash leaves no output file.
- `tests/test_transform_output_summary.py` (new): plain pair, per-ontology files, nothing written, header-only.
- `tests/test_transform_fingerprint.py`: version parsed; same version / different bytes → different digest; no schema on disk → `None`; the marker carries it.
- `tests/test_transform_dispatch_and_data_inputs.py`: moved schema → `STALE_VS_SCHEMA`; matching → FRESH; absent field → not judged.
- `ruff check kg_microbe/ tests/ scripts/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E