### PR TITLE
Merge the UBERON, FOODON and PATO files the ontologies transform already builds (#1010)

### DIFF
--- a/merge.no_metatraits.yaml
+++ b/merge.no_metatraits.yaml
@@ -56,6 +56,27 @@ merged_graph:
         filename:
         - data/transformed/ontologies/metpo_nodes.tsv
         - data/transformed/ontologies/metpo_edges.tsv
+    uberon:
+      name: UBERON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/uberon_nodes.tsv
+        - data/transformed/ontologies/uberon_edges.tsv
+    foodon:
+      name: FOODON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/foodon_nodes.tsv
+        - data/transformed/ontologies/foodon_edges.tsv
+    pato:
+      name: PATO
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/pato_nodes.tsv
+        - data/transformed/ontologies/pato_edges.tsv
     ontologies_stubs:
       name: ontologies_stubs
       input:

--- a/merge.noprego.yaml
+++ b/merge.noprego.yaml
@@ -56,6 +56,27 @@ merged_graph:
         filename:
         - data/transformed/ontologies/metpo_nodes.tsv
         - data/transformed/ontologies/metpo_edges.tsv
+    uberon:
+      name: UBERON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/uberon_nodes.tsv
+        - data/transformed/ontologies/uberon_edges.tsv
+    foodon:
+      name: FOODON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/foodon_nodes.tsv
+        - data/transformed/ontologies/foodon_edges.tsv
+    pato:
+      name: PATO
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/pato_nodes.tsv
+        - data/transformed/ontologies/pato_edges.tsv
     ontologies_stubs:
       name: ontologies_stubs
       input:

--- a/merge.prego-full.yaml
+++ b/merge.prego-full.yaml
@@ -56,6 +56,27 @@ merged_graph:
         filename:
         - data/transformed/ontologies/metpo_nodes.tsv
         - data/transformed/ontologies/metpo_edges.tsv
+    uberon:
+      name: UBERON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/uberon_nodes.tsv
+        - data/transformed/ontologies/uberon_edges.tsv
+    foodon:
+      name: FOODON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/foodon_nodes.tsv
+        - data/transformed/ontologies/foodon_edges.tsv
+    pato:
+      name: PATO
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/pato_nodes.tsv
+        - data/transformed/ontologies/pato_edges.tsv
     ontologies_stubs:
       name: ontologies_stubs
       input:

--- a/merge.yaml
+++ b/merge.yaml
@@ -82,6 +82,35 @@ merged_graph:
         filename:
           - data/transformed/ontologies/metpo_nodes.tsv
           - data/transformed/ontologies/metpo_edges.tsv
+    # UBERON, FOODON and PATO are built by the ontologies transform on every run
+    # but were never merged, so every isolation-source anatomy (bacdive, gold),
+    # food (bacdive, gold, mediadive) and quality (bacdive) term they reference
+    # arrived as a label-less NamedThing KGX invented -- 168 of them in the
+    # 2026-09-08 graph -- while the labelled rows sat unused on disk. gold's
+    # label join assumes UBERON is loaded (gold.py). Most of those ids are not
+    # in any mappings/ file, so the selective stub import cannot see them; the
+    # full files are small (UBERON 25.9k, FOODON 39.3k, PATO 8.0k nodes) (#1010).
+    uberon:
+      name: "UBERON"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/uberon_nodes.tsv
+          - data/transformed/ontologies/uberon_edges.tsv
+    foodon:
+      name: "FOODON"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/foodon_nodes.tsv
+          - data/transformed/ontologies/foodon_edges.tsv
+    pato:
+      name: "PATO"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/ontologies/pato_nodes.tsv
+          - data/transformed/ontologies/pato_edges.tsv
     # Selective per-CURIE stub-import for NCIT, mesh, BTO, PO, and MICRO —
     # only the IDs referenced by mappings/* are imported (not the full
     # ontologies). See kg_microbe/transform_utils/ontologies_stubs/ for

--- a/merge_bakta.yaml
+++ b/merge_bakta.yaml
@@ -56,6 +56,27 @@ merged_graph:
         filename:
         - data/transformed/ontologies/metpo_nodes.tsv
         - data/transformed/ontologies/metpo_edges.tsv
+    uberon:
+      name: UBERON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/uberon_nodes.tsv
+        - data/transformed/ontologies/uberon_edges.tsv
+    foodon:
+      name: FOODON
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/foodon_nodes.tsv
+        - data/transformed/ontologies/foodon_edges.tsv
+    pato:
+      name: PATO
+      input:
+        format: tsv
+        filename:
+        - data/transformed/ontologies/pato_nodes.tsv
+        - data/transformed/ontologies/pato_edges.tsv
     ontologies_stubs:
       name: ontologies_stubs
       input:


### PR DESCRIPTION
Closes #1010.

## What

`merge.yaml` (and the regenerated variants) now read `ontologies/{uberon,foodon,pato}_{nodes,edges}.tsv`, which the ontologies transform has been writing on every run and nothing merged.

## Why this and not stubs

bacdive, gold and mediadive reference UBERON (142 ids / 4,605 edge uses), FOODON (23 / 631) and PATO (3 / 5,056) terms, all present as labelled rows in those files; the merge invented a label-less `NamedThing` for each. `gold.py:82` documents a label join "against ontologies KG-Microbe already loads (537 more, overwhelmingly UBERON host anatomy)" — UBERON was never loaded.

The selective stub import (#918's design) can't reach them: checked against `collect_stub_curies`, **109 of 142 UBERON, 15 of 23 FOODON and 3 of 3 PO invented ids are in no `mappings/` file** — they come from gold's GOLD→ontology xrefs and bacdive fallbacks — and `gold ← ontologies_stubs` makes collecting from gold's output a cycle. The full files are ENVO-sized (25.9k / 39.3k / 8.0k nodes), and ENVO is merged in full.

Residual: PO's 3 ids (`po_nodes.tsv` is not produced; the PO stub set is collected from mappings).

## Verification

- `scripts/generate_merge_configs.py --check` clean; `test_merge_configs.py`, `test_merge_config_generation.py`, `test_gold_merge_wiring.py`: 36 passed.
- No transform rerun needed; the canonical merge is rerun after this lands and the invented-endpoint report should drop UBERON/FOODON/PATO to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)