### PR TITLE
Fingerprint the shared code too, hash by relative name, and migrate the markers that still hold (#1002, #983)

### DIFF
--- a/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
+++ b/.claude/skills/kgm-freshness-check/kgm_freshness_check.py
@@ -331,6 +331,7 @@ def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
             data_fingerprint,
             read_fingerprint,
             schema_fingerprint,
+            shared_code_fingerprint,
             upstream_fingerprint,
         )
     except ImportError:
@@ -340,7 +341,12 @@ def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
         recorded = read_fingerprint(TRANSFORMED_DIR / name)
         if recorded is None:
             continue
-        code_stale = recorded.get("code") != code_fingerprint(code_dir)
+        # The package, then the first-party code every transform shares (#1002):
+        # either moving means the output may differ, and the note says which.
+        package_stale = recorded.get("code") != code_fingerprint(code_dir, REPO)
+        shared_stale = recorded.get("shared") != shared_code_fingerprint(REPO)
+        code_stale = package_stale or shared_stale
+        code_what = "code" if package_stale else "shared code (utils/, constants.py, transform.py)"
         data_stale = recorded.get("data") != data_fingerprint(REPO, _declared_data_inputs(source))
         upstream_stale = recorded.get("upstream") != upstream_fingerprint(
             TRANSFORMED_DIR, _declared_transform_inputs(source)
@@ -363,9 +369,15 @@ def _fingerprint_verdict(source: str, code_dir: Path) -> Optional[tuple]:
                 f"{upstreams} rebuilt since this output; rerun `poetry run kg transform -s {source}`",
             )
         if code_stale and data_stale:
-            return "STALE_VS_CODE_AND_DATA", f"code and data differ from the recorded build; rerun `poetry run kg transform -s {source}`"
+            return (
+                "STALE_VS_CODE_AND_DATA",
+                f"{code_what} and data differ from the recorded build; rerun `poetry run kg transform -s {source}`",
+            )
         if code_stale:
-            return "STALE_VS_CODE", f"code differs from the recorded build; rerun `poetry run kg transform -s {source}`"
+            return (
+                "STALE_VS_CODE",
+                f"{code_what} differs from the recorded build; rerun `poetry run kg transform -s {source}`",
+            )
         if data_stale:
             return "STALE_VS_DATA", f"a declared data input differs from the recorded build; rerun `poetry run kg transform -s {source}`"
         return "FRESH", "verified by content fingerprint"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,13 @@ fetches every file the shipped model imports, at one pinned tag. Updating the
 Biolink version requires changing `download.yaml`, the lock file, fixtures, and
 tests together. Each transform's `source_fingerprint.json` records the schema
 it was built against, and `kgm-freshness-check` reports `STALE_VS_SCHEMA` when
