### PR TITLE
ontologies_stubs: write the MIREOT module as RDF/XML, which ROBOT can read back (#986)

### DIFF
--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -481,7 +481,7 @@ class OntologiesStubsTransform(Transform):
         """
         Run ``robot extract --method MIREOT`` and convert the result to OBO Graph JSON.
 
-        Writes intermediate ``.ofn`` and ``.json`` files into ``self.output_dir``
+        Writes intermediate ``.owl`` (RDF/XML) and ``.json`` files into ``self.output_dir``
         so they're available for inspection if the module needs auditing.
         """
         robot_bin = shutil.which("robot")
@@ -499,7 +499,12 @@ class OntologiesStubsTransform(Transform):
 
         lower_terms_file = self.output_dir / f"{prefix.lower()}_mireot_lower.txt"
         lower_terms_file.write_text("\n".join(lower_iris) + "\n", encoding="utf-8")
-        module_ofn = self.output_dir / f"{prefix.lower()}_mireot_module.ofn"
+        # RDF/XML, not functional syntax. ROBOT 1.9.6 writes an `.ofn` it then
+        # cannot parse back once the module carries MICRO literals with
+        # embedded newlines and a `™` -- every OWLAPI parser rejects it and the
+        # convert step fails with INVALID ONTOLOGY FILE ERROR. RDF/XML round-
+        # trips the same content (#986).
+        module_owl = self.output_dir / f"{prefix.lower()}_mireot_module.owl"
         module_json = self.output_dir / f"{prefix.lower()}_mireot_module.json"
 
         extract_cmd: List[str] = [
@@ -514,7 +519,7 @@ class OntologiesStubsTransform(Transform):
         ]
         for iri in upper_iris:
             extract_cmd += ["--upper-term", iri]
-        extract_cmd += ["--output", str(module_ofn)]
+        extract_cmd += ["--output", str(module_owl)]
         subprocess.run(extract_cmd, check=True)  # noqa: S603
 
         subprocess.run(  # noqa: S603
@@ -522,7 +527,7 @@ class OntologiesStubsTransform(Transform):
                 robot_bin,
                 "convert",
                 "--input",
-                str(module_ofn),
+                str(module_owl),
                 "--output",
                 str(module_json),
                 "-f",

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -506,6 +506,9 @@ class OntologiesStubsTransform(Transform):
         # trips the same content (#986).
         module_owl = self.output_dir / f"{prefix.lower()}_mireot_module.owl"
         module_json = self.output_dir / f"{prefix.lower()}_mireot_module.json"
+        # The superseded intermediate: leaving the unparseable file beside the
+        # parseable one says nothing about which is current (#988).
+        module_owl.with_suffix(".ofn").unlink(missing_ok=True)
 
         extract_cmd: List[str] = [
             robot_bin,

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -506,7 +506,7 @@ class OntologiesStubsTransform(Transform):
         # trips the same content (#986).
         module_owl = self.output_dir / f"{prefix.lower()}_mireot_module.owl"
         module_json = self.output_dir / f"{prefix.lower()}_mireot_module.json"
-        # The superseded intermediate: leaving the unparseable file beside the
+        # The superseded intermediate: leaving the unparsable file beside the
         # parseable one says nothing about which is current (#988).
         module_owl.with_suffix(".ofn").unlink(missing_ok=True)
 

--- a/tests/test_ontologies_stubs.py
+++ b/tests/test_ontologies_stubs.py
@@ -298,6 +298,8 @@ def test_mireot_intermediate_is_rdfxml_not_functional_syntax(tmp_path, monkeypat
     monkeypatch.setattr(subprocess, "run", fake_run)
     transform = OntologiesStubsTransform(input_dir=tmp_path / "raw", output_dir=tmp_path / "out")
     (tmp_path / "out").mkdir(parents=True, exist_ok=True)
+    stale = tmp_path / "out" / "micro_mireot_module.ofn"
+    stale.write_text("Ontology()\n", encoding="utf-8")
     module_json = transform._run_mireot_extract(
         prefix="MICRO",
         lower_curies=["MICRO:0000082"],
@@ -313,6 +315,8 @@ def test_mireot_intermediate_is_rdfxml_not_functional_syntax(tmp_path, monkeypat
     assert convert[convert.index("--input") + 1] == written
     assert convert[convert.index("--output") + 1] == str(module_json)
     assert module_json.suffix == ".json"
+    # The superseded intermediate does not linger beside the new one (#988).
+    assert not stale.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ontologies_stubs.py
+++ b/tests/test_ontologies_stubs.py
@@ -276,6 +276,45 @@ def test_transform_raises_when_mireot_owl_missing(tmp_path):
         )
 
 
+def test_mireot_intermediate_is_rdfxml_not_functional_syntax(tmp_path, monkeypatch):
+    """
+    ROBOT cannot re-read the `.ofn` it writes for this content (#986).
+
+    Once the MICRO module carried literals with embedded newlines and a
+    trademark sign, every OWLAPI parser rejected ROBOT's own functional-syntax
+    output and the convert step died with INVALID ONTOLOGY FILE ERROR. RDF/XML
+    round-trips the same module, so the extract must be written as `.owl` and
+    the convert must read that same file.
+    """
+    import subprocess
+
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(list(cmd))
+        return None
+
+    monkeypatch.setattr("shutil.which", lambda _name: "/fake/robot")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    transform = OntologiesStubsTransform(input_dir=tmp_path / "raw", output_dir=tmp_path / "out")
+    (tmp_path / "out").mkdir(parents=True, exist_ok=True)
+    module_json = transform._run_mireot_extract(
+        prefix="MICRO",
+        lower_curies=["MICRO:0000082"],
+        upper_curie="MICRO:0000031",
+        owl_path=tmp_path / "raw" / "micro.owl",
+    )
+    extract, convert = calls
+    assert extract[1] == "extract"
+    written = extract[extract.index("--output") + 1]
+    assert written.endswith("_mireot_module.owl"), written
+    assert not written.endswith(".ofn")
+    assert convert[1] == "convert"
+    assert convert[convert.index("--input") + 1] == written
+    assert convert[convert.index("--output") + 1] == str(module_json)
+    assert module_json.suffix == ".json"
+
+
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_ontologies_stubs.py
+++ b/tests/test_ontologies_stubs.py
@@ -297,8 +297,8 @@ def test_mireot_intermediate_is_rdfxml_not_functional_syntax(tmp_path, monkeypat
     monkeypatch.setattr("shutil.which", lambda _name: "/fake/robot")
     monkeypatch.setattr(subprocess, "run", fake_run)
     transform = OntologiesStubsTransform(input_dir=tmp_path / "raw", output_dir=tmp_path / "out")
-    (tmp_path / "out").mkdir(parents=True, exist_ok=True)
-    stale = tmp_path / "out" / "micro_mireot_module.ofn"
+    transform.output_dir.mkdir(parents=True, exist_ok=True)
+    stale = transform.output_dir / "micro_mireot_module.ofn"
     stale.write_text("Ontology()\n", encoding="utf-8")
     module_json = transform._run_mireot_extract(
         prefix="MICRO",


### PR DESCRIPTION
Closes #986.

## What broke

During the rebuild, `kg transform -s ontologies_stubs` died on the MICRO step after NCIT/mesh/BTO/PO had written:

```
INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file: micro_mireot_module.ofn
```

`_run_mireot_extract` writes the MIREOT module in OWL functional syntax and immediately asks ROBOT to convert it to OBO-JSON. ROBOT 1.9.6 writes the `.ofn` but cannot parse it back once the module carries MICRO annotation literals with embedded newlines and a `™` (`"Difco™ Nutrient Broth … pH 6.8 ± 0.2"`). Twenty MICRO terms the current mapping set references — and the 2026-08-15 run did not — brought those literals in. `gold` depends on this transform, and the merge on both.

## Why the fix is the format, not the terms

- Extract the same module to **RDF/XML** → `robot convert` to JSON succeeds (114 nodes / 103 edges).
- Convert that RDF/XML to `.ofn` **with ROBOT itself** → converting it back fails with the same error.

So ROBOT's own functional-syntax output does not round-trip for this content; RDF/XML does. The intermediate is now `{prefix}_mireot_module.owl`. Nothing else reads the `.ofn` (checked `kg_microbe/`, `tests/`, `scripts/`, `.claude/skills/`).

## Verification

- Real run through the same driver the rebuild uses: **MICRO wrote 90 nodes / 89 edges**; all five stub ontologies landed; the completion line reads `5 nodes files: 755 rows; 4 edges files: 841 rows` (the #949 fix showing its first real output).
- `test_mireot_intermediate_is_rdfxml_not_functional_syntax`: mocks ROBOT, asserts the extract writes `.owl`, the convert reads that same file, and the JSON path is returned. **Fails on the old line, passes on the new** (checked by stashing the source).
- Ruff clean.

Stale `micro_mireot_module.ofn` / `po_mireot_module.ofn` files from earlier runs are not removed by the transform; they are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E
