### PR TITLE
Review renderer prints every example the check returned (#1011 follow-up)

### DIFF
--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -305,7 +305,10 @@ class Finding:
     def __str__(self):
         icon = {"ERROR": "❌", "WARNING": "⚠️ ", "INFO": "ℹ️ "}.get(self.severity, "  ")
         s = f"    [{self.check:<8}] {icon} {self.severity}: {self.message}"
-        for ex in self.examples[:3]:
+        # Every example the check chose to return. A cap here hid three of
+        # six domain/range constraints from the #810 review; the checks decide
+        # how many examples are worth showing, the renderer does not.
+        for ex in self.examples:
             s += f"\n              e.g. {ex!r}"
         return s
 

--- a/tests/test_kg_model_review_domain_range.py
+++ b/tests/test_kg_model_review_domain_range.py
@@ -140,6 +140,13 @@ class DomainRangeFromTheModelTests(unittest.TestCase):
         self.assertIn("WARNING", out)
         self.assertIn("[table]", out["WARNING"][0].examples[0])
 
+    def test_the_renderer_prints_every_example_the_check_returned(self):
+        """The checker returned all six constraints; the markdown renderer used to print three."""
+        finding = self.mod.Finding("WARNING", "DomainRange", "six constraints", [f"constraint {i}" for i in range(6)])
+        rendered = finding.render() if hasattr(finding, "render") else str(finding)
+        for i in range(6):
+            self.assertIn(f"constraint {i}", rendered)
+
     def test_verbose_lists_every_constraint_not_the_first_five(self):
         """A release reviewer needs all of them; the old cap hid three of six."""
         cats = [


### PR DESCRIPTION
Follow-up to #1016. `check_domain_range` returns every violated constraint, but `Finding.__str__` capped output at `examples[:3]`, so a verbose report of six constraints printed three. The renderer now prints everything the check returned; the checks decide how many examples are worth showing.

- `Finding.__str__`: drop the `[:3]` slice, with a comment recording why.
- `tests/test_kg_model_review_domain_range.py`: a six-example `Finding` renders all six.

Ruff reports 57 pre-existing findings in `kg_model_review.py` on `master` (the `.claude/` tree is outside the tox lint gate); this diff adds none and the test file is clean.

Refs #1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
