### PR TITLE
Derive METPO predicates from the properties template's RANGE, not a column that no longer exists (#568)

### DIFF
--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -185,6 +185,25 @@ class MetpoTreeNode:
         return None
 
 
+#: Classes-tab columns that can carry a Biolink category URI, in precedence order.
+_CLASS_CATEGORY_COLUMNS = ("biolink equivalent", "biolink close match", "biolink broad match")
+
+
+def _class_biolink_category(row: Dict[str, str]) -> str:
+    """
+    Return the Biolink category URI a classes-tab row declares, if any.
+
+    :param row: One row of the METPO classes template.
+    :return: The first URI found across :data:`_CLASS_CATEGORY_COLUMNS`, or "".
+    """
+    for column in _CLASS_CATEGORY_COLUMNS:
+        value = (row.get(column) or "").strip()
+        # The ROBOT template row carries `AI skos:closeMatch`, not a URI.
+        if value.startswith("http"):
+            return value
+    return ""
+
+
 def _build_metpo_tree() -> Dict[str, MetpoTreeNode]:
     """
     Build a tree structure from METPO classes based on parent-child relationships.
@@ -221,7 +240,11 @@ def _build_metpo_tree() -> Dict[str, MetpoTreeNode]:
             label = row.get("label", "").strip()
             madin_synonym = row.get("madin synonym or field", "").strip()
             bacdive_synonym = row.get("bacdive keyword synonym", "").strip()
-            biolink_equivalent = row.get("biolink equivalent", "").strip()
+            # The 2026-06-12 classes tab has no `biolink equivalent` column any more;
+            # the Biolink category now travels in `biolink close match` (and, for a
+            # handful of rows, `biolink broad match`). Reading only the old column
+            # made every lookup below fall to its defaults for months (#568).
+            biolink_equivalent = _class_biolink_category(row)
 
             if iri and label:
                 # handle pipe-separated synonyms from madin column
@@ -303,18 +326,44 @@ def _load_metpo_properties() -> Dict[str, Dict[str, str]]:
         lines = response.text.splitlines()
         reader = csv.DictReader(lines[2:], fieldnames=lines[0].split("\t"), delimiter="\t")
 
-        range_to_predicate = {}
+        # Several properties share one RANGE ("quality" is claimed by `has quality`,
+        # `isolated from host with quality` and `isolated from environment with
+        # quality`; "chemical entity" by eleven). "Last row wins" handed a
+        # class under `quality` to `isolated from environment with quality`
+        # (#568). Prefer, in order: the generic `has <RANGE>` property, one with
+        # a Biolink equivalent, a family root (no parent property), then the
+        # lowest id. Ids alone are not enough: `isolated from host with
+        # quality` is METPO:2000067 and `has quality` METPO:2000101.
+        candidates: Dict[str, list] = {}
         for row in reader:
             range_class = row.get("RANGE", "").strip()
             label = row.get("label", "").strip()
-            biolink_equivalent = row.get("biolink equivalent", "").strip()
-
             if range_class and label:
-                # Map RANGE class labels to property info
-                range_to_predicate[range_class] = {
-                    "label": label,
-                    "biolink_equivalent": biolink_equivalent,
-                }
+                candidates.setdefault(range_class, []).append(
+                    {
+                        "id": row.get("ID", "").strip(),
+                        "label": label,
+                        "biolink_equivalent": row.get("biolink equivalent", "").strip(),
+                        "parent": (row.get("parent property") or "").strip(),
+                    }
+                )
+
+        range_to_predicate = {}
+        for range_class, rows in candidates.items():
+            rows.sort(
+                key=lambda r: (
+                    r["label"] != f"has {range_class}",
+                    not r["biolink_equivalent"],
+                    bool(r["parent"]),
+                    r["id"],
+                )
+            )
+            chosen = rows[0]
+            range_to_predicate[range_class] = {
+                "id": chosen["id"],
+                "label": chosen["label"],
+                "biolink_equivalent": chosen["biolink_equivalent"],
+            }
 
         return range_to_predicate
 
@@ -330,29 +379,55 @@ def _resolve_metpo_predicate(
     """
     Resolve a METPO term's predicate routing via parent-chain traversal.
 
-    Walks the METPO parent chain to find the ``biolink equivalent``
-    ancestor that determines this term's predicate, biolink equivalent,
-    and category. Returns the same five fields the main mapping loop
-    populates so override entries are shape-compatible with
-    remote-fetched ones.
+    Two independent walks up the class tree (#568):
+
+    * **predicate** -- the nearest ancestor (self included) whose *label* is a
+      RANGE in the properties template names the property that relates an
+      organism to this kind of term: a class under ``biological process`` is
+      asserted with ``capable of``, one under ``phenotype`` with ``has
+      phenotype``, one under ``quality`` with ``has quality``. The Biolink
+      predicate is the property's ``biolink equivalent`` when the template
+      declares one, else the shared METPO -> Biolink map.
+    * **category** -- the nearest ancestor (self included) that declares a
+      Biolink category URI on the classes tab.
+
+    The previous single walk required an ancestor with a class-level
+    ``biolink equivalent`` before it would even consult the RANGE table; the
+    pinned classes tab has no such column, so every term fell to the
+    defaults and three transforms asserted ``has_phenotype`` for everything.
+
+    :param metpo_curie: The term to resolve.
+    :param nodes: The class tree from :func:`_build_metpo_tree`.
+    :param range_to_predicate: The RANGE table from :func:`_load_metpo_properties`.
+    :return: ``predicate``, ``predicate_biolink_equivalent``, ``biolink_equivalent``
+        and ``inferred_category``; defaults when the term is unknown.
     """
+    from kg_microbe.utils.metpo_predicates import METPO_TO_BIOLINK_PREDICATE
+
     predicate_label = "has phenotype"
     predicate_biolink_equivalent = ""
     biolink_equivalent = ""
     inferred_category = ""
+    node = nodes.get(metpo_curie)
 
-    if metpo_curie in nodes:
-        current = nodes[metpo_curie]
-        while current is not None:
-            if current.biolink_equivalent:
-                biolink_equivalent = current.biolink_equivalent
-                inferred_category = normalize_biolink_category(current.biolink_equivalent)
-                parent_label = current.label
-                if parent_label in range_to_predicate:
-                    predicate_label = range_to_predicate[parent_label]["label"]
-                    predicate_biolink_equivalent = range_to_predicate[parent_label]["biolink_equivalent"]
-                break
-            current = current.parent
+    current = node
+    while current is not None:
+        if current.label in range_to_predicate:
+            prop = range_to_predicate[current.label]
+            predicate_label = prop["label"]
+            predicate_biolink_equivalent = prop["biolink_equivalent"] or METPO_TO_BIOLINK_PREDICATE.get(
+                prop.get("id", ""), ""
+            )
+            break
+        current = current.parent
+
+    current = node
+    while current is not None:
+        if current.biolink_equivalent:
+            biolink_equivalent = current.biolink_equivalent
+            inferred_category = normalize_biolink_category(current.biolink_equivalent)
+            break
+        current = current.parent
 
     return {
         "predicate": predicate_label,
@@ -475,37 +550,20 @@ def load_metpo_mappings(synonym_column: str) -> Dict[str, Dict[str, str]]:
             synonym = row.get(synonym_column, "").strip()
             metpo_curie = row.get("ID", "").strip()  # already a CURIE
             metpo_label = row.get("label", "").strip()
-            biolink_equivalent = row.get("biolink equivalent", "").strip()
 
             if synonym and metpo_curie:
-                # Find the appropriate predicate and category using tree traversal logic:
-                # 1. find the closest parent with `biolink equivalent`
-                # 2. use the parent's label to find matching RANGE in properties sheet
-                # 3. get the predicate info for that RANGE
-                # 4. use the parent's label as the category
-                predicate_label = "has phenotype"  # default
-                predicate_biolink_equivalent = ""  # default empty
-                inferred_category = ""  # default empty, will be inferred from parent
+                # One implementation of the walk, shared with the alias overrides
+                # (#568): predicate from the nearest RANGE ancestor, category from
+                # the nearest ancestor declaring a Biolink category.
+                resolved = _resolve_metpo_predicate(metpo_curie, nodes, range_to_predicate)
+                predicate_label = resolved["predicate"]
+                predicate_biolink_equivalent = resolved["predicate_biolink_equivalent"]
+                biolink_equivalent = resolved["biolink_equivalent"]
+                inferred_category = resolved["inferred_category"]
                 immediate_parent_label = None  # Track the immediate parent for compound keys
 
-                if metpo_curie in nodes:
-                    node = nodes[metpo_curie]
-                    # Get immediate parent label for compound key creation
-                    if node.parent:
-                        immediate_parent_label = node.parent.label
-
-                    # find the parent node that has a `biolink equivalent`
-                    current = node
-                    while current is not None:
-                        if current.biolink_equivalent:
-                            # use the parent's biolink_equivalent URL as the category
-                            parent_label = current.label
-                            inferred_category = normalize_biolink_category(current.biolink_equivalent)
-                            if parent_label in range_to_predicate:
-                                predicate_label = range_to_predicate[parent_label]["label"]
-                                predicate_biolink_equivalent = range_to_predicate[parent_label]["biolink_equivalent"]
-                            break
-                        current = current.parent
+                if metpo_curie in nodes and nodes[metpo_curie].parent:
+                    immediate_parent_label = nodes[metpo_curie].parent.label
 
                 # handle pipe-separated synonyms
                 synonyms = [s.strip() for s in synonym.split("|")]

--- a/tests/test_metpo_predicate_derivation.py
+++ b/tests/test_metpo_predicate_derivation.py
@@ -1,0 +1,136 @@
+"""A METPO term's Biolink predicate must come from the properties template, not a default (#568)."""
+
+import os
+import unittest
+from importlib import import_module
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+mfu = import_module("kg_microbe.utils.mapping_file_utils")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: A classes tab shaped like the pinned 2026-06-12 template: no `biolink
+#: equivalent` column, categories in `biolink close match`, a ROBOT row second.
+SHEET = "\t".join(
+    ["ID", "label", "parent classes (one strongly preferred)", "metatraits synonym", "biolink close match"]
+) + "\n" + "\t".join(["ID", "LABEL", "SC %", "A oboInOwl:hasRelatedSynonym", "AI skos:closeMatch"]) + "\n" + "\n".join(
+    [
+        "METPO:1\tphenotype\t\t\thttps://biolink.github.io/biolink-model/PhenotypicQuality",
+        "METPO:2\tbiological process\t\t\t",
+        "METPO:3\tquality\t\t\t",
+        "METPO:4\tmotility\tphenotype\tmotile\t",
+        "METPO:5\tnitrogen fixation\tbiological process\tnitrogen fixer\t",
+        "METPO:6\tsalt tolerance\tquality\thalotolerant\t",
+        "METPO:7\tunplaced trait\t\torphan\t",
+    ]
+) + "\n"
+
+PROPERTIES = "\t".join(["ID", "label", "RANGE", "parent property", "biolink equivalent"]) + "\n" + "\t".join(
+    ["ID", "LABEL", "RANGE", "SP %", "AI skos:exactMatch"]
+) + "\n" + "\n".join(
+    [
+        "METPO:2000101\thas quality\tquality\t\t",
+        "METPO:2000067\tisolated from host with quality\tquality\t\t",
+        "METPO:2000102\thas phenotype\tphenotype\thas quality\thttps://biolink.github.io/biolink-model/has_phenotype",
+        "METPO:2000103\tcapable of\tbiological process\t\thttps://biolink.github.io/biolink-model/capable_of",
+    ]
+) + "\n"
+
+
+class _Templates:
+    """Point the loaders at a throwaway template directory for one test."""
+
+    def __init__(self, sheet=SHEET, properties=PROPERTIES):
+        self.sheet, self.properties = sheet, properties
+
+    def __enter__(self):
+        self._td = TemporaryDirectory()
+        root = Path(self._td.name)
+        (root / "metpo_sheet.tsv").write_text(self.sheet, encoding="utf-8")
+        (root / "metpo-properties.tsv").write_text(self.properties, encoding="utf-8")
+        self._old = os.environ.get("KG_MICROBE_METPO_TEMPLATE_DIR")
+        os.environ["KG_MICROBE_METPO_TEMPLATE_DIR"] = str(root)
+        return mfu.load_metpo_mappings("metatraits synonym")
+
+    def __exit__(self, *exc):
+        if self._old is None:
+            os.environ.pop("KG_MICROBE_METPO_TEMPLATE_DIR", None)
+        else:
+            os.environ["KG_MICROBE_METPO_TEMPLATE_DIR"] = self._old
+        self._td.cleanup()
+
+
+class PredicateDerivationTests(unittest.TestCase):
+    """The RANGE walk, on a sheet with no class-level `biolink equivalent`."""
+
+    def test_a_process_is_asserted_with_capable_of(self):
+        """
+        The #568 no-op.
+
+        Requiring a class-level `biolink equivalent` before consulting the
+        RANGE table meant this walked to the root and fell to `has phenotype`.
+        """
+        with _Templates() as m:
+            self.assertEqual(m["nitrogen fixer"]["predicate"], "capable of")
+            self.assertTrue(m["nitrogen fixer"]["predicate_biolink_equivalent"].endswith("/capable_of"))
+
+    def test_a_phenotype_keeps_has_phenotype(self):
+        """The common case is unchanged, and now reached on purpose."""
+        with _Templates() as m:
+            self.assertEqual(m["motile"]["predicate"], "has phenotype")
+            self.assertTrue(m["motile"]["predicate_biolink_equivalent"].endswith("/has_phenotype"))
+
+    def test_a_quality_gets_the_generic_property_not_a_colliding_one(self):
+        """
+        Three properties share RANGE `quality`; last-row-wins picked an isolation one.
+
+        The generic `has <RANGE>` property wins, and its Biolink predicate
+        comes from the shared METPO -> Biolink map when the template has none.
+        """
+        with _Templates() as m:
+            self.assertEqual(m["halotolerant"]["predicate"], "has quality")
+            self.assertEqual(m["halotolerant"]["predicate_biolink_equivalent"], "biolink:has_attribute")
+
+    def test_the_category_comes_from_the_close_match_column(self):
+        """The classes tab lost `biolink equivalent`; `biolink close match` carries the URI now."""
+        with _Templates() as m:
+            # A URI here; the transforms compress it with uri_to_curie at emit time.
+            self.assertTrue(m["motile"]["inferred_category"].endswith("/PhenotypicQuality"))
+
+    def test_a_term_with_no_range_ancestor_falls_to_the_default(self):
+        """Unplaced is still unplaced; the default is a fallback, not the rule."""
+        with _Templates() as m:
+            self.assertEqual(m["orphan"]["predicate"], "has phenotype")
+            self.assertEqual(m["orphan"]["predicate_biolink_equivalent"], "")
+
+    def test_the_robot_template_row_is_not_read_as_a_category(self):
+        """`AI skos:closeMatch` is a ROBOT directive, not a URI."""
+        row = {"biolink close match": "AI skos:closeMatch", "biolink broad match": ""}
+        self.assertEqual(mfu._class_biolink_category(row), "")
+
+
+PINNED_SHEET = REPO_ROOT / "data" / "raw" / "metpo_sheet.tsv"
+
+
+@unittest.skipUnless(PINNED_SHEET.is_file(), "pinned METPO templates not downloaded")
+class PinnedSheetTests(unittest.TestCase):
+    """On the real pinned templates, the derivation must not be a no-op."""
+
+    def test_at_least_one_metatraits_term_is_not_has_phenotype(self):
+        """Before #568 all 102 metatraits synonyms resolved to `has phenotype`."""
+        old = os.environ.get("KG_MICROBE_METPO_TEMPLATE_DIR")
+        os.environ["KG_MICROBE_METPO_TEMPLATE_DIR"] = str(REPO_ROOT / "data" / "raw")
+        try:
+            m = mfu.load_metpo_mappings("metatraits synonym")
+        finally:
+            if old is None:
+                os.environ.pop("KG_MICROBE_METPO_TEMPLATE_DIR", None)
+            else:
+                os.environ["KG_MICROBE_METPO_TEMPLATE_DIR"] = old
+        predicates = {v["predicate"] for v in m.values()}
+        self.assertIn("capable of", predicates, sorted(predicates))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #568.

## The no-op

`load_metpo_mappings` walked a term's ancestors for one with a class-level `biolink equivalent` and only then consulted the properties template's RANGE table. The pinned classes tab has no such column (its Biolink URIs moved to `biolink close match` / `biolink broad match`), so the walk always came back empty and **all 393 synonyms across four columns resolved to the default `has phenotype` with no category**. `madin_etal`, `bactotraits` and `metatraits_gtdb` therefore asserted `biolink:has_phenotype` for processes and qualities alike — the `has_phenotype`-on-process-endpoints half of #643.

## The change

One resolver (`_resolve_metpo_predicate`, now used by the main loop and the alias overrides), two walks:

- **predicate** — nearest ancestor whose *label* is a RANGE in the properties template: under `biological process` → `capable of`; under `phenotype` → `has phenotype`; under `quality` → `has quality`. Biolink predicate from the property's `biolink equivalent`, else the shared METPO→Biolink map (`biolink:has_attribute` for `has quality`).
- **category** — nearest ancestor declaring a Biolink category URI, read from `biolink equivalent` → `biolink close match` → `biolink broad match`; the ROBOT directive row (`AI skos:closeMatch`) is not a URI.

Also fixed a collision in the RANGE table: "quality" is claimed by three properties and "chemical entity" by eleven; last-row-wins handed every quality to `isolated from environment with quality`. The generic `has <RANGE>` wins, then Biolink-equivalent, then family root, then lowest id (ids alone fail: `isolated from host with quality` is METPO:2000067, `has quality` METPO:2000101).

## Measured on the pinned templates

| column | before | after |
|---|---|---|
| metatraits synonym (102) | 102 `has phenotype`, 0 categories | 75 `has phenotype` / 21 `has quality`→`biolink:has_attribute` / 6 `capable of`; 75 with a category |
| bactotraits related synonym (159) | 159 / 0 | 135 / 23 / 1; 135 with a category |

## Tests

`tests/test_metpo_predicate_derivation.py` drives a template shaped like the pinned one (no `biolink equivalent`, categories in `biolink close match`, ROBOT row second): process → `capable of`, phenotype → `has phenotype`, quality → the generic property not the colliding one, category from the close-match column, orphan → default, directive row ignored. A skip-unless-present test on the real sheet pins that it no longer collapses. Existing madin/metatraits/category-alignment tests: 62 passed.

## Follow-through

`madin_etal`, `bactotraits`, `metatraits_gtdb` must rerun for this to reach the graph, then the merge — that is the targeted rerun the rebuild decision deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E