### PR TITLE
bacdive: name the knowledge source as a CURIE on isolation-source and quality edges (#432)

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -3367,7 +3367,7 @@ class BacDiveTransform(Transform):
                                         predicate_override,
                                         subject_id,
                                         predicate_override,
-                                        self.source_name,
+                                        self.knowledge_source,
                                         knowledge_level,
                                         agent_type,
                                     ]
@@ -3460,6 +3460,9 @@ class BacDiveTransform(Transform):
                                 )
                             )
                         # Write edge from the isolation source to organism
+                        # knowledge_source, not source_name: the bare "bacdive" that used
+                        # to land here is not a CURIE, and 228,738 location_of edges
+                        # shipped with it while every other edge said infores:bacdive (#432).
                         knowledge_level, agent_type = self._add_edge_metadata(
                             NCBI_TO_ISOLATION_SOURCE_EDGE, LOCATION_OF, organism_id
                         )
@@ -3469,7 +3472,7 @@ class BacDiveTransform(Transform):
                                 NCBI_TO_ISOLATION_SOURCE_EDGE,
                                 organism_id,
                                 LOCATION_OF,
-                                self.source_name,
+                                self.knowledge_source,
                                 knowledge_level,
                                 agent_type,
                             ]

--- a/tests/test_bacdive_edge_provenance_is_a_curie.py
+++ b/tests/test_bacdive_edge_provenance_is_a_curie.py
@@ -1,0 +1,56 @@
+"""Every BacDive edge must name its knowledge source as a CURIE (#432)."""
+
+import ast
+import unittest
+from pathlib import Path
+
+BACDIVE = Path(__file__).resolve().parents[1] / "kg_microbe" / "transform_utils" / "bacdive" / "bacdive.py"
+
+
+def _edge_row_literals(tree: ast.AST):
+    """
+    Yield the list literal of every ``edge_writer.writerow([...])`` call.
+
+    :param tree: Parsed module.
+    :return: Generator of ``ast.List`` nodes.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "writerow"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "edge_writer"):
+            continue
+        if node.args and isinstance(node.args[0], ast.List):
+            yield node.args[0]
+
+
+class BacdiveEdgeProvenanceTests(unittest.TestCase):
+    """The transform has no fixture-driven end-to-end run, so guard the source."""
+
+    def test_no_edge_row_carries_the_bare_source_name(self):
+        """
+        ``self.source_name`` is ``"bacdive"``; ``self.knowledge_source`` is ``infores:bacdive``.
+
+        Two edge sites wrote the former into ``primary_knowledge_source`` and
+        228,738 rebuilt edges (222,880 ``location_of``, 5,858 METPO quality
+        edges) carried a value that is not a CURIE, while every other edge in
+        the same file said ``infores:bacdive`` (#432).
+        """
+        tree = ast.parse(BACDIVE.read_text(encoding="utf-8"))
+        offenders = []
+        for row in _edge_row_literals(tree):
+            for elt in row.elts:
+                if isinstance(elt, ast.Attribute) and elt.attr == "source_name":
+                    offenders.append(row.lineno)
+        self.assertEqual(offenders, [], f"edge rows written with self.source_name at lines {offenders}")
+
+    def test_the_guard_sees_the_edge_rows_it_guards(self):
+        """A guard that matches nothing would pass on any file; pin that it finds rows."""
+        tree = ast.parse(BACDIVE.read_text(encoding="utf-8"))
+        self.assertGreaterEqual(sum(1 for _ in _edge_row_literals(tree)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #432.

## Measured on the rebuilt bacdive output (FRESH, 2026-09-08)

| `primary_knowledge_source` | edges |
|---|---:|
| `bacdive` (bare, not a CURIE) | **228,738** |
| … of which `biolink:location_of` / `RO:0001015` | 222,880 |
| … `METPO:2000067` | 5,056 |
| … `METPO:2000068` | 802 |

Every other edge in the file says `infores:bacdive`, or `['infores:bacdive', 'bacdive:<id>']` where a strain is an endpoint. Two sites wrote `self.source_name` instead of `self.knowledge_source` into the edge row: the isolation-source edge (`bacdive.py` ~3472) and the quality-aware PATO emit (~3370).

## Change

Both sites pass `self.knowledge_source`. The existing `StrainProvenanceWriter` then rewrites it to the list form where the organism is a strain, as it already does for the other edges (`tests/test_bacdive_provenance.py` covers that path for `location_of`).

## Guard

No fixture drives `BacDiveTransform.run()` end to end, so `tests/test_bacdive_edge_provenance_is_a_curie.py` parses the module and fails if any `edge_writer.writerow([...])` carries `self.source_name`; a second test pins that the guard actually finds edge rows. **Fails on the old file, passes on the new** (checked by swapping the file, not with `git stash`).

Rerunning `bacdive` (~11 min) after merge so the graph about to be merged does not carry 228,738 edges with a non-CURIE source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E