### PR TITLE
lpsn_api: label the 665 API-less basonyms from LPSN's web page (#1004)

### DIFF
--- a/kg_microbe/transform_utils/lpsn_api/README.md
+++ b/kg_microbe/transform_utils/lpsn_api/README.md
@@ -64,6 +64,15 @@ Every API response is cached to `data/raw/lpsn/api_cache/<record_no>.json`
 (gitignored) so partial runs resume cleanly and re-runs skip
 already-fetched records.
 
+Records the API does not serve at all — every basonym that predates the
+Approved Lists (665 in the 2026-09-10 graph, #1004) — are labelled from
+LPSN's public web page `https://lpsn.dsmz.de/taxon/<record_no>` instead:
+rank and name from the page title, nomenclatural and taxonomic status from
+the page body. Those are cached apart, under `data/raw/lpsn/web_cache/`,
+and the node's description says the label came from the page. No edges are
+minted from a page. If the page fetch fails too, the node is an unnamed
+stub in our namespace, as before.
+
 ## Expected wall-clock
 
 - **Cold cache** — 6–10 hours for 34,300 records (LPSN's empirical

--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -54,11 +54,14 @@ The merge step then combines both nodes.tsv / edges.tsv files.
 """
 
 import csv
+import html
 import json
 import os
+import re
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Union
 
+import requests
 from dotenv import load_dotenv
 
 from kg_microbe.transform_utils.constants import (
@@ -109,9 +112,76 @@ INSDC_DATABASE_PREFIX = "insdc"
 # (typically ``data/raw/``).
 API_CACHE_SUBDIR = "lpsn/api_cache"
 
+# Names the JSON API does not serve at all: the 665 basonym targets in the
+# 2026-09-10 graph are pre-Approved-Lists names ("not validly published,
+# basonym of name in Approved Lists") and ``fetch/<id>`` returns an empty
+# result set for every one of them by every route (#1004). LPSN's website
+# still has a page per record number, unauthenticated, with the rank and
+# name in the title. Those pages are cached here, apart from the API
+# cache, so a web-derived record is never mistaken for an API record.
+WEB_CACHE_SUBDIR = "lpsn/web_cache"
+LPSN_TAXON_PAGE_URL = "https://lpsn.dsmz.de/taxon/{record_no}"
+WEB_PAGE_TIMEOUT_S = 30
+#: Marks a record dict assembled from the web page rather than the API.
+WEB_RECORD_SOURCE_KEY = "kgmicrobe_source"
+WEB_RECORD_SOURCE = "lpsn-web-page"
+_TITLE_RE = re.compile(r"<title>\s*([A-Za-z ]+?)\s*:\s*(.+?)\s*</title>", re.IGNORECASE | re.DOTALL)
+_STATUS_RE = re.compile(r"<b>\s*(Nomenclatural|Taxonomic) status:\s*</b>\s*(?:<[^>]*>\s*)*([^<]+)", re.IGNORECASE)
+
 # Path (relative to ``input_base_dir``'s parent) to the GSS transform's
 # output, which we read to know which record_no's to enrich.
 GSS_NODES_RELPATH = "transformed/lpsn/nodes.tsv"
+
+
+def fetch_taxon_page(record_no: str) -> Optional[str]:
+    """
+    Return the HTML of LPSN's web page for ``record_no``, or ``None``.
+
+    Only reached for records the JSON API has no result for; the page is
+    public and needs no credentials. Any transport or HTTP failure is
+    reported and yields ``None`` so the caller falls back to a bare stub
+    rather than aborting the run.
+    """
+    url = LPSN_TAXON_PAGE_URL.format(record_no=record_no)
+    try:
+        resp = requests.get(url, timeout=WEB_PAGE_TIMEOUT_S, headers={"User-Agent": "kg-microbe lpsn_api transform"})
+    except requests.RequestException as e:
+        print(f"[lpsn_api] web page fetch failed for {record_no}: {e}")
+        return None
+    if resp.status_code != 200:
+        print(f"[lpsn_api] web page fetch for {record_no} returned HTTP {resp.status_code}")
+        return None
+    return resp.text
+
+
+def parse_taxon_page(record_no: str, page: str) -> Optional[dict]:
+    """
+    Build an API-shaped record from an LPSN taxon page, or ``None``.
+
+    The page title is ``<rank>: <name>`` (``Species: Bacterium sonnei``);
+    that is the whole reason the page is worth fetching, so no title means
+    no record. Nomenclatural and taxonomic status are taken when present.
+    The dict carries :data:`WEB_RECORD_SOURCE_KEY` so consumers can tell
+    it from an API record; it never carries ids to link to.
+    """
+    match = _TITLE_RE.search(page)
+    if not match:
+        return None
+    rank, name = match.groups()
+    name = html.unescape(re.sub(r"<[^>]+>", "", name)).strip().strip('"').strip()
+    if not name:
+        return None
+    record = {
+        "id": int(record_no) if record_no.isdigit() else record_no,
+        "category": rank.strip().lower(),
+        JSON_FULL_NAME: name,
+        "lpsn_address": LPSN_TAXON_PAGE_URL.format(record_no=record_no),
+        WEB_RECORD_SOURCE_KEY: WEB_RECORD_SOURCE,
+    }
+    for kind, text in _STATUS_RE.findall(page):
+        key = JSON_NOMENCLATURAL_STATUS if kind.lower() == "nomenclatural" else JSON_LPSN_TAXONOMIC_STATUS
+        record[key] = html.unescape(text).strip()
+    return record
 
 
 class LPSNAPITransform(Transform):
@@ -125,6 +195,7 @@ class LPSNAPITransform(Transform):
         input_dir: Optional[Path] = None,
         output_dir: Optional[Path] = None,
         client: Any = None,
+        page_fetch: Optional[Callable[[str], Optional[str]]] = None,
     ):
         """
         Instantiate.
@@ -148,12 +219,25 @@ class LPSNAPITransform(Transform):
             -s lpsn`` (GSS path) with no LPSN Python-package
             dependency. Tests inject a fake client to keep the
             fixture self-contained.
+        page_fetch:
+            Fetches LPSN's web page for a record number the API has no
+            record for (#1004). Defaults to :func:`fetch_taxon_page`;
+            tests inject a fake so nothing touches the network.
 
         """
         super().__init__(LPSN_API_SOURCE, input_dir, output_dir)
         self.knowledge_source = LPSN_KNOWLEDGE_SOURCE
         self._client_override = client
-        self._stats = {"fetched": 0, "from_cache": 0, "errors": 0, "linked_declared": 0, "linked_stubbed": 0}
+        self._page_fetch = page_fetch or fetch_taxon_page
+        self._web_cache_dir: Optional[Path] = None
+        self._stats = {
+            "fetched": 0,
+            "from_cache": 0,
+            "errors": 0,
+            "linked_declared": 0,
+            "linked_from_web": 0,
+            "linked_stubbed": 0,
+        }
 
     # ------------------------------------------------------------------
     # public entry point
@@ -191,6 +275,8 @@ class LPSNAPITransform(Transform):
 
         cache_dir = Path(self.input_base_dir) / API_CACHE_SUBDIR
         cache_dir.mkdir(parents=True, exist_ok=True)
+        self._web_cache_dir = Path(self.input_base_dir) / WEB_CACHE_SUBDIR
+        self._web_cache_dir.mkdir(parents=True, exist_ok=True)
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
         with (
@@ -221,6 +307,7 @@ class LPSNAPITransform(Transform):
             f"cached={self._stats['from_cache']:,} "
             f"errors={self._stats['errors']:,} "
             f"linked_records_declared={self._stats.get('linked_declared', 0):,} "
+            f"linked_records_from_web={self._stats.get('linked_from_web', 0):,} "
             f"linked_records_stubbed={self._stats.get('linked_stubbed', 0):,}"
         )
 
@@ -356,9 +443,12 @@ class LPSNAPITransform(Transform):
 
         Fetches the record so the node carries LPSN's own name and status,
         emits its own parent/basonym edges, and walks up so the chain to the
-        domain is declared end to end. When the API has nothing for it, a
-        bare stub still declares the endpoint -- an unnamed node in our own
-        namespace beats one KGX invents, because it says where it came from.
+        domain is declared end to end. When the API has nothing for it --
+        every basonym that predates the Approved Lists, #1004 -- the name
+        and rank come from LPSN's web page for the record instead, and the
+        description says so. Only when that fails too does a bare stub
+        declare the endpoint: an unnamed node in our own namespace beats one
+        KGX invents, because it says where it came from.
 
         :param client: The LPSN client.
         :param record_no: The referenced record number.
@@ -372,8 +462,13 @@ class LPSNAPITransform(Transform):
         self._declared.add(record_no)
         record = self._fetch(client, record_no, cache_dir)
         if record is None:
-            node_writer.writerow(self._stub_linked_node(record_no))
-            self._stats["linked_stubbed"] = self._stats.get("linked_stubbed", 0) + 1
+            web_record = self._fetch_from_web(record_no)
+            if web_record is None:
+                node_writer.writerow(self._stub_linked_node(record_no))
+                self._stats["linked_stubbed"] = self._stats.get("linked_stubbed", 0) + 1
+                return
+            node_writer.writerow(self._make_web_linked_node(record_no, web_record))
+            self._stats["linked_from_web"] = self._stats.get("linked_from_web", 0) + 1
             return
         node_writer.writerow(self._make_linked_node(record_no, record))
         self._stats["linked_declared"] = self._stats.get("linked_declared", 0) + 1
@@ -496,6 +591,56 @@ class LPSNAPITransform(Transform):
         headers = self.node_header
         if "name" in headers:
             row[headers.index("name")] = (record.get(JSON_FULL_NAME) or "").strip()
+        return row
+
+    def _fetch_from_web(self, record_no: str) -> Optional[dict]:
+        """
+        Return a record assembled from LPSN's web page, using the web cache.
+
+        A cached ``None`` is not stored: a page that failed once is retried
+        on the next run, the same as an API miss. Parse failures are
+        reported so a changed page layout shows up as a count, not as a
+        quiet return to 665 unnamed stubs.
+        """
+        cache_dir = self._web_cache_dir
+        cache_path = cache_dir / f"{record_no}.json" if cache_dir is not None else None
+        if cache_path is not None and cache_path.exists():
+            try:
+                with open(cache_path) as fh:
+                    return json.load(fh)
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"[lpsn_api] web cache read failed for {record_no}: {e}")
+        page = self._page_fetch(record_no)
+        if page is None:
+            return None
+        record = parse_taxon_page(record_no, page)
+        if record is None:
+            print(f"[lpsn_api] web page for {record_no} has no parsable title")
+            return None
+        if cache_path is not None:
+            try:
+                with open(cache_path, "w") as fh:
+                    json.dump(record, fh)
+            except OSError as e:
+                print(f"[lpsn_api] web cache write failed for {record_no}: {e}")
+        return record
+
+    def _make_web_linked_node(self, record_no: str, record: dict) -> list:
+        """
+        Build a node row for a linked record labelled from its LPSN web page.
+
+        Same shape as :meth:`_make_linked_node`; the description records
+        that the API had no record and where the label came from.
+        """
+        row = self._make_linked_node(record_no, record)
+        headers = self.node_header
+        if "description" in headers:
+            idx = headers.index("description")
+            note = (
+                "LPSN record linked from another record; not served by the LPSN JSON API, "
+                f"name and rank taken from {record.get('lpsn_address', 'its LPSN web page')}"
+            )
+            row[idx] = f"{row[idx]}; {note}" if row[idx] else note
         return row
 
     def _stub_linked_node(self, record_no: str) -> list:

--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -656,7 +656,8 @@ class LPSNAPITransform(Transform):
             "id": f"{LPSN_PREFIX}{record_no}",
             "category": NCBI_CATEGORY,
             "description": (
-                "LPSN record linked from another record; not retrievable from the LPSN API when this file was built"
+                "LPSN record linked from another record; not retrievable from the LPSN API "
+                "or its web page when this file was built"
             ),
             "provided_by": LPSN_KNOWLEDGE_SOURCE,
         }.items():

--- a/tests/test_lpsn_api_transform.py
+++ b/tests/test_lpsn_api_transform.py
@@ -36,6 +36,32 @@ class _FakeLpsnClient:
         yield rec
 
 
+#: LPSN's web page for a record the API does not serve (#1004): the rank
+#: and name sit in the title, the statuses in labelled paragraphs. 1004 is
+#: the fixture's basonym target; the family (999) has no page in the fake.
+_WEB_PAGES = {
+    "1004": """<html><head><title>Species: Bacterium coli</title></head><body>
+    <p><b>Nomenclatural status:</b>
+        not validly published, basonym of name in Approved Lists        </p>
+    <p><b>Taxonomic status:</b>
+        <span>synonym (and no standing)</span></p></body></html>""",
+}
+
+
+class _FakePageFetch:
+    """Serve canned LPSN pages; record every request so tests can assert on it."""
+
+    def __init__(self, pages):
+        """Keep the ``{record_no: html}`` map."""
+        self._pages = pages
+        self.calls = []
+
+    def __call__(self, record_no):
+        """Return the page for ``record_no`` or ``None`` when the fake has none."""
+        self.calls.append(record_no)
+        return self._pages.get(record_no)
+
+
 def _write_gss_nodes(path: Path, record_nos):
     """Write a fake GSS nodes.tsv with one row per requested record_no."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -119,6 +145,7 @@ def api_transform(tmp_path, api_records):
         input_dir=input_dir,
         output_dir=output_dir,
         client=_FakeLpsnClient(api_records),
+        page_fetch=_FakePageFetch(_WEB_PAGES),
     )
     return xform
 
@@ -332,19 +359,79 @@ def test_a_fetchable_linked_record_is_named_and_walks_up(api_transform):
 
 def test_an_unfetchable_linked_record_gets_a_declared_stub(api_transform):
     """
-    The family (999) and the basonym (1004) are not in the API.
+    The family (999) is in neither the API nor the fake web.
 
     A bare stub in our own namespace, saying so, beats a NamedThing KGX
     invents with nothing on it.
     """
     api_transform.run()
     nodes = {n["id"]: n for n in _read_tsv(api_transform.output_node_file)}
-    for ref in ("999", "1004"):
-        stub = nodes[f"{LPSN_PREFIX}{ref}"]
-        assert stub["category"] == "biolink:OrganismTaxon"
-        assert stub["name"] == ""
-        assert "not retrievable" in stub["description"]
-    assert api_transform._stats["linked_stubbed"] == 2
+    stub = nodes[f"{LPSN_PREFIX}999"]
+    assert stub["category"] == "biolink:OrganismTaxon"
+    assert stub["name"] == ""
+    assert "not retrievable" in stub["description"]
+    assert api_transform._stats["linked_stubbed"] == 1
+    assert "999" in api_transform._page_fetch.calls
+
+
+def test_a_basonym_the_api_lacks_is_labelled_from_its_web_page(api_transform):
+    """
+    #1004: every one of the 665 API misses is a pre-Approved-Lists basonym.
+
+    The JSON API has no record for them by any route, but the website has
+    a page per record number. The node takes its name and rank from the
+    page and its description says where the label came from; no edges are
+    minted from it because the page carries no ids.
+    """
+    api_transform.run()
+    nodes = {n["id"]: n for n in _read_tsv(api_transform.output_node_file)}
+    basonym = nodes[f"{LPSN_PREFIX}1004"]
+    assert basonym["name"] == "Bacterium coli"
+    assert basonym["category"] == "biolink:OrganismTaxon"
+    assert "not served by the LPSN JSON API" in basonym["description"]
+    assert "https://lpsn.dsmz.de/taxon/1004" in basonym["description"]
+    assert "basonym of name in Approved Lists" in basonym["description"]
+    assert api_transform._stats["linked_from_web"] == 1
+    edges = _read_tsv(api_transform.output_edge_file)
+    assert not [e for e in edges if e["subject"] == f"{LPSN_PREFIX}1004"]
+
+
+def test_a_web_labelled_record_is_cached_apart_from_the_api_cache(api_transform, tmp_path):
+    """The page is fetched once; the second run reads the web cache and never touches the fetcher."""
+    api_transform.run()
+    web_cache = tmp_path / "raw" / "lpsn" / "web_cache" / "1004.json"
+    assert web_cache.exists()
+    assert not (tmp_path / "raw" / "lpsn" / "api_cache" / "1004.json").exists()
+    cached = json.loads(web_cache.read_text())
+    assert cached["kgmicrobe_source"] == "lpsn-web-page"
+    api_transform._page_fetch = _FakePageFetch({})
+    api_transform.run()
+    assert api_transform._page_fetch.calls == ["999"]
+    nodes = {n["id"]: n for n in _read_tsv(api_transform.output_node_file)}
+    assert nodes[f"{LPSN_PREFIX}1004"]["name"] == "Bacterium coli"
+
+
+def test_parse_taxon_page_reads_rank_name_and_statuses():
+    """Title gives rank and name (quotes and italics stripped); statuses are optional."""
+    from kg_microbe.transform_utils.lpsn_api.lpsn_api import parse_taxon_page
+
+    record = parse_taxon_page(
+        "4387", _WEB_PAGES["1004"].replace("Bacterium coli", "&quot;<i>Bacterium</i> sonnei&quot;")
+    )
+    assert record["full_name"] == "Bacterium sonnei"
+    assert record["category"] == "species"
+    assert record["id"] == 4387
+    assert record["nomenclatural_status"] == "not validly published, basonym of name in Approved Lists"
+    assert record["lpsn_taxonomic_status"] == "synonym (and no standing)"
+    assert parse_taxon_page("1", "<html><title>Genus: Escherichia</title></html>") == {
+        "id": 1,
+        "category": "genus",
+        "full_name": "Escherichia",
+        "lpsn_address": "https://lpsn.dsmz.de/taxon/1",
+        "kgmicrobe_source": "lpsn-web-page",
+    }
+    assert parse_taxon_page("1", "<html><title>LPSN</title></html>") is None
+    assert parse_taxon_page("1", "<html></html>") is None
 
 
 def test_a_linked_record_is_declared_once(api_transform):


### PR DESCRIPTION
Closes #1004.

## What the 665 are

Measured on the 35,425-record API cache and the live API (details on the issue): every one of the 665 `no record returned` ids is a `basonym_id` target of a species/subspecies record — none is an `lpsn_parent_id` — and they are pre-Approved-Lists names the JSON API does not serve by any route (`fetch/<id>` → `count: 0`; `flexible_search` → 0; `advanced_search?id=` → 400). LPSN's website serves each at `https://lpsn.dsmz.de/taxon/<id>` without auth, with `<title>Species: Bacterium sonnei</title>`.

## Change

- `lpsn_api.py`: on an API miss for a linked record, `_fetch_from_web` fetches the taxon page (`fetch_taxon_page`, `requests`, 30 s timeout), `parse_taxon_page` takes rank + name from the title and the two status lines from the body, the parsed record is cached under `data/raw/lpsn/web_cache/<id>.json` (apart from `api_cache/`, marked `kgmicrobe_source: lpsn-web-page`), and `_make_web_linked_node` writes a labelled node whose description says the label came from the page. No edges are minted from a page. A failed fetch keeps the unnamed stub; a page with no usable title is printed and counted. New summary field `linked_records_from_web`.
- `README.md`: the web-cache paragraph.
- `tests/test_lpsn_api_transform.py`: the fixture injects a fake page fetcher (`page_fetch=`), so the suite stays offline; new tests for the web-labelled node, the separate cache (second run never calls the fetcher), and the parser.

## Verification

- `pytest tests/test_lpsn_api_transform.py`: 19 passed; ruff clean.
- Canary through the real path: `_fetch_from_web("4387")` with the default fetcher wrote `data/raw/lpsn/web_cache/4387.json` (294 bytes) for *Bacterium sonnei*, with both statuses. The remaining 664 fetches run in the `lpsn_api` rerun after merge; the summary line should read `linked_records_from_web=665 linked_records_stubbed=0`, and `merged_stub_nodes.tsv` should stay at 0 `lpsn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
