### PR TITLE
metatraits_gtdb: pick the NCBITaxon id by genome count, not by set iteration order (#1006)

### DIFF
--- a/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
+++ b/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
@@ -6,9 +6,9 @@ Uses GTDB metadata files to map GTDB species names to NCBITaxon IDs.
 """
 
 import gzip
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Dict, Optional, Set, Union
+from typing import Dict, Optional, Union
 
 from kg_microbe.transform_utils.constants import METATRAITS_GTDB, RAW_DATA_DIR
 from kg_microbe.transform_utils.gtdb.utils import clean_taxon_name
@@ -98,8 +98,12 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
         self.unresolved_taxa_file = self.output_dir / "unresolved_taxa.tsv"
         self.measurement_traits_file = self.output_dir / "measurement_traits.tsv"
 
-        # GTDB species name -> set of NCBITaxon IDs mapping
-        self.gtdb_to_ncbi: Dict[str, Set[str]] = defaultdict(set)
+        # GTDB name -> how many member genomes carry each NCBITaxon id. A set
+        # here, read back with list(...)[0], picked a taxid in hash order: a
+        # fifth of GTDB species carry more than one (species record plus
+        # subspecies/strain ids), so ~22% of this transform's edges changed
+        # subject on every run (#1006).
+        self.gtdb_to_ncbi: Dict[str, Counter] = defaultdict(Counter)
         # Genome accession -> NCBITaxon ID mapping (for equivalence links)
         self.accession_to_ncbi: Dict[str, str] = {}
         # Genome accession -> current GTDB species name (for hierarchical links)
@@ -169,19 +173,19 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
                             if len(tax_parts) >= 7:
                                 species = tax_parts[6].replace("s__", "")  # Remove 's__' prefix
                                 if species:
-                                    self.gtdb_to_ncbi[species].add(ncbi_id)
+                                    self.gtdb_to_ncbi[species][ncbi_id] += 1
 
                             # Also map genus level (for gtdb_genus_summary.jsonl.gz)
                             if len(tax_parts) >= 6:
                                 genus = tax_parts[5].replace("g__", "")
                                 if genus:
-                                    self.gtdb_to_ncbi[genus].add(ncbi_id)
+                                    self.gtdb_to_ncbi[genus][ncbi_id] += 1
 
                             # Also map family level (for gtdb_family_summary.jsonl.gz)
                             if len(tax_parts) >= 5:
                                 family = tax_parts[4].replace("f__", "")
                                 if family:
-                                    self.gtdb_to_ncbi[family].add(ncbi_id)
+                                    self.gtdb_to_ncbi[family][ncbi_id] += 1
 
                             # Map genome accession to NCBITaxon for fallback lookup
                             # Accession format: GB_GCA_001788565.1 or RS_GCF_001788565.1
@@ -192,7 +196,12 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
                                 # Store with 'sp' prefix for matching metatraits format
                                 self.accession_to_ncbi[f"sp{acc_parts}"] = ncbi_id
 
+        ambiguous = sum(1 for counts in self.gtdb_to_ncbi.values() if len(counts) > 1)
         print(f"  Loaded {len(self.gtdb_to_ncbi)} unique GTDB → NCBITaxon name mappings")
+        print(
+            f"  {ambiguous:,} of them carry more than one NCBI taxid across their genomes; "
+            "the taxid most genomes carry is used, ties to the lowest id (#1006)"
+        )
         print(f"  Loaded {len(self.accession_to_ncbi)} unique accession → NCBITaxon mappings")
 
     def _load_gtdb_taxonomy(self) -> None:
@@ -244,7 +253,7 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
         super()._init_from_shared_data(shared_data)
 
         # Restore GTDB-specific state
-        self.gtdb_to_ncbi = defaultdict(set, shared_data.get("gtdb_to_ncbi", {}))
+        self.gtdb_to_ncbi = defaultdict(Counter, shared_data.get("gtdb_to_ncbi", {}))
         self.accession_to_ncbi = shared_data.get("accession_to_ncbi", {})
         self.accession_to_gtdb_species = shared_data.get("accession_to_gtdb_species", {})
         self.synthetic_nodes_metadata = {}  # Will be populated during processing
@@ -252,6 +261,26 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
         # Disable OAK adapter in worker (GTDB uses metadata mapping only)
         self.ncbitaxon_name_to_id.clear()
         self._ncbi_adapter = "DISABLED"
+
+    @staticmethod
+    def _pick_ncbi_id(counts: "Counter") -> str:
+        """
+        Choose one NCBITaxon id for a GTDB name, deterministically.
+
+        The id most member genomes carry is, in practice, the species-level
+        record -- subspecies and strain ids are usually one genome each. Ties
+        go to the lowest numeric id, so the answer never depends on iteration
+        order (#1006).
+
+        :param counts: ``{NCBITaxon CURIE: number of genomes}``.
+        :return: The chosen CURIE.
+        """
+
+        def numeric(curie: str) -> int:
+            tail = curie.rsplit(":", 1)[-1]
+            return int(tail) if tail.isdigit() else 0
+
+        return max(counts, key=lambda curie: (counts[curie], -numeric(curie)))
 
     def _get_ncbitaxon_impl(self):
         """Override parent method - GTDB transform doesn't use OAK adapter."""
@@ -283,7 +312,7 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
         ncbi_ids = self.gtdb_to_ncbi.get(search_name)
         if ncbi_ids:
             # Current taxonomy - use NCBITaxon directly (no synthetic node needed)
-            return list(ncbi_ids)[0]
+            return self._pick_ncbi_id(ncbi_ids)
 
         # Create synthetic GTDB: node for historical/renamed taxonomy
         if not search_name or search_name.startswith("NCBITaxon:"):

--- a/tests/test_metatraits_gtdb_taxid_pick.py
+++ b/tests/test_metatraits_gtdb_taxid_pick.py
@@ -1,0 +1,51 @@
+"""The NCBITaxon id chosen for a GTDB name must not depend on iteration order (#1006)."""
+
+import ast
+import unittest
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from kg_microbe.transform_utils.metatraits_gtdb.metatraits_gtdb import MetaTraitsGTDBTransform
+
+SOURCE = Path(MetaTraitsGTDBTransform.__module__.replace(".", "/") + ".py")
+
+
+class TaxidPickTests(unittest.TestCase):
+    """A fifth of GTDB species carry several taxids; the pick has to be a rule."""
+
+    def test_the_taxid_most_genomes_carry_wins(self):
+        """Streptococcus phocae: 119224 is the species record, 1000562 a subspecies with one genome."""
+        counts = Counter({"NCBITaxon:1000562": 1, "NCBITaxon:119224": 3})
+        self.assertEqual(MetaTraitsGTDBTransform._pick_ncbi_id(counts), "NCBITaxon:119224")
+
+    def test_a_tie_goes_to_the_lowest_id_not_to_iteration_order(self):
+        """Two insertion orders, one answer."""
+        a = Counter({"NCBITaxon:1962118": 1, "NCBITaxon:1001739": 1})
+        b = Counter({"NCBITaxon:1001739": 1, "NCBITaxon:1962118": 1})
+        self.assertEqual(MetaTraitsGTDBTransform._pick_ncbi_id(a), "NCBITaxon:1001739")
+        self.assertEqual(MetaTraitsGTDBTransform._pick_ncbi_id(b), "NCBITaxon:1001739")
+
+    def test_the_resolver_uses_the_rule(self):
+        """The consumer at the lookup site, driven without constructing the whole transform."""
+        transform = object.__new__(MetaTraitsGTDBTransform)
+        counts = Counter({"NCBITaxon:1000562": 1, "NCBITaxon:119224": 4})
+        transform.gtdb_to_ncbi = defaultdict(Counter, {"Streptococcus phocae": counts})
+        transform.accession_to_ncbi = {}
+        transform.accession_to_gtdb_species = {}
+        transform.synthetic_nodes_metadata = {}
+        self.assertEqual(transform._search_ncbitaxon_by_label("Streptococcus phocae"), "NCBITaxon:119224")
+
+    def test_no_first_of_an_unordered_collection_remains(self):
+        """The defect was `list(ncbi_ids)[0]`; guard against it coming back in any spelling."""
+        tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        offenders = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Call):
+                func = node.value.func
+                if isinstance(func, ast.Name) and func.id == "list":
+                    offenders.append(node.lineno)
+        self.assertEqual(offenders, [], f"list(...)[i] over a possibly unordered collection at lines {offenders}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1006.

## The defect

`metatraits_gtdb` builds `gtdb_to_ncbi` as a **set** of every member genome's `ncbi_taxid` per GTDB name and resolves with `list(ncbi_ids)[0]`. Set order is per-process hash order, and the map is pickled into nine workers — so a species' NCBITaxon id was a random draw on every run.

Evidence (all on identical code and inputs):
- four unpinned runs → four different outputs (4,239,399 / 4,224,916 / 4,223,579 / 4,250,151 edges);
- run 2 vs run 3: **4,665 species names resolved to different ids**, 944,512 edges only in one, 971,084 only in the other (≈22%); e.g. *Streptococcus phocae* `NCBITaxon:1000562` (a subspecies) vs `NCBITaxon:119224` (the species);
- **40,138 of 199,923 GTDB species (20.1%)** carry more than one taxid in the metadata the transform reads;
- two runs with `PYTHONHASHSEED=0` → **byte-identical** (sorted-edges md5 `cff5939f…` both).

Every merged graph this transform has fed carried one arbitrary draw of those assignments, silently.

## The fix

The map counts genomes per taxid; the pick is the taxid most genomes carry (in practice the species record — subspecies/strain ids are usually one genome each), ties to the lowest numeric id. The load step prints how many names were ambiguous. `bacdive.py`'s `search_by_label(..., limit=1)` was checked and is deterministic; not part of this.

## Tests

`tests/test_metatraits_gtdb_taxid_pick.py`: majority wins (the *S. phocae* case); a tie does not depend on insertion order; the resolver goes through the rule; and an AST guard that no `list(...)[i]` over a collection remains in the module. **All fail on the old file** (checked by swapping it). 63 metatraits/gtdb tests pass; ruff clean.

## Follow-through

After merge: rerun `metatraits_gtdb` **twice unpinned** and confirm identical output; then the canonical `merge.yaml` again, since today's `merged-kg.tar.gz` carries one draw of the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjJ3SqbfGvwsiezu4TNS4E