### PR TITLE
kg transform: isolate a failed source, skip its dependents, preflight inputs, accept one ontology (#685, #690)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,16 @@ poetry run kg download -t ontologies -t gtdb
 poetry run kg download -i -t mediadive
 poetry run kg transform
 poetry run kg transform -s bacdive -s mediadive
+poetry run kg transform -s ec          # one ontology; leaves the ontologies fingerprint alone
 poetry run kg merge -y merge.yaml
 make run-summary
 ```
+
+`kg transform` checks every selected source's declared `DATA_INPUTS` before
+running anything, isolates a failure to its source (later sources still run;
+those that declare the failed one in `TRANSFORM_INPUTS` are skipped rather
+than built on stale upstream output), and exits non-zero with a per-source
+summary. `FatalOntologyError` and Ctrl-C still abort at once. See #685, #690.
 
 `kg download` skips existing files, but a pin change now takes effect on its own: the URL behind each artifact is recorded in `data/raw/.download_manifest.json`, and a file whose declared URL has moved is re-fetched. A file with no record is left alone — unknown provenance is not wrong provenance (#911). `-i` still invalidates every selected entry, so always combine it with one or more `-t` tags. MediaDive invalidation also clears
 its response cache and can trigger an approximately one-hour crawl.

--- a/kg_microbe/run.py
+++ b/kg_microbe/run.py
@@ -84,12 +84,17 @@ def transform(*args, **kwargs) -> None:
     :param sources: A list of sources to transform.
     :return: None
     """
+    from kg_microbe.transform import TransformBatchError
     from kg_microbe.transform import transform as kg_transform
 
     try:
         kg_transform(*args, **kwargs)
     except ValueError as e:
         raise click.BadParameter(str(e), param_hint="--sources") from e
+    except (FileNotFoundError, TransformBatchError) as e:
+        # Per-source tracebacks were already printed; end with the summary
+        # and a non-zero exit, not a second traceback (#685).
+        raise click.ClickException(str(e)) from e
 
     return None
 

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -233,10 +233,15 @@ def transform(
 
     failed: dict = {}
     skipped: dict = {}
+    # Names a later source may declare in TRANSFORM_INPUTS that did not
+    # complete. A single ontology failing counts as `ontologies` failing:
+    # gold and prego declare the directory, not the ontology inside it.
+    unavailable: set = set()
     for source in sources:
-        upstream = [u for u in getattr(DATA_SOURCES.get(source), "TRANSFORM_INPUTS", ()) if u in failed or u in skipped]
+        upstream = [u for u in getattr(DATA_SOURCES.get(source), "TRANSFORM_INPUTS", ()) if u in unavailable]
         if upstream:
             skipped[source] = upstream
+            unavailable.add(source)
             print(f"[transform] {source}: skipped — upstream {', '.join(upstream)} did not complete", flush=True)
             continue
         # print, not logging.info: the CLI does not configure a handler that
@@ -247,6 +252,9 @@ def transform(
             _run_one(source, input_dir, output_dir, show_status)
         except Exception as exc:  # noqa: BLE001 - isolate one source; BaseException still aborts the batch
             failed[source] = exc
+            unavailable.add(source)
+            if source not in DATA_SOURCES:
+                unavailable.add(ONTOLOGIES)
             print(f"[transform] {source}: FAILED — {type(exc).__name__}: {exc}", flush=True)
             traceback.print_exc()
 

--- a/kg_microbe/transform.py
+++ b/kg_microbe/transform.py
@@ -1,6 +1,7 @@
 """Transform module."""
 
 import inspect
+import traceback
 from functools import cached_property
 from importlib import import_module
 from pathlib import Path
@@ -107,6 +108,77 @@ DATA_SOURCES = {
 }
 
 
+class TransformBatchError(RuntimeError):
+    """
+    One or more sources in a batch failed; raised after the others ran.
+
+    Carries ``failed`` (source -> exception) and ``skipped`` (source -> the
+    upstream sources it declares in ``TRANSFORM_INPUTS`` that failed first),
+    and renders both, so the exit is non-zero and the summary is unmissable.
+    """
+
+    def __init__(self, failed: dict, skipped: dict):
+        """Render the per-source outcome into the message."""
+        self.failed = failed
+        self.skipped = skipped
+        lines = [f"{len(failed)} transform(s) failed" + (f", {len(skipped)} skipped" if skipped else "")]
+        for source, exc in failed.items():
+            lines.append(f"  failed:  {source}: {type(exc).__name__}: {exc}")
+        for source, upstream in skipped.items():
+            lines.append(f"  skipped: {source}: upstream {', '.join(upstream)} did not complete")
+        super().__init__("\n".join(lines))
+
+
+def _ontology_map() -> dict:
+    """Return ONTOLOGIES_MAP, imported lazily so ``kg --help`` stays light."""
+    from kg_microbe.transform_utils.ontologies.ontologies_transform import ONTOLOGIES_MAP
+
+    return ONTOLOGIES_MAP
+
+
+def _missing_declared_inputs(sources: List[str], repo_root: Path) -> List[str]:
+    """
+    Return ``"source: path"`` for every declared curation input that is absent.
+
+    Checked before any source runs (#685): a missing prerequisite should fail
+    in seconds, not after the hours of upstream work that precede it in the
+    batch. Only ``DATA_INPUTS`` can be checked this way -- raw downloads are
+    not declared per transform.
+    """
+    missing = []
+    for source in sources:
+        cls = DATA_SOURCES.get(source)
+        for rel in getattr(cls, "DATA_INPUTS", ()) if cls is not None else ():
+            if not (repo_root / rel).exists():
+                missing.append(f"{source}: {rel}")
+    return missing
+
+
+def _run_one(source: str, input_dir: Optional[Path], output_dir: Optional[Path], show_status: bool) -> None:
+    """Run one registered source, or one ontology by name, and report what it wrote."""
+    if source in DATA_SOURCES:
+        t = DATA_SOURCES[source](input_dir, output_dir)
+        t.run(show_status=show_status)
+        written = _describe_output(t, source)
+        # After the outputs, so a run that dies partway leaves no marker
+        # claiming its output matches the current inputs. Central here rather
+        # than in each transform: every source gets it, and none can forget.
+        _record_fingerprint(t, source)
+        print(f"[transform] {source}: done — {written}", flush=True)
+        return
+
+    # A single ontology (#690). OntologiesTransform.run(data_file) has always
+    # scoped to one file; the CLI branch meant to reach it tested a source
+    # name against ONTOLOGIES_MAP, whose keys never overlapped DATA_SOURCES.
+    t = DATA_SOURCES[ONTOLOGIES](input_dir, output_dir)
+    t.run(_ontology_map()[source], show_status=show_status)
+    written = _describe_output(t, source, file_prefix=f"{source}_")
+    # Deliberately no fingerprint: the marker covers the whole ontologies
+    # directory, and one refreshed ontology does not make the other thirteen
+    # current. The existing marker stays, and reads STALE if the code moved.
+    print(f"[transform] {source}: done — {written} (single ontology; ontologies fingerprint not updated)", flush=True)
+
+
 def transform(
     input_dir: Optional[Path],
     output_dir: Optional[Path],
@@ -123,8 +195,17 @@ def transform(
 
     :param input_dir: A string pointing to the directory to import data from.
     :param output_dir: A string pointing to the directory to output data to.
-    :param sources: A list of sources to transform.
+    :param sources: A list of sources to transform. A registered source name,
+        or one ontology name from ``ONTOLOGIES_MAP`` (``ec``, ``chebi``, ...)
+        to refresh that ontology alone (#690).
     :raises ValueError: If a requested source is not registered in DATA_SOURCES.
+    :raises FileNotFoundError: If a selected source declares a curation input
+        that is not on disk; nothing runs (#685).
+    :raises TransformBatchError: After the batch, if any source failed. A
+        failure is isolated to its source: later sources still run unless
+        they declare the failed one in ``TRANSFORM_INPUTS``, in which case they
+        are skipped rather than built on stale upstream output (#685).
+        ``BaseException`` (``FatalOntologyError``, Ctrl-C) still aborts at once.
     """
     if not sources:
         # run all sources
@@ -135,32 +216,42 @@ def transform(
     # no output — indistinguishable from a successful run, and from a transform
     # that died early (#813).
     unknown = [s for s in sources if s not in DATA_SOURCES]
+    ontology_names: List[str] = []
+    if unknown:
+        ontology_names = sorted(_ontology_map())
+        unknown = [s for s in unknown if s not in ontology_names]
     if unknown:
         raise ValueError(
             f"Unknown transform source(s): {', '.join(sorted(unknown))}. "
-            f"Registered sources: {', '.join(sorted(DATA_SOURCES))}"
+            f"Registered sources: {', '.join(sorted(DATA_SOURCES))}; "
+            f"single ontologies: {', '.join(ontology_names)}"
         )
 
+    missing = _missing_declared_inputs(sources, Path(__file__).resolve().parent.parent)
+    if missing:
+        raise FileNotFoundError("Declared curation input(s) missing; nothing was run: " + "; ".join(missing))
+
+    failed: dict = {}
+    skipped: dict = {}
     for source in sources:
+        upstream = [u for u in getattr(DATA_SOURCES.get(source), "TRANSFORM_INPUTS", ()) if u in failed or u in skipped]
+        if upstream:
+            skipped[source] = upstream
+            print(f"[transform] {source}: skipped — upstream {', '.join(upstream)} did not complete", flush=True)
+            continue
         # print, not logging.info: the CLI does not configure a handler that
         # shows INFO, so the old log line was invisible and a run that produced
         # nothing looked identical to one that worked.
         print(f"[transform] {source}: starting", flush=True)
-        t = DATA_SOURCES[source](input_dir, output_dir)
-        if source == ONTOLOGIES:
-            from kg_microbe.transform_utils.ontologies.ontologies_transform import ONTOLOGIES_MAP
+        try:
+            _run_one(source, input_dir, output_dir, show_status)
+        except Exception as exc:  # noqa: BLE001 - isolate one source; BaseException still aborts the batch
+            failed[source] = exc
+            print(f"[transform] {source}: FAILED — {type(exc).__name__}: {exc}", flush=True)
+            traceback.print_exc()
 
-        if source == ONTOLOGIES and source in ONTOLOGIES_MAP:
-            t.run(ONTOLOGIES_MAP[source])
-        else:
-            t.run(show_status=show_status)
-
-        written = _describe_output(t, source)
-        # After the outputs, so a run that dies partway leaves no marker
-        # claiming its output matches the current inputs. Central here rather
-        # than in each transform: every source gets it, and none can forget.
-        _record_fingerprint(t, source)
-        print(f"[transform] {source}: done — {written}", flush=True)
+    if failed:
+        raise TransformBatchError(failed, skipped)
 
 
 def _record_fingerprint(transform_obj, source: str) -> None:
@@ -192,7 +283,7 @@ def _record_fingerprint(transform_obj, source: str) -> None:
         print(f"[transform] {source}: could not record fingerprint ({exc})", flush=True)
 
 
-def _describe_output(transform_obj, source: str) -> str:
+def _describe_output(transform_obj, source: str, file_prefix: str = "") -> str:
     """
     Summarise what a transform actually wrote, for the completion line.
 
@@ -201,6 +292,8 @@ def _describe_output(transform_obj, source: str) -> str:
 
     :param transform_obj: The Transform instance that just ran.
     :param source: Source name, used when the instance exposes no output dir.
+    :param file_prefix: Count only ``<prefix>nodes.tsv`` / ``<prefix>edges.tsv``;
+        a single-ontology run must not report the whole ontologies directory.
     :return: Human-readable summary of the files written.
     """
     out_dir = getattr(transform_obj, "output_dir", None)
@@ -213,7 +306,7 @@ def _describe_output(transform_obj, source: str) -> str:
     # what the guard is for (#949).
     parts = []
     for kind in ("nodes", "edges"):
-        files = sorted(Path(out_dir).glob(f"*{kind}.tsv"))
+        files = sorted(Path(out_dir).glob(f"{file_prefix or '*'}{kind}.tsv"))
         if not files:
             continue
         counted = []

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -424,7 +424,7 @@ class SingleOntologySourceTest(TestCase):
         self.assertNotIn("chebi", done[0])
 
     def test_a_failed_single_ontology_skips_what_depends_on_ontologies(self):
-        """gold declares `ontologies`, not `ec`; a failed `-s ec` must still keep gold from running on it."""
+        """A dependent declares `ontologies`, not `ec`; a failed `-s ec` must still keep it from running."""
         calls = []
         fake = self._ontologies_fake(calls)
         original_run = fake.run

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -423,6 +423,28 @@ class SingleOntologySourceTest(TestCase):
         self.assertIn("ec_nodes.tsv: 1 rows", done[0])
         self.assertNotIn("chebi", done[0])
 
+    def test_a_failed_single_ontology_skips_what_depends_on_ontologies(self):
+        """gold declares `ontologies`, not `ec`; a failed `-s ec` must still keep gold from running on it."""
+        calls = []
+        fake = self._ontologies_fake(calls)
+        original_run = fake.run
+
+        def failing_run(self_, data_file=None, show_status=True):
+            original_run(self_, data_file, show_status)
+            raise RuntimeError("robot died")
+
+        fake.run = failing_run
+        log = []
+        registry = {"ontologies": fake, "gold": _fake_source("gold", log, self.base, inputs=("ontologies",))}
+        with (
+            mock.patch.dict(DATA_SOURCES, registry, clear=True),
+            mock.patch("kg_microbe.transform._ontology_map", return_value={"ec": "ec.json"}),
+        ):
+            with pytest.raises(TransformBatchError) as excinfo:
+                transform(None, None, sources=["ec", "gold"])
+        self.assertEqual(log, [])
+        self.assertEqual(excinfo.value.skipped, {"gold": ["ontologies"]})
+
     def test_an_unknown_name_lists_the_ontologies_too(self):
         """The error names both kinds of accepted source, so `-s EC` is an obvious typo."""
         with (

--- a/tests/test_transform_dispatch_and_data_inputs.py
+++ b/tests/test_transform_dispatch_and_data_inputs.py
@@ -2,12 +2,13 @@
 
 import importlib.util
 import sys
+import tempfile
 from pathlib import Path
 from unittest import TestCase, mock
 
 import pytest
 
-from kg_microbe.transform import DATA_SOURCES, LazyTransform, transform
+from kg_microbe.transform import DATA_SOURCES, LazyTransform, TransformBatchError, transform
 from kg_microbe.transform_utils.transform import Transform
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -266,3 +267,168 @@ class FreshnessSchemaTest(TestCase):
     def test_a_marker_without_a_schema_is_not_judged_on_it(self):
         """Unknown provenance is not wrong provenance (#911)."""
         self.assertEqual(self._verdict(None)[0], "FRESH")
+
+
+def _fake_source(name: str, log: list, base: Path, raises=None, inputs=()):
+    """Build a registry entry that records its run and optionally fails."""
+
+    class Fake:
+        DATA_INPUTS = ()
+        TRANSFORM_INPUTS = inputs
+
+        def __init__(self, input_dir, output_dir):
+            self.output_dir = base / name
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        def run(self, show_status=True):
+            log.append(name)
+            if raises is not None:
+                raise raises
+
+    return Fake
+
+
+class BatchIsolationTest(TestCase):
+    """#685: one source failing must not take the rest of the batch with it."""
+
+    def setUp(self):
+        """Make a scratch output root and an empty run log."""
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.log = []
+
+    def tearDown(self):
+        """Drop the scratch root."""
+        self._tmp.cleanup()
+
+    def test_a_failure_is_isolated_and_reported_at_the_end(self):
+        """
+        `mediadive` raising mid-batch used to abort seven sources behind it.
+
+        Now the later sources run, and the batch ends non-zero with a summary
+        naming what failed.
+        """
+        registry = {
+            "a": _fake_source("a", self.log, self.base, raises=RuntimeError("bulk data missing")),
+            "b": _fake_source("b", self.log, self.base),
+        }
+        with mock.patch.dict(DATA_SOURCES, registry, clear=True):
+            with pytest.raises(TransformBatchError) as excinfo:
+                transform(None, None, sources=["a", "b"])
+        self.assertEqual(self.log, ["a", "b"])
+        self.assertEqual(list(excinfo.value.failed), ["a"])
+        self.assertIn("a: RuntimeError: bulk data missing", str(excinfo.value))
+
+    def test_a_dependent_of_a_failed_source_is_skipped_not_built_on_stale_output(self):
+        """A source that declares the failed one in TRANSFORM_INPUTS must not run against its stale output."""
+        registry = {
+            "gtdb": _fake_source("gtdb", self.log, self.base, raises=RuntimeError("boom")),
+            "lpsn": _fake_source("lpsn", self.log, self.base, inputs=("gtdb",)),
+            "lpsn_api": _fake_source("lpsn_api", self.log, self.base, inputs=("lpsn",)),
+            "gold": _fake_source("gold", self.log, self.base),
+        }
+        with mock.patch.dict(DATA_SOURCES, registry, clear=True):
+            with pytest.raises(TransformBatchError) as excinfo:
+                transform(None, None, sources=["gtdb", "lpsn", "lpsn_api", "gold"])
+        self.assertEqual(self.log, ["gtdb", "gold"])
+        self.assertEqual(excinfo.value.skipped, {"lpsn": ["gtdb"], "lpsn_api": ["lpsn"]})
+        self.assertIn("skipped: lpsn_api: upstream lpsn did not complete", str(excinfo.value))
+
+    def test_a_base_exception_still_aborts_the_batch(self):
+        """FatalOntologyError subclasses BaseException on purpose; isolation must not swallow it."""
+
+        class Fatal(BaseException):
+            pass
+
+        registry = {
+            "a": _fake_source("a", self.log, self.base, raises=Fatal()),
+            "b": _fake_source("b", self.log, self.base),
+        }
+        with mock.patch.dict(DATA_SOURCES, registry, clear=True):
+            with pytest.raises(Fatal):
+                transform(None, None, sources=["a", "b"])
+        self.assertEqual(self.log, ["a"])
+
+    def test_a_clean_batch_raises_nothing(self):
+        """No failure, no exception: the old contract for the good path is unchanged."""
+        registry = {"a": _fake_source("a", self.log, self.base), "b": _fake_source("b", self.log, self.base)}
+        with mock.patch.dict(DATA_SOURCES, registry, clear=True):
+            transform(None, None, sources=["a", "b"])
+        self.assertEqual(self.log, ["a", "b"])
+
+    def test_a_missing_declared_input_fails_before_anything_runs(self):
+        """A missing curation file is known in seconds; do not spend hours finding out."""
+        fake = _fake_source("a", self.log, self.base)
+        fake.DATA_INPUTS = ("mappings/this-file-does-not-exist.tsv",)
+        registry = {"early": _fake_source("early", self.log, self.base), "a": fake}
+        with mock.patch.dict(DATA_SOURCES, registry, clear=True):
+            with pytest.raises(FileNotFoundError) as excinfo:
+                transform(None, None, sources=["early", "a"])
+        self.assertEqual(self.log, [])
+        self.assertIn("a: mappings/this-file-does-not-exist.tsv", str(excinfo.value))
+
+
+class SingleOntologySourceTest(TestCase):
+    """#690: `-s ec` runs one ontology; the branch meant to do this was unreachable."""
+
+    def setUp(self):
+        """Scratch output root."""
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+
+    def tearDown(self):
+        """Drop it."""
+        self._tmp.cleanup()
+
+    def _ontologies_fake(self, calls: list):
+        base = self.base
+
+        class FakeOntologies:
+            DATA_INPUTS = ()
+            TRANSFORM_INPUTS = ()
+
+            def __init__(self, input_dir, output_dir):
+                self.output_dir = base / "ontologies"
+                self.output_dir.mkdir(parents=True, exist_ok=True)
+
+            def run(self, data_file=None, show_status=True):
+                calls.append(data_file)
+                (self.output_dir / "ec_nodes.tsv").write_text("id\tname\nEC:1.1.1.1\tx\n")
+                (self.output_dir / "chebi_nodes.tsv").write_text("id\tname\nCHEBI:1\ty\nCHEBI:2\tz\n")
+
+        return FakeOntologies
+
+    def test_an_ontology_name_runs_only_that_ontology_and_leaves_the_fingerprint_alone(self):
+        """One ontology's file is refreshed; the directory-wide marker is not rewritten to claim the rest are."""
+        calls = []
+        with (
+            mock.patch.dict(DATA_SOURCES, {"ontologies": self._ontologies_fake(calls)}, clear=True),
+            mock.patch("kg_microbe.transform._ontology_map", return_value={"ec": "ec.json", "chebi": "chebi.json"}),
+        ):
+            transform(None, None, sources=["ec"])
+        self.assertEqual(calls, ["ec.json"])
+        self.assertFalse((self.base / "ontologies" / "source_fingerprint.json").exists())
+
+    def test_the_completion_line_counts_only_that_ontology(self):
+        """A single-ontology run must not report the whole directory as what it wrote."""
+        calls = []
+        with (
+            mock.patch.dict(DATA_SOURCES, {"ontologies": self._ontologies_fake(calls)}, clear=True),
+            mock.patch("kg_microbe.transform._ontology_map", return_value={"ec": "ec.json"}),
+            mock.patch("builtins.print") as printed,
+        ):
+            transform(None, None, sources=["ec"])
+        done = [str(c.args[0]) for c in printed.call_args_list if "done" in str(c.args[0])]
+        self.assertEqual(len(done), 1)
+        self.assertIn("ec_nodes.tsv: 1 rows", done[0])
+        self.assertNotIn("chebi", done[0])
+
+    def test_an_unknown_name_lists_the_ontologies_too(self):
+        """The error names both kinds of accepted source, so `-s EC` is an obvious typo."""
+        with (
+            mock.patch.dict(DATA_SOURCES, {"ontologies": self._ontologies_fake([])}, clear=True),
+            mock.patch("kg_microbe.transform._ontology_map", return_value={"ec": "ec.json"}),
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                transform(None, None, sources=["EC"])
+        self.assertIn("single ontologies: ec", str(excinfo.value))


### PR DESCRIPTION
Closes #685. Closes #690.

## #685 — one failure no longer aborts the batch

- `transform()` catches `Exception` per source, prints the traceback, continues, and raises `TransformBatchError` at the end with a per-source summary (`failed:` / `skipped:` lines). `run.py` maps it to `click.ClickException` → exit 1 without a second traceback.
- A source whose `TRANSFORM_INPUTS` name a failed (or skipped) source is **skipped**, not run on stale upstream output — `gtdb` failing skips `lpsn`, `lpsn_api`, `microbedecoder`; `gold` still runs.
- `BaseException` (`FatalOntologyError`, Ctrl-C) still aborts immediately (CLAUDE.md rule).
- Preflight: every selected source's declared `DATA_INPUTS` is checked before anything runs; a missing curation file raises `FileNotFoundError` in seconds and nothing runs. (Raw downloads are not declared per transform, so option 1 from the issue is possible only for curation inputs; option 2 covers the rest.)

## #690 — `-s ec` runs one ontology

The unreachable branch tested the source name against `ONTOLOGIES_MAP`, whose keys never overlap `DATA_SOURCES`. An ontology name is now accepted in `-s`, runs `OntologiesTransform.run(<file>)` alone, reports only `<ontology>_nodes/edges.tsv`, and **does not** rewrite the directory-wide `ontologies` fingerprint (one refreshed ontology does not make the other thirteen current; the old marker stays and reads STALE if the code moved). The unknown-source error now lists both kinds of accepted name.

## Tests

`tests/test_transform_dispatch_and_data_inputs.py` — 8 new tests with fake registries: failure isolated and reported; dependents skipped with the chain named; `BaseException` propagates; clean batch raises nothing; missing `DATA_INPUTS` fails before any run; ontology name runs only that file and leaves no fingerprint; completion line counts only that ontology; unknown name lists ontologies. The two `FreshnessDataStalenessTest` failures in this file are #1001 (pre-existing on this checkout, next in the queue).

## Canary (real path)

`poetry run kg transform -s ec`: rc 0, 11.6 min, `[transform] ec: done — ec_nodes.tsv: 11,871 rows; ec_edges.tsv: 12,021 rows (single ontology; ontologies fingerprint not updated)`; `source_fingerprint.json` and `ec_edges.tsv` byte-identical before/after. `ec_nodes.tsv` differs in exactly one row — `dcterms:license` vs `dct:license` for the same IRI — a pre-existing prefix nondeterminism in the ontologies transform, filed as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuYY9wZKmXeNJ8rrQ2psqt