-the pinned model has moved since (#943).
+the pinned model has moved since (#943). The marker also covers the shared
+code every transform runs through (`kg_microbe/utils/`, `constants.py`,
+`transform.py`), not only the transform's own package, and hashes by
+repo-relative name so a marker reads the same from any checkout (#1002,
+#983). When the fingerprint scheme changes, run
+`poetry run python scripts/migrate_fingerprints.py` before trusting the table:
+it rewrites markers that still hold and leaves stale ones for a real rerun.
 
 A pin bump alone does not refresh `data/raw`. The 4.4.2 bump landed in August
 2026 and the 4.3.6 file already on disk was never replaced, so every run since

--- a/kg_microbe/utils/transform_fingerprint.py
+++ b/kg_microbe/utils/transform_fingerprint.py
@@ -26,7 +26,7 @@ import hashlib
 import json
 import re
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Dict, Iterable, Optional
 
 from kg_microbe.utils.atomic_io import atomic_write
 
@@ -35,7 +35,16 @@ FINGERPRINT_FILE = "source_fingerprint.json"
 
 #: Bumped when the hashing scheme changes, so an old marker is treated as
 #: absent rather than silently compared under different rules.
-FINGERPRINT_VERSION = 2
+FINGERPRINT_VERSION = 3
+
+#: First-party code every transform runs through besides its own package.
+#: A change here changes outputs just as much as a change in the package, and
+#: most behaviour-changing PRs land here (#1002).
+SHARED_CODE = (
+    Path("kg_microbe") / "utils",
+    Path("kg_microbe") / "transform_utils" / "constants.py",
+    Path("kg_microbe") / "transform_utils" / "transform.py",
+)
 
 # Files at or below this size are cheap enough to hash completely. Larger graph
 # TSVs are sampled at evenly spaced offsets so a freshness check does bounded IO
@@ -80,21 +89,47 @@ def bounded_file_fingerprint(path: Path) -> str:
     return f"sampled-sha256:{digest.hexdigest()}"
 
 
-def _hash_files(paths: Iterable[Path]) -> str:
-    """
-    Hash a set of files by path and content, order-independently.
+def _repo_root() -> Path:
+    """Return the repository root this module lives in."""
+    return Path(__file__).resolve().parents[2]
 
-    The path is folded in as well as the bytes, so renaming a file — which
+
+def _folded_name(path: Path, relative_to: Optional[Path]) -> str:
+    """
+    Return the name folded into a digest for ``path``.
+
+    Repo-relative when ``relative_to`` is given: the absolute path made the
+    same files under two checkouts hash differently, so a marker carried with
+    its output directory read as stale from any other root (#983).
+
+    :param path: File path.
+    :param relative_to: Root to relativise against, or None for the path as is.
+    :return: The name to fold in.
+    """
+    if relative_to is not None:
+        try:
+            return path.resolve().relative_to(relative_to.resolve()).as_posix()
+        except ValueError:
+            pass
+    return path.as_posix()
+
+
+def _hash_files(paths: Iterable[Path], relative_to: Optional[Path] = None) -> str:
+    """
+    Hash a set of files by name and content, order-independently.
+
+    The name is folded in as well as the bytes, so renaming a file — which
     changes what runs without changing any content — is a different
     fingerprint. Missing files are folded in as such rather than skipped: a
     deleted curation file is a change, and skipping it would read as no change.
 
     :param paths: Files to fingerprint.
+    :param relative_to: Fold repo-relative names rather than absolute paths.
     :return: Hex digest.
     """
     digest = hashlib.sha256()
     for path in sorted(set(paths), key=lambda p: p.as_posix()):
-        digest.update(path.as_posix().encode("utf-8"))
+        digest.update(_folded_name(path, relative_to).encode("utf-8"))
         digest.update(b"\0")
         try:
             digest.update(hashlib.sha256(path.read_bytes()).digest())
@@ -133,7 +168,24 @@ def _behaviour_digest(path: Path) -> bytes:
         return hashlib.sha256(source).digest()
 
 
-def code_fingerprint(code_dir: Path) -> str:
+def _behaviour_tree_digest(paths: Iterable[Path], relative_to: Optional[Path]) -> str:
+    """
+    Digest Python files by behaviour, keyed by repo-relative name.
+
+    :param paths: Python files.
+    :param relative_to: Root the names are relative to.
+    :return: Hex digest.
+    """
+    digest = hashlib.sha256()
+    for path in sorted(paths, key=lambda p: p.as_posix()):
+        digest.update(_folded_name(path, relative_to).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(_behaviour_digest(path))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def code_fingerprint(code_dir: Path, repo_root: Optional[Path] = None) -> str:
     """
     Fingerprint every Python file in a transform's package directory.
 
@@ -142,18 +194,41 @@ def code_fingerprint(code_dir: Path) -> str:
     across helper modules in the same package, and a change to one of those
     changes the output just as much.
 
+    Names are folded in repo-relative, so the same package under two
+    checkouts is one fingerprint (#983).
+
     :param code_dir: e.g. ``kg_microbe/transform_utils/gold``.
+    :param repo_root: Repository root; inferred from this module when omitted.
     :return: Hex digest, or the digest of nothing when the directory is absent.
     """
     if not code_dir.is_dir():
         return hashlib.sha256(b"").hexdigest()
-    digest = hashlib.sha256()
-    for path in sorted(code_dir.rglob("*.py"), key=lambda p: p.as_posix()):
-        digest.update(path.as_posix().encode("utf-8"))
-        digest.update(b"\0")
-        digest.update(_behaviour_digest(path))
-        digest.update(b"\0")
-    return digest.hexdigest()
+    return _behaviour_tree_digest(code_dir.rglob("*.py"), repo_root or _repo_root())
+
+
+def shared_code_fingerprint(repo_root: Optional[Path] = None) -> str:
+    """
+    Fingerprint the first-party code every transform shares.
+
+    ``code_fingerprint`` sees only the transform's own package, so a change in
+    ``kg_microbe/utils/`` -- the mapping loaders, the ontology adapters, the
+    chemical-mapping utils -- or in ``constants.py`` marked nothing stale:
+    #999 changed three transforms' predicates and the freshness table stayed
+    FRESH (#1002). Blunt by design: an edit here reads as "every output may
+    differ", which is the honest answer.
+
+    :param repo_root: Repository root; inferred from this module when omitted.
+    :return: Hex digest.
+    """
+    root = repo_root or _repo_root()
+    paths = []
+    for rel in SHARED_CODE:
+        target = root / rel
+        if target.is_dir():
+            paths.extend(target.rglob("*.py"))
+        elif target.is_file():
+            paths.append(target)
+    return _behaviour_tree_digest(paths, root)
 
 
 def upstream_fingerprint(output_base_dir: Path, transform_inputs: Iterable[str]) -> str:
@@ -191,7 +266,7 @@ def data_fingerprint(repo_root: Path, data_inputs: Iterable[str]) -> str:
     :param data_inputs: Repo-relative paths from ``Transform.DATA_INPUTS``.
     :return: Hex digest.
     """
-    return _hash_files(repo_root / rel for rel in data_inputs)
+    return _hash_files((repo_root / rel for rel in data_inputs), relative_to=repo_root)
 
 
 #: The pinned Biolink schema every transform validates against, relative to
@@ -266,7 +341,10 @@ def write_fingerprint(
     """
     payload = {
         "version": FINGERPRINT_VERSION,
-        "code": code_fingerprint(code_dir),
+        "code": code_fingerprint(code_dir, repo_root),
+        # Shared first-party code, recorded apart from the package so the
+        # report can say which of the two moved (#1002).
+        "shared": shared_code_fingerprint(repo_root),
         "data": data_fingerprint(repo_root, data_inputs),
         # Recorded separately so a stale output says which of the three moved:
         # its code, its curation data, or something it reads (#845).
@@ -299,3 +377,125 @@ def read_fingerprint(output_dir: Path) -> Optional[dict]:
     if not isinstance(payload, dict) or payload.get("version") != FINGERPRINT_VERSION:
         return None
     return payload
+
+
+# ---------------------------------------------------------------------------
+# Migration from scheme 2
+# ---------------------------------------------------------------------------
+# Scheme 2 folded absolute paths into every digest and did not see shared code.
+# Bumping the version makes every existing marker read as absent, which would
+# send a freshly rebuilt tree back to timestamp comparison until each source
+# ran again. A marker whose scheme-2 digests still match its inputs vouches
+# for the same output under scheme 3; rewrite those, leave the rest alone.
+
+
+def _read_marker_any_version(output_dir: Path) -> Optional[dict]:
+    """
+    Read a marker regardless of scheme version.
+
+    :param output_dir: Directory holding the marker.
+    :return: The payload, or None.
+    """
+    try:
+        payload = json.loads((output_dir / FINGERPRINT_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _v2_hash_files(paths: Iterable[Path]) -> str:
+    """Scheme-2 file digest: absolute paths folded in."""
+    return _hash_files(paths, relative_to=None)
+
+
+def _v2_code_fingerprint(code_dir: Path) -> str:
+    """Scheme-2 package digest: absolute paths folded in."""
+    if not code_dir.is_dir():
+        return hashlib.sha256(b"").hexdigest()
+    return _behaviour_tree_digest(code_dir.rglob("*.py"), None)
+
+
+def _v2_upstream_fingerprint(output_base_dir: Path, transform_inputs: Iterable[str]) -> str:
+    """Scheme-2 upstream digest, read from the markers as they were before migration."""
+    digest = hashlib.sha256()
+    for name in sorted(set(transform_inputs)):
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        recorded = _read_marker_any_version(output_base_dir / name)
+        if recorded is not None and recorded.get("version") != 2:
+            recorded = None
+        digest.update(json.dumps(recorded, sort_keys=True).encode("utf-8") if recorded else b"<absent>")
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def migrate_markers(transformed_dir: Path, repo_root: Path, sources: Iterable[dict]) -> Dict[str, str]:
+    """
+    Rewrite scheme-2 markers that still vouch for their output as scheme 3.
+
+    Two phases, because upstream digests read other markers: first judge every
+    scheme-2 marker against its inputs under scheme 2, while all markers are
+    still scheme 2; then rewrite the ones that were FRESH, in dependency order,
+    so each downstream's new upstream digest sees its upstreams' new markers.
+
+    :param transformed_dir: ``data/transformed``.
+    :param repo_root: Repository root.
+    :param sources: One dict per registered source: ``name``, ``output_dir``
+        (the directory under ``transformed_dir``), ``code_dir``,
+        ``data_inputs``, ``transform_inputs``.
+    :return: ``{source name: "migrated" | "left: <reason>"}``.
+    """
+    sources = list(sources)
+    by_name = {src["name"]: src for src in sources}
+
+    # Phase 1: verdicts under scheme 2, before anything is rewritten.
+    fresh_v2: Dict[str, bool] = {}
+    reasons: Dict[str, str] = {}
+    for src in sources:
+        out = transformed_dir / src["output_dir"]
+        marker = _read_marker_any_version(out)
+        if marker is None:
+            reasons[src["name"]] = "left: no marker"
+            continue
+        if marker.get("version") == FINGERPRINT_VERSION:
+            reasons[src["name"]] = "left: already current"
+            continue
+        if marker.get("version") != 2:
+            reasons[src["name"]] = f"left: unknown scheme {marker.get('version')!r}"
+            continue
+        ok = (
+            marker.get("code") == _v2_code_fingerprint(src["code_dir"])
+            and marker.get("data") == _v2_hash_files(repo_root / rel for rel in src["data_inputs"])
+            and marker.get("upstream") == _v2_upstream_fingerprint(transformed_dir, src["transform_inputs"])
+        )
+        fresh_v2[src["name"]] = ok
+        if not ok:
+            reasons[src["name"]] = "left: stale under scheme 2; rerun the transform"
+
+    # Phase 2: rewrite in dependency order.
+    done: set = set()
+    order = []
+    remaining = [name for name, ok in fresh_v2.items() if ok]
+    while remaining:
+        progressed = False
+        for name in list(remaining):
+            deps = [d for d in by_name[name]["transform_inputs"] if d in fresh_v2 and fresh_v2[d]]
+            if all(d in done for d in deps):
+                order.append(name)
+                done.add(name)
+                remaining.remove(name)
+                progressed = True
+        if not progressed:  # a cycle; write the rest in registration order
+            order.extend(remaining)
+            remaining = []
+    for name in order:
+        src = by_name[name]
+        write_fingerprint(
+            output_dir=transformed_dir / src["output_dir"],
+            code_dir=src["code_dir"],
+            repo_root=repo_root,
+            data_inputs=src["data_inputs"],
+            transform_inputs=src["transform_inputs"],
+        )
+        reasons[name] = "migrated"
+    return reasons

--- a/scripts/migrate_fingerprints.py
+++ b/scripts/migrate_fingerprints.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Rewrite scheme-2 ``source_fingerprint.json`` markers as scheme 3 where they still hold.
+
+Scheme 3 (#1002, #983) folds shared first-party code into every transform's
+fingerprint and hashes by repo-relative name. Bumping the scheme makes every
+older marker unreadable, which would send a freshly rebuilt tree back to
+timestamp comparison until each source ran again. A scheme-2 marker whose
+digests still match its inputs vouches for the same output under scheme 3,
+so it is rewritten; a stale one is left for a real rerun.
+
+Usage: ``poetry run python scripts/migrate_fingerprints.py``
+"""
+
+import inspect
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Sources whose output lives in a directory not named after the source.
+OUTPUT_DIR_ALIASES = {"prego": ("prego_habitat", "prego")}
+
+
+def main() -> int:
+    """
+    Migrate every registered source's marker and report what happened.
+
+    :return: Process exit code.
+    """
+    from kg_microbe.transform import DATA_SOURCES
+    from kg_microbe.utils.transform_fingerprint import migrate_markers
+
+    transformed = REPO_ROOT / "data" / "transformed"
+    sources = []
+    for name, lazy in DATA_SOURCES.items():
+        try:
+            cls = lazy.transform_class
+        except AttributeError:
+            continue  # optional dependency missing; nothing to migrate for it
+        candidates = OUTPUT_DIR_ALIASES.get(name, (name,))
+        output_dir = next((c for c in candidates if (transformed / c).is_dir()), candidates[-1])
+        sources.append(
+            {
+                "name": name,
+                "output_dir": output_dir,
+                "code_dir": Path(inspect.getsourcefile(cls)).parent,
+                "data_inputs": tuple(getattr(cls, "DATA_INPUTS", ()) or ()),
+                "transform_inputs": tuple(getattr(cls, "TRANSFORM_INPUTS", ()) or ()),
+            }
+        )
+    outcome = migrate_markers(transformed, REPO_ROOT, sources)
+    for name in sorted(outcome):
+        print(f"{name:28s} {outcome[name]}")
+    migrated = sum(1 for v in outcome.values() if v == "migrated")
+    print(f"migrated {migrated} of {len(outcome)} markers")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -216,12 +216,13 @@ class FreshnessSchemaTest(TestCase):
         """
         import kg_microbe.utils.transform_fingerprint as fp
 
-        marker = {"version": fp.FINGERPRINT_VERSION, "code": "c", "data": "d", "upstream": "u"}
+        marker = {"version": fp.FINGERPRINT_VERSION, "code": "c", "shared": "s", "data": "d", "upstream": "u"}
         if recorded_schema is not None:
             marker["schema"] = recorded_schema
         with (
             mock.patch.object(fp, "read_fingerprint", return_value=marker),
             mock.patch.object(fp, "code_fingerprint", return_value="c"),
+            mock.patch.object(fp, "shared_code_fingerprint", return_value="s"),
             mock.patch.object(fp, "data_fingerprint", return_value="d"),
             mock.patch.object(fp, "upstream_fingerprint", return_value="u"),
             mock.patch.object(fp, "schema_fingerprint", return_value={"version": "4.4.2", "digest": "new"}),

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -207,6 +207,28 @@ class FreshnessSchemaTest(TestCase):
         sys.modules["kgm_freshness_check"] = self.mod
         spec.loader.exec_module(self.mod)
 
+    def test_a_shared_code_change_is_stale_and_says_so(self):
+        """
+        #1002: a change under kg_microbe/utils/ must not read FRESH.
+
+        Recorded apart from the package digest, so the note can name which moved.
+        """
+        import kg_microbe.utils.transform_fingerprint as fp
+
+        marker = {"version": fp.FINGERPRINT_VERSION, "code": "c", "shared": "old", "data": "d", "upstream": "u"}
+        with (
+            mock.patch.object(fp, "read_fingerprint", return_value=marker),
+            mock.patch.object(fp, "code_fingerprint", return_value="c"),
+            mock.patch.object(fp, "shared_code_fingerprint", return_value="new"),
+            mock.patch.object(fp, "data_fingerprint", return_value="d"),
+            mock.patch.object(fp, "upstream_fingerprint", return_value="u"),
+            mock.patch.object(fp, "schema_fingerprint", return_value=None),
+        ):
+            code_dir = REPO_ROOT / "kg_microbe" / "transform_utils" / "bactotraits"
+            status, note = self.mod._fingerprint_verdict("bactotraits", code_dir)
+        self.assertEqual(status, "STALE_VS_CODE")
+        self.assertIn("shared code", note)
+
     def _verdict(self, recorded_schema):
         """
         Run ``_fingerprint_verdict`` over a marker whose other fields all match.

--- a/tests/test_transform_fingerprint.py
+++ b/tests/test_transform_fingerprint.py
@@ -7,10 +7,14 @@ from unittest import TestCase
 
 from kg_microbe.utils.transform_fingerprint import (
     FINGERPRINT_FILE,
+    FINGERPRINT_VERSION,
     code_fingerprint,
     data_fingerprint,
+    migrate_markers,
     read_fingerprint,
     schema_fingerprint,
+    shared_code_fingerprint,
+    upstream_fingerprint,
     write_fingerprint,
 )
 
@@ -180,3 +184,180 @@ class SchemaFingerprintTests(TestCase):
             recorded = read_fingerprint(out)
         self.assertEqual(payload["schema"]["version"], "4.4.2")
         self.assertEqual(recorded["schema"], payload["schema"])
+
+
+def _package(root: Path, name: str, body: str) -> Path:
+    """
+    Lay out a one-module transform package under ``root``.
+
+    :param root: Repository root.
+    :param name: Package name.
+    :param body: Module source.
+    :return: The package directory.
+    """
+    pkg = root / "kg_microbe" / "transform_utils" / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / f"{name}.py").write_text(body, encoding="utf-8")
+    return pkg
+
+
+def _shared(root: Path, body: str) -> None:
+    """
+    Lay out the shared code every transform runs through.
+
+    :param root: Repository root.
+    :param body: Source for the one utils module.
+    :return: None.
+    """
+    (root / "kg_microbe" / "utils").mkdir(parents=True, exist_ok=True)
+    (root / "kg_microbe" / "utils" / "helper.py").write_text(body, encoding="utf-8")
+
+
+class PathIndependenceTests(TestCase):
+    """The same code and data under two checkouts is one fingerprint (#983)."""
+
+    def test_the_package_digest_does_not_fold_in_the_checkout_path(self):
+        """A marker carried with its output must not read stale from another root."""
+        with tempfile.TemporaryDirectory() as a, tempfile.TemporaryDirectory() as b:
+            pa = _package(Path(a), "gold", "x = 1\n")
+            pb = _package(Path(b), "gold", "x = 1\n")
+            self.assertEqual(code_fingerprint(pa, Path(a)), code_fingerprint(pb, Path(b)))
+
+    def test_the_data_digest_does_not_fold_in_the_checkout_path(self):
+        """Same rule for declared curation inputs."""
+        with tempfile.TemporaryDirectory() as a, tempfile.TemporaryDirectory() as b:
+            for root in (a, b):
+                (Path(root) / "mappings").mkdir()
+                (Path(root) / "mappings" / "m.tsv").write_text("k\tv\n", encoding="utf-8")
+            self.assertEqual(
+                data_fingerprint(Path(a), ["mappings/m.tsv"]), data_fingerprint(Path(b), ["mappings/m.tsv"])
+            )
+
+    def test_renaming_a_file_still_changes_the_digest(self):
+        """Path independence must not lose rename detection."""
+        with tempfile.TemporaryDirectory() as a:
+            (Path(a) / "mappings").mkdir()
+            (Path(a) / "mappings" / "m.tsv").write_text("k\tv\n", encoding="utf-8")
+            before = data_fingerprint(Path(a), ["mappings/m.tsv"])
+            (Path(a) / "mappings" / "m.tsv").rename(Path(a) / "mappings" / "n.tsv")
+            self.assertNotEqual(before, data_fingerprint(Path(a), ["mappings/n.tsv"]))
+
+
+class SharedCodeTests(TestCase):
+    """A change under kg_microbe/utils/ must mark every transform stale (#1002)."""
+
+    def test_editing_shared_code_changes_the_shared_digest_not_the_package(self):
+        """The two are recorded apart so the report can say which moved."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pkg = _package(root, "gold", "x = 1\n")
+            _shared(root, "def f():\n    return 1\n")
+            code_before, shared_before = code_fingerprint(pkg, root), shared_code_fingerprint(root)
+            _shared(root, "def f():\n    return 2\n")
+            self.assertEqual(code_fingerprint(pkg, root), code_before)
+            self.assertNotEqual(shared_code_fingerprint(root), shared_before)
+
+    def test_the_marker_records_the_shared_digest(self):
+        """Wired into write_fingerprint."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pkg = _package(root, "gold", "x = 1\n")
+            _shared(root, "y = 1\n")
+            out = root / "out"
+            out.mkdir()
+            payload = write_fingerprint(out, pkg, root, data_inputs=())
+            self.assertEqual(payload["shared"], shared_code_fingerprint(root))
+            self.assertEqual(payload["version"], FINGERPRINT_VERSION)
+
+
+class MigrationTests(TestCase):
+    """Scheme-2 markers that still vouch for their output are carried forward."""
+
+    def _v2_marker(self, out: Path, pkg: Path, root: Path, data_inputs=(), upstream=None):
+        """
+        Write a scheme-2 marker the way the old code did (absolute paths, no shared).
+
+        :param out: Output directory.
+        :param pkg: Package directory.
+        :param root: Repository root.
+        :param data_inputs: Declared inputs.
+        :param upstream: Precomputed scheme-2 upstream digest, if any.
+        :return: None.
+        """
+        import kg_microbe.utils.transform_fingerprint as fp
+
+        payload = {
+            "version": 2,
+            "code": fp._v2_code_fingerprint(pkg),
+            "data": fp._v2_hash_files(root / rel for rel in data_inputs),
+            "upstream": upstream or fp._v2_upstream_fingerprint(out.parent, ()),
+        }
+        (out / "source_fingerprint.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_a_marker_that_still_holds_is_rewritten_as_scheme_3(self):
+        """The rebuilt tree keeps its FRESH verdicts across the scheme bump."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pkg = _package(root, "gold", "x = 1\n")
+            _shared(root, "y = 1\n")
+            out = root / "data" / "transformed" / "gold"
+            out.mkdir(parents=True)
+            self._v2_marker(out, pkg, root)
+            outcome = migrate_markers(
+                root / "data" / "transformed",
+                root,
+                [{"name": "gold", "output_dir": "gold", "code_dir": pkg, "data_inputs": (), "transform_inputs": ()}],
+            )
+            self.assertEqual(outcome, {"gold": "migrated"})
+            recorded = read_fingerprint(out)
+            self.assertEqual(recorded["version"], FINGERPRINT_VERSION)
+            self.assertEqual(recorded["code"], code_fingerprint(pkg, root))
+            self.assertEqual(recorded["shared"], shared_code_fingerprint(root))
+
+    def test_a_marker_that_no_longer_holds_is_left_for_a_real_rerun(self):
+        """Migration must not launder staleness into a fresh marker."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pkg = _package(root, "gold", "x = 1\n")
+            out = root / "data" / "transformed" / "gold"
+            out.mkdir(parents=True)
+            self._v2_marker(out, pkg, root)
+            _package(root, "gold", "x = 2\n")  # behaviour changed after the marker was written
+            outcome = migrate_markers(
+                root / "data" / "transformed",
+                root,
+                [{"name": "gold", "output_dir": "gold", "code_dir": pkg, "data_inputs": (), "transform_inputs": ()}],
+            )
+            self.assertEqual(outcome, {"gold": "left: stale under scheme 2; rerun the transform"})
+            self.assertIsNone(read_fingerprint(out))
+
+    def test_downstream_is_rewritten_after_its_upstream(self):
+        """A downstream's new upstream digest must see the upstream's new marker."""
+        import kg_microbe.utils.transform_fingerprint as fp
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            up_pkg = _package(root, "gtdb", "x = 1\n")
+            down_pkg = _package(root, "lpsn", "x = 1\n")
+            transformed = root / "data" / "transformed"
+            for name in ("gtdb", "lpsn"):
+                (transformed / name).mkdir(parents=True)
+            self._v2_marker(transformed / "gtdb", up_pkg, root)
+            self._v2_marker(
+                transformed / "lpsn", down_pkg, root, upstream=fp._v2_upstream_fingerprint(transformed, ("gtdb",))
+            )
+            sources = [
+                {
+                    "name": "lpsn",
+                    "output_dir": "lpsn",
+                    "code_dir": down_pkg,
+                    "data_inputs": (),
+                    "transform_inputs": ("gtdb",),
+                },
+                {"name": "gtdb", "output_dir": "gtdb", "code_dir": up_pkg, "data_inputs": (), "transform_inputs": ()},
+            ]
+            outcome = migrate_markers(transformed, root, sources)
+            self.assertEqual(outcome, {"gtdb": "migrated", "lpsn": "migrated"})
+            self.assertEqual(
+                read_fingerprint(transformed / "lpsn")["upstream"], upstream_fingerprint(transformed, ("gtdb",))
+            )


### PR DESCRIPTION
Closes #1002. Closes #983.

## What changes (scheme 3 of `source_fingerprint.json`)

- **`shared` digest (#1002).** `code_fingerprint` saw only the transform's package; a change in `kg_microbe/utils/` marked nothing stale — #999 changed three transforms' predicates while every source stayed FRESH. Every marker now records a behaviour digest over `kg_microbe/utils/`, `transform_utils/constants.py` and `transform_utils/transform.py`, and `kgm-freshness-check` says which of the two moved (`code differs…` vs `shared code (utils/, constants.py, transform.py) differs…`). Blunt by design.
- **Repo-relative names (#983).** Digests folded absolute paths in, so the same files under two checkouts hashed differently; a marker read from a scratch worktree produced four spurious failures yesterday. Names are folded in relative to the repo root; a rename is still a change (tested).
- **Migration.** `FINGERPRINT_VERSION` 2 → 3 makes every existing marker unreadable, which would push today's fully rebuilt tree back to timestamp comparison. `scripts/migrate_fingerprints.py` rewrites a scheme-2 marker as scheme 3 **only when its scheme-2 digests still match the inputs** (it vouched for the output then and still does); stale ones are left for a real rerun. Two phases so downstreams are rewritten after their upstreams and see the new upstream markers.

## Tests

`tests/test_transform_fingerprint.py`: package and data digests are path-independent; renames still change them; shared-code edits move `shared` and not `code`; the marker carries `shared`; a holding marker migrates to scheme 3 with the right digests; a stale one is left (and reads as absent); a downstream is rewritten after its upstream. `FreshnessSchemaTest` extended for the new key. 47 passed; ruff clean.

## Follow-through

After merge: `poetry run python scripts/migrate_fingerprints.py` on the rebuilt tree, then `kgm-freshness-check` should still read 15 FRESH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E