### PR TITLE
lpsn_api declares the records it links to; METPO processes are typed as processes (#991, #438)

### DIFF
--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -153,7 +153,7 @@ class LPSNAPITransform(Transform):
         super().__init__(LPSN_API_SOURCE, input_dir, output_dir)
         self.knowledge_source = LPSN_KNOWLEDGE_SOURCE
         self._client_override = client
-        self._stats = {"fetched": 0, "from_cache": 0, "errors": 0}
+        self._stats = {"fetched": 0, "from_cache": 0, "errors": 0, "linked_declared": 0, "linked_stubbed": 0}
 
     # ------------------------------------------------------------------
     # public entry point
@@ -202,16 +202,26 @@ class LPSNAPITransform(Transform):
             node_writer.writerow(self.node_header)
             edge_writer.writerow(self.edge_header)
 
-            for record_no in self._iter_record_nos(gss_nodes):
+            # Every record the GSS declares, plus every record this file links
+            # to. The parent chain above genus and the basonym targets are not
+            # in the GSS, and without a node row KGX invents a bare NamedThing
+            # for each at merge time -- 1,344 of them in the 2026-09-08 graph
+            # (#991). Same rule LPSN applies to deposits (#932).
+            self._declared = set(self._iter_record_nos(gss_nodes))
+            for record_no in sorted(self._declared):
                 record = self._fetch(client, record_no, cache_dir)
                 if record is None:
                     continue
                 self._emit(record_no, record, node_writer, edge_writer)
+                for ref in self._linked_record_nos(record_no, record):
+                    self._ensure_declared(client, ref, cache_dir, node_writer, edge_writer)
 
         print(
             f"[lpsn_api] fetched={self._stats['fetched']:,} "
             f"cached={self._stats['from_cache']:,} "
-            f"errors={self._stats['errors']:,}"
+            f"errors={self._stats['errors']:,} "
+            f"linked_records_declared={self._stats.get('linked_declared', 0):,} "
+            f"linked_records_stubbed={self._stats.get('linked_stubbed', 0):,}"
         )
 
     # ------------------------------------------------------------------
@@ -318,6 +328,59 @@ class LPSNAPITransform(Transform):
         self._stats["fetched"] += 1
         return record
 
+    #: How far up `lpsn_parent_id` to walk. LPSN's ranks stop at domain; a
+    #: cycle in the data would otherwise be an infinite fetch loop.
+    _MAX_LINK_DEPTH = 12
+
+    @staticmethod
+    def _linked_record_nos(record_no: str, record: dict) -> list:
+        """
+        Return the LPSN record numbers this record's edges point at.
+
+        :param record_no: The record being emitted.
+        :param record: Its JSON payload.
+        :return: Parent and basonym record numbers, as strings, excluding self.
+        """
+        refs = []
+        for key in (JSON_LPSN_PARENT_ID, JSON_BASONYM_ID):
+            value = str(record.get(key) or "").strip()
+            if value.isdigit() and value != record_no:
+                refs.append(value)
+        return refs
+
+    def _ensure_declared(
+        self, client: Any, record_no: str, cache_dir: Path, node_writer, edge_writer, depth: int = 0
+    ) -> None:
+        """
+        Write a node row for a linked record the GSS does not cover, once.
+
+        Fetches the record so the node carries LPSN's own name and status,
+        emits its own parent/basonym edges, and walks up so the chain to the
+        domain is declared end to end. When the API has nothing for it, a
+        bare stub still declares the endpoint -- an unnamed node in our own
+        namespace beats one KGX invents, because it says where it came from.
+
+        :param client: The LPSN client.
+        :param record_no: The referenced record number.
+        :param cache_dir: API cache directory.
+        :param node_writer: Nodes writer.
+        :param edge_writer: Edges writer.
+        :param depth: Recursion depth, capped at :attr:`_MAX_LINK_DEPTH`.
+        """
+        if record_no in self._declared or depth > self._MAX_LINK_DEPTH:
+            return
+        self._declared.add(record_no)
+        record = self._fetch(client, record_no, cache_dir)
+        if record is None:
+            node_writer.writerow(self._stub_linked_node(record_no))
+            self._stats["linked_stubbed"] = self._stats.get("linked_stubbed", 0) + 1
+            return
+        node_writer.writerow(self._make_linked_node(record_no, record))
+        self._stats["linked_declared"] = self._stats.get("linked_declared", 0) + 1
+        self._emit_links(record_no, record, edge_writer)
+        for ref in self._linked_record_nos(record_no, record):
+            self._ensure_declared(client, ref, cache_dir, node_writer, edge_writer, depth + 1)
+
     def _emit(self, record_no: str, record: dict, node_writer, edge_writer) -> None:
         """Write enrichment rows for one LPSN record's JSON payload."""
         # Node update: description enriched with nomenclatural + taxonomic
@@ -326,17 +389,7 @@ class LPSNAPITransform(Transform):
         # merger keeps the union of columns).
         node_writer.writerow(self._make_enrichment_node(record_no, record))
 
-        # Parent link (above-genus taxonomy). LPSN returns record_no as
-        # an int, so coerce before doing string operations.
-        parent = str(record.get(JSON_LPSN_PARENT_ID) or "").strip()
-        if parent.isdigit() and parent != record_no:
-            edge_writer.writerow(self._edge(record_no, SUBCLASS_PREDICATE, f"{LPSN_PREFIX}{parent}", RDFS_SUBCLASS_OF))
-
-        # Basonym link (nomenclatural equivalence — a comb. nov. / new
-        # combination points at its basonym, the original name).
-        basonym = str(record.get(JSON_BASONYM_ID) or "").strip()
-        if basonym.isdigit() and basonym != record_no:
-            edge_writer.writerow(self._edge(record_no, SAME_AS_PREDICATE, f"{LPSN_PREFIX}{basonym}", EXACT_MATCH))
+        self._emit_links(record_no, record, edge_writer)
 
         # Publication cross-refs. LPSN populates one or both of DOI/PMID
         # per record for the valid publication of the name, plus (often)
@@ -405,6 +458,61 @@ class LPSNAPITransform(Transform):
         for col, val in {
             "id": curie,
             "category": "biolink:NucleicAcidEntity",
+            "provided_by": LPSN_KNOWLEDGE_SOURCE,
+        }.items():
+            if col in headers:
+                row[headers.index(col)] = val
+        return row
+
+    def _emit_links(self, record_no: str, record: dict, edge_writer) -> None:
+        """
+        Write the parent and basonym edges for one record.
+
+        :param record_no: The record.
+        :param record: Its JSON payload.
+        :param edge_writer: Edges writer.
+        """
+        # Parent link (above-genus taxonomy). LPSN returns record_no as
+        # an int, so coerce before doing string operations.
+        parent = str(record.get(JSON_LPSN_PARENT_ID) or "").strip()
+        if parent.isdigit() and parent != record_no:
+            edge_writer.writerow(self._edge(record_no, SUBCLASS_PREDICATE, f"{LPSN_PREFIX}{parent}", RDFS_SUBCLASS_OF))
+
+        # Basonym link (nomenclatural equivalence — a comb. nov. / new
+        # combination points at its basonym, the original name).
+        basonym = str(record.get(JSON_BASONYM_ID) or "").strip()
+        if basonym.isdigit() and basonym != record_no:
+            edge_writer.writerow(self._edge(record_no, SAME_AS_PREDICATE, f"{LPSN_PREFIX}{basonym}", EXACT_MATCH))
+
+    def _make_linked_node(self, record_no: str, record: dict) -> list:
+        """
+        Build a full node row for a linked record the GSS does not carry.
+
+        :param record_no: The record.
+        :param record: Its JSON payload; ``full_name`` becomes the label.
+        :return: A row aligned to ``node_header``.
+        """
+        row = self._make_enrichment_node(record_no, record)
+        headers = self.node_header
+        if "name" in headers:
+            row[headers.index("name")] = (record.get(JSON_FULL_NAME) or "").strip()
+        return row
+
+    def _stub_linked_node(self, record_no: str) -> list:
+        """
+        Build a bare node row for a linked record the API could not supply.
+
+        :param record_no: The record.
+        :return: A row aligned to ``node_header``.
+        """
+        headers = self.node_header
+        row = [""] * len(headers)
+        for col, val in {
+            "id": f"{LPSN_PREFIX}{record_no}",
+            "category": NCBI_CATEGORY,
+            "description": (
+                "LPSN record linked from another record; not retrievable from the LPSN API when this file was built"
+            ),
             "provided_by": LPSN_KNOWLEDGE_SOURCE,
         }.items():
             if col in headers:

--- a/kg_microbe/utils/mapping_file_utils.py
+++ b/kg_microbe/utils/mapping_file_utils.py
@@ -371,6 +371,19 @@ def _load_metpo_properties() -> Dict[str, Dict[str, str]]:
         raise requests.exceptions.HTTPError(f"Please ensure the METPO properties URL is accessible: {e}") from e
 
 
+#: Biolink category implied by a RANGE ancestor when no class on the path
+#: declares one. The METPO `biological process` class carries no close match,
+#: so every term under it fell to the transforms' default (PhenotypicQuality)
+#: and 148,357 `capable_of` edges pointed at "qualities" that are processes
+#: (#438). Declared categories always win; this is the fallback.
+_RANGE_FALLBACK_CATEGORY = {
+    "biological process": "biolink:BiologicalProcess",
+    "chemical entity": "biolink:ChemicalEntity",
+    "phenotype": "biolink:PhenotypicQuality",
+    "quality": "biolink:PhenotypicQuality",
+}
+
+
 def _resolve_metpo_predicate(
     metpo_curie: str,
     nodes: Dict[str, "MetpoTreeNode"],
@@ -410,10 +423,12 @@ def _resolve_metpo_predicate(
     inferred_category = ""
     node = nodes.get(metpo_curie)
 
+    range_label = ""
     current = node
     while current is not None:
         if current.label in range_to_predicate:
             prop = range_to_predicate[current.label]
+            range_label = current.label
             predicate_label = prop["label"]
             predicate_biolink_equivalent = prop["biolink_equivalent"] or METPO_TO_BIOLINK_PREDICATE.get(
                 prop.get("id", ""), ""
@@ -428,6 +443,9 @@ def _resolve_metpo_predicate(
             inferred_category = normalize_biolink_category(current.biolink_equivalent)
             break
         current = current.parent
+
+    if not inferred_category:
+        inferred_category = _RANGE_FALLBACK_CATEGORY.get(range_label, "")
 
     return {
         "predicate": predicate_label,

--- a/tests/test_lpsn_api_transform.py
+++ b/tests/test_lpsn_api_transform.py
@@ -77,6 +77,19 @@ def api_records():
                 {"kind": "16S rRNA gene", "database": "silva", "identifier": "SILVA123"},
             ],
         },
+        "1001": {
+            "id": 1001,
+            "full_name": "Escherichia",
+            "publication_doi": "",
+            "publication_pmid": None,
+            "ijsem_list_doi": "",
+            "lpsn_parent_id": 999,  # family; deliberately absent from the fake API
+            "basonym_id": None,
+            "is_legitimate": True,
+            "nomenclatural_status": "correct name",
+            "lpsn_taxonomic_status": "correct name",
+            "molecules": [],
+        },
         "1005": {
             "id": 1005,
             "publication_doi": "",
@@ -276,3 +289,66 @@ def test_empty_molecules_emit_no_insdc_edges(api_transform):
     edges = _read_tsv(api_transform.output_edge_file)
     hits = [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1005" and e["object"].startswith("INSDC:")]
     assert hits == []
+
+
+def _linked_targets(edges):
+    """Every lpsn:* object of a subclass_of / same_as edge."""
+    return {
+        e["object"]
+        for e in edges
+        if e["object"].startswith(LPSN_PREFIX) and e["predicate"] in ("biolink:subclass_of", "biolink:same_as")
+    }
+
+
+def test_every_linked_record_has_a_node_row(api_transform):
+    """
+    #991: 1,344 lpsn:* endpoints were invented by KGX at merge time.
+
+    The parent chain above genus and the basonym targets are not in the GSS,
+    so nothing declared them. Every record this file links to now has a row.
+    """
+    api_transform.run()
+    nodes = {n["id"] for n in _read_tsv(api_transform.output_node_file)}
+    missing = _linked_targets(_read_tsv(api_transform.output_edge_file)) - nodes
+    assert not missing, sorted(missing)
+
+
+def test_a_fetchable_linked_record_is_named_and_walks_up(api_transform):
+    """The genus (1001) is fetched, labelled from full_name, and its own parent edge is emitted."""
+    api_transform.run()
+    nodes = {n["id"]: n for n in _read_tsv(api_transform.output_node_file)}
+    genus = nodes[f"{LPSN_PREFIX}1001"]
+    assert genus["name"] == "Escherichia"
+    assert genus["category"] == "biolink:OrganismTaxon"
+    edges = _read_tsv(api_transform.output_edge_file)
+    assert any(
+        e["subject"] == f"{LPSN_PREFIX}1001"
+        and e["object"] == f"{LPSN_PREFIX}999"
+        and e["predicate"] == "biolink:subclass_of"
+        for e in edges
+    )
+    assert api_transform._stats["linked_declared"] >= 1
+
+
+def test_an_unfetchable_linked_record_gets_a_declared_stub(api_transform):
+    """
+    The family (999) and the basonym (1004) are not in the API.
+
+    A bare stub in our own namespace, saying so, beats a NamedThing KGX
+    invents with nothing on it.
+    """
+    api_transform.run()
+    nodes = {n["id"]: n for n in _read_tsv(api_transform.output_node_file)}
+    for ref in ("999", "1004"):
+        stub = nodes[f"{LPSN_PREFIX}{ref}"]
+        assert stub["category"] == "biolink:OrganismTaxon"
+        assert stub["name"] == ""
+        assert "not retrievable" in stub["description"]
+    assert api_transform._stats["linked_stubbed"] == 2
+
+
+def test_a_linked_record_is_declared_once(api_transform):
+    """1002 and 1005 both sit under genus 1001 (via 1002); one row for it, not two."""
+    api_transform.run()
+    ids = [n["id"] for n in _read_tsv(api_transform.output_node_file)]
+    assert ids.count(f"{LPSN_PREFIX}1001") == 1

--- a/tests/test_metpo_predicate_derivation.py
+++ b/tests/test_metpo_predicate_derivation.py
@@ -98,6 +98,23 @@ class PredicateDerivationTests(unittest.TestCase):
             # A URI here; the transforms compress it with uri_to_curie at emit time.
             self.assertTrue(m["motile"]["inferred_category"].endswith("/PhenotypicQuality"))
 
+    def test_a_process_with_no_declared_category_is_typed_as_a_process(self):
+        """
+        #438: four METPO processes reached the graph as PhenotypicQuality.
+
+        `biological process` declares no Biolink category, so the transforms'
+        default won and 148,357 `capable_of` edges pointed at "qualities".
+        The RANGE ancestor implies the category when nothing on the path
+        declares one.
+        """
+        with _Templates() as m:
+            self.assertEqual(m["nitrogen fixer"]["inferred_category"], "biolink:BiologicalProcess")
+
+    def test_a_declared_category_beats_the_range_fallback(self):
+        """The fallback is a fallback: `phenotype` declares PhenotypicQuality and keeps it."""
+        with _Templates() as m:
+            self.assertTrue(m["motile"]["inferred_category"].endswith("/PhenotypicQuality"))
+
     def test_a_term_with_no_range_ancestor_falls_to_the_default(self):
         """Unplaced is still unplaced; the default is a fallback, not the rule."""
         with _Templates() as m:


### PR DESCRIPTION
Closes #991. Closes #438.

## #991 — 1,344 invented `lpsn:*` nodes

`lpsn_api` emits `subclass_of` edges to the parent chain above genus and `same_as` edges to basonyms, but the GSS covers genus and below and the API layer only fetched GSS records — so nothing declared those endpoints and KGX invented 1,344 bare NamedThings in the 2026-09-08 merge.

Every linked record is now declared, once: fetched through the existing cache so the node carries LPSN's `full_name` and status, its own parent/basonym edges emitted, and the walk continued up to the domain (depth-capped at 12). When the API has nothing, a stub in our own namespace still declares the endpoint with a description saying so — an unnamed node that records its origin beats one KGX invents with nothing on it. The completion line reports `linked_records_declared` / `linked_records_stubbed`.

## #438 — four processes typed as qualities

All 148,357 `capable_of → PhenotypicQuality` edges in metatraits_gtdb point at **four** METPO classes: Fermentation, nitrification, nitrogen fixation, denitrification. The predicate is right; the category was the transform default, because the METPO `biological process` class declares no Biolink category. The resolver now falls back to the category the RANGE ancestor implies (`biological process → BiologicalProcess`, `chemical entity → ChemicalEntity`, `phenotype`/`quality → PhenotypicQuality`) when nothing on the path declares one. A declared category still wins (tested).

## Tests

- lpsn_api: every linked target has a node row; a fetchable genus is named and walks up; unfetchable family/basonym get declared stubs; a shared parent is declared once. **All four fail on the old code.**
- predicate derivation: process with no declared category → `biolink:BiologicalProcess`; declared category beats the fallback. **Fails on the old resolver.**
- 125 tests across lpsn, lpsn_api, microbedecoder, madin and category alignment pass; ruff clean.

## Follow-through

Per the decisions on record: rerun `lpsn_api`, `madin_etal`, `bactotraits`, `metatraits_gtdb`, then the **canonical `merge.yaml`** (habitat PREGO), which refreshes `merged-kg.tar.gz` and `merged_graph_stats.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E