### PR TITLE
kg merge: stamp merged_graph_stats.yaml with provenance and count every predicate as written (#1013, #993)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,13 @@ transform classes -> data/transformed/<source>/{nodes,edges}.tsv
 merge.yaml -> data/merged/merged-kg.tar.gz + merged_graph_stats.yaml
 ```
 
+`merged_graph_stats.yaml` carries a `provenance` block (when, commit, merge
+config, each source's fingerprint digest) and
+`edge_stats.count_by_raw_predicate`, the predicate column counted as
+written. KGX's own `count_by_predicates` resolves through Biolink and records
+every METPO predicate as `None`, so it cannot see two thirds of the edges;
+compare predicates with the raw block. See #993 and #1013.
+
 - `download.yaml` owns upstream URLs and pinned versions.
 - `kg_microbe/transform_utils/<source>/` owns source parsing and normalization.
 - `kg_microbe/transform_utils/transform.py` owns the standard TSV headers.

--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -12,6 +12,7 @@ import networkx as nx  # type: ignore
 import yaml
 
 from kg_microbe.merge_utils.invariants import check_merged_invariants
+from kg_microbe.merge_utils.stats_provenance import annotate_graph_stats, stats_filename_from_config
 from kg_microbe.transform_utils.constants import (
     AGENT_TYPE_COLUMN,
     CATEGORY_COLUMN,
@@ -142,6 +143,11 @@ def load_and_merge(
     return merged_graph
 
 
+def _repo_root() -> Path:
+    """Return the checkout root; merge configs and stats paths are relative to it."""
+    return Path(__file__).resolve().parents[2]
+
+
 def _cleanup_merged_outputs(yaml_file: str) -> None:
     r"""
     Defensive post-merge normalization of the KGX-merged TSVs.
@@ -229,6 +235,17 @@ def _cleanup_merged_outputs(yaml_file: str) -> None:
                 check_merged_invariants(edges_file, output_dir, nodes_file=nodes_file)
             except Exception as exc:  # noqa: BLE001
                 print(f"[merge-invariants] check skipped: {exc}")
+            # The stats file KGX wrote says nothing about what produced it and
+            # cannot name a METPO predicate (#1013, #993). Annotate it here,
+            # while the loose edges file exists. Same isolation as above: a
+            # bookkeeping failure must not stop the archive from shipping.
+            stats_name = stats_filename_from_config(config)
+            if stats_name:
+                try:
+                    annotate_graph_stats(Path(stats_name), edges_file, Path(yaml_file), _repo_root())
+                    print(f"[merge-stats] {stats_name}: provenance and raw predicate counts written")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"[merge-stats] annotation skipped: {exc}")
 
         if dest.get("compression") == "tar.gz":
             if nodes_file.is_file() and edges_file.is_file():

--- a/kg_microbe/merge_utils/stats_provenance.py
+++ b/kg_microbe/merge_utils/stats_provenance.py
@@ -1,0 +1,222 @@
+"""
+Make ``merged_graph_stats.yaml`` say what produced it, and count every predicate.
+
+KGX's ``generate_graph_stats`` writes only what it computes, and it resolves
+predicates through the Biolink toolkit: anything it cannot resolve is recorded
+as ``None``. METPO predicates are deliberately not Biolink, so two thirds of
+the graph's edges were invisible in the stats file the README points readers
+at (#993). The file also carried no merge date, commit, config or input
+digests, so a stale copy could not be told from a current one except by
+diffing counts against a graph one already trusted (#1013).
+
+After the merge writes the stats, :func:`annotate_graph_stats` adds two
+blocks the merge step already knows how to fill:
+
+``provenance``
+    when, from which commit (short HEAD, ``-dirty`` if tracked files other than
+    the stats file differ), which merge
+    config, which edges file, and each source's ``source_fingerprint.json``
+    digest or ``no marker``.
+``edge_stats.count_by_raw_predicate``
+    the predicate column counted directly from the merged edges TSV, no
+    resolution, so ``METPO:*`` predicates appear next to ``biolink:*`` and
+    the counts sum to the edge total.
+
+Idempotent: both blocks are replaced, never appended, so re-annotating a
+file yields the same shape.
+"""
+
+import csv
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import yaml
+
+from kg_microbe.utils.transform_fingerprint import FINGERPRINT_FILE, read_fingerprint
+
+STATS_OPERATION = "kgx.graph_operations.summarize_graph.generate_graph_stats"
+PROVENANCE_KEY = "provenance"
+RAW_PREDICATE_KEY = "count_by_raw_predicate"
+
+
+def stats_filename_from_config(config: Dict) -> Optional[str]:
+    """Return the stats filename the merge config asks KGX to write, if any."""
+    for operation in config.get("merged_graph", {}).get("operations", []) or []:
+        if operation.get("name") == STATS_OPERATION:
+            return (operation.get("args") or {}).get("filename")
+    return None
+
+
+def count_raw_predicates(edges_file: Path) -> Counter:
+    """Count the ``predicate`` column of a KGX edges TSV as written, no resolution."""
+    counts: Counter = Counter()
+    with edges_file.open(encoding="utf-8", errors="replace", newline="") as handle:
+        reader = csv.reader(handle, delimiter="\t", quoting=csv.QUOTE_NONE)
+        header = next(reader, None)
+        if header is None:
+            return counts
+        try:
+            column = header.index("predicate")
+        except ValueError as exc:
+            raise ValueError(f"{edges_file} has no 'predicate' column: {header}") from exc
+        for row in reader:
+            if len(row) > column:
+                counts[row[column] or "(blank)"] += 1
+    return counts
+
+
+def git_commit(repo_root: Path, ignore: Iterable[Path] = ()) -> str:
+    """
+    Return the short HEAD commit, with ``-dirty`` when tracked files differ.
+
+    ``git describe --dirty`` cannot be used as-is: at annotation time KGX has
+    just rewritten the stats file, so the tree is always dirty by exactly
+    that file. Paths in ``ignore`` (the stats file) are excluded from the
+    dirtiness check; untracked files never count. ``unknown`` when git or
+    the checkout is unavailable.
+    """
+    git = shutil.which("git")
+    if git is None:
+        return "unknown"
+    try:
+        head = _git(git, repo_root, "rev-parse", "--short", "HEAD")
+        status = _git(git, repo_root, "status", "--porcelain", "--untracked-files=no")
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    if not head:
+        return "unknown"
+    ignored = {_relative(Path(path), repo_root) for path in ignore}
+    changed = [line[3:] for line in status.splitlines() if line.strip()]
+    dirty = any(path not in ignored for path in changed)
+    return f"{head}-dirty" if dirty else head
+
+
+def _git(git: str, repo_root: Path, *args: str) -> str:
+    """Run one git command in the checkout and return stripped stdout."""
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [git, *args], cwd=repo_root, capture_output=True, text=True, check=False, timeout=30
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _relative(path: Path, repo_root: Path) -> str:
+    """Render a path the way ``git status --porcelain`` does: repo-relative, POSIX."""
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def source_markers(config: Dict, repo_root: Path) -> Dict[str, str]:
+    """
+    Map each merge source to its transform's fingerprint digest.
+
+    The source's input files name the transform directory
+    (``data/transformed/<source>/...``); its ``source_fingerprint.json`` is
+    the marker the freshness check reads. ``no marker`` is recorded rather
+    than omitted, so an unfingerprinted input is visible in the artifact.
+    """
+    markers: Dict[str, str] = {}
+    for name, source in (config.get("merged_graph", {}).get("source", {}) or {}).items():
+        filenames = (source.get("input") or {}).get("filename") or []
+        dirs = {Path(f).parent for f in filenames}
+        digests = []
+        for directory in sorted(dirs):
+            marker = read_fingerprint(repo_root / directory)
+            digests.append(_digest_of(marker) if marker else f"no marker in {directory}")
+        markers[name] = "; ".join(digests) if digests else "no input files"
+    return markers
+
+
+def _digest_of(marker: Dict) -> str:
+    """Compress a fingerprint marker to the fields that identify a build."""
+    parts = []
+    for key in ("code", "shared", "data", "upstream", "schema"):
+        value = marker.get(key)
+        if isinstance(value, dict):
+            value = value.get("digest") or value.get("hash") or value
+        if value:
+            parts.append(f"{key}={str(value)[:20]}")
+    return " ".join(parts) if parts else "marker without digests"
+
+
+def annotate_graph_stats(
+    stats_file: Path,
+    edges_file: Path,
+    yaml_file: Path,
+    repo_root: Path,
+    now: Optional[datetime] = None,
+) -> Dict:
+    """
+    Add ``provenance`` and ``edge_stats.count_by_raw_predicate`` to a stats file.
+
+    :param stats_file: The YAML KGX wrote.
+    :param edges_file: The merged edges TSV (loose, not the archive).
+    :param yaml_file: The merge config that produced both.
+    :param repo_root: Checkout root, for ``git describe`` and the markers.
+    :param now: Timestamp to record; defaults to UTC now.
+    :return: The annotated stats dict, as written.
+    :raises ValueError: If the raw predicate total disagrees with KGX's
+        ``total_edges`` -- the two counted different files.
+    """
+    with stats_file.open(encoding="utf-8") as handle:
+        stats = yaml.safe_load(handle) or {}
+    with Path(yaml_file).open(encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+
+    raw = count_raw_predicates(edges_file)
+    raw_total = sum(raw.values())
+    kgx_total = (stats.get("edge_stats") or {}).get("total_edges")
+    if kgx_total is not None and kgx_total != raw_total:
+        raise ValueError(
+            f"raw predicate count {raw_total:,} != KGX total_edges {kgx_total:,}; "
+            f"{edges_file} is not the file the stats describe"
+        )
+
+    edge_stats = stats.setdefault("edge_stats", {})
+    edge_stats[RAW_PREDICATE_KEY] = {predicate: raw[predicate] for predicate in sorted(raw)}
+
+    stamp = (now or datetime.now(timezone.utc)).astimezone(timezone.utc).replace(microsecond=0)
+    stats[PROVENANCE_KEY] = {
+        "generated_at": stamp.isoformat(),
+        "commit": git_commit(repo_root, ignore=(stats_file,)),
+        "merge_config": str(yaml_file),
+        "edges_file": str(edges_file),
+        "python": sys.version.split()[0],
+        "kgx": _kgx_version(),
+        "sources": source_markers(config, repo_root),
+        "note": (
+            f"{RAW_PREDICATE_KEY} is the predicate column counted as written; KGX's "
+            "count_by_predicates resolves through Biolink and records METPO and other "
+            "non-Biolink predicates as None (#993). provenance is written by kg merge (#1013)."
+        ),
+    }
+
+    with stats_file.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(stats, handle, sort_keys=True, allow_unicode=True)
+    return stats
+
+
+def _kgx_version() -> str:
+    """Return the installed KGX version, or ``unknown``."""
+    try:
+        import kgx  # noqa: PLC0415 - optional at import time
+
+        return str(getattr(kgx, "__version__", "unknown"))
+    except ImportError:
+        return "unknown"
+
+
+__all__ = [
+    "FINGERPRINT_FILE",
+    "annotate_graph_stats",
+    "count_raw_predicates",
+    "git_commit",
+    "source_markers",
+    "stats_filename_from_config",
+]

--- a/tests/test_merge_stats_provenance.py
+++ b/tests/test_merge_stats_provenance.py
@@ -1,0 +1,146 @@
+"""The stats file says what produced it and counts every predicate (#1013, #993)."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from kg_microbe.merge_utils.stats_provenance import (
+    annotate_graph_stats,
+    count_raw_predicates,
+    stats_filename_from_config,
+)
+
+EDGES = [
+    ("NCBITaxon:1", "METPO:2000517", "medium:1"),
+    ("NCBITaxon:1", "METPO:2000517", "medium:2"),
+    ("NCBITaxon:2", "biolink:subclass_of", "NCBITaxon:1"),
+    ("NCBITaxon:2", "", "medium:2"),
+]
+
+
+def _write_fixture(tmp_path: Path):
+    edges = tmp_path / "merged-kg_edges.tsv"
+    with edges.open("w", encoding="utf-8") as handle:
+        handle.write("subject\tpredicate\tobject\n")
+        for row in EDGES:
+            handle.write("\t".join(row) + "\n")
+    stats = tmp_path / "stats.yaml"
+    stats.write_text(
+        yaml.safe_dump(
+            {
+                "graph_name": "kg-microbe graph",
+                "edge_stats": {"total_edges": 4, "count_by_predicates": {"biolink:subclass_of": {"count": 1}}},
+                "node_stats": {"total_nodes": 4},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "data" / "transformed" / "bacdive").mkdir(parents=True)
+    (tmp_path / "data" / "transformed" / "bacdive" / "source_fingerprint.json").write_text(
+        '{"version": 3, "code": "c0de", "data": "da7a", "schema": {"digest": "5c", "version": "4.4.2"}}',
+        encoding="utf-8",
+    )
+    (tmp_path / "data" / "transformed" / "gold").mkdir(parents=True)
+    config = tmp_path / "merge.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "merged_graph": {
+                    "source": {
+                        "bacdive": {"input": {"filename": ["data/transformed/bacdive/nodes.tsv"]}},
+                        "gold": {"input": {"filename": ["data/transformed/gold/edges.tsv"]}},
+                    },
+                    "operations": [
+                        {
+                            "name": "kgx.graph_operations.summarize_graph.generate_graph_stats",
+                            "args": {"filename": "stats.yaml"},
+                        }
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return stats, edges, config
+
+
+def test_raw_predicate_counts_include_metpo_and_sum_to_the_edge_total(tmp_path):
+    """KGX's count_by_predicates records METPO as None; the raw count names it and adds up."""
+    stats, edges, config = _write_fixture(tmp_path)
+    result = annotate_graph_stats(stats, edges, config, tmp_path, now=datetime(2026, 9, 10, tzinfo=timezone.utc))
+    raw = result["edge_stats"]["count_by_raw_predicate"]
+    assert raw == {"(blank)": 1, "METPO:2000517": 2, "biolink:subclass_of": 1}
+    assert sum(raw.values()) == result["edge_stats"]["total_edges"]
+    assert result["edge_stats"]["count_by_predicates"] == {"biolink:subclass_of": {"count": 1}}, "KGX's block is kept"
+
+
+def test_provenance_names_when_config_commit_and_source_markers(tmp_path):
+    """A committed copy can be told from a stale one without diffing counts."""
+    stats, edges, config = _write_fixture(tmp_path)
+    result = annotate_graph_stats(stats, edges, config, tmp_path, now=datetime(2026, 9, 10, 1, 24, tzinfo=timezone.utc))
+    prov = result["provenance"]
+    assert prov["generated_at"] == "2026-09-10T01:24:00+00:00"
+    assert prov["merge_config"] == str(config)
+    assert prov["edges_file"] == str(edges)
+    assert prov["commit"] == "unknown", "tmp_path is not a git checkout; the field is still written"
+    assert prov["sources"]["bacdive"].startswith("code=c0de data=da7a schema=5c")
+    assert prov["sources"]["gold"] == "no marker in data/transformed/gold"
+    on_disk = yaml.safe_load(stats.read_text(encoding="utf-8"))
+    assert on_disk["provenance"] == prov
+
+
+def test_annotating_twice_replaces_rather_than_appends(tmp_path):
+    """Re-running the merge must not stack provenance blocks or double the raw counts."""
+    stats, edges, config = _write_fixture(tmp_path)
+    annotate_graph_stats(stats, edges, config, tmp_path)
+    second = annotate_graph_stats(stats, edges, config, tmp_path)
+    assert list(second) == ["edge_stats", "graph_name", "node_stats", "provenance"]
+    assert second["edge_stats"]["count_by_raw_predicate"]["METPO:2000517"] == 2
+
+
+def test_a_mismatched_edges_file_is_refused(tmp_path):
+    """Counting a different file than the stats describe would be worse than no count."""
+    stats, edges, config = _write_fixture(tmp_path)
+    with edges.open("a", encoding="utf-8") as handle:
+        handle.write("NCBITaxon:9\tbiolink:related_to\tNCBITaxon:1\n")
+    try:
+        annotate_graph_stats(stats, edges, config, tmp_path)
+    except ValueError as exc:
+        assert "5 != KGX total_edges 4" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_the_stats_filename_comes_from_the_config_operation(tmp_path):
+    """The merge config, not a hardcoded name, says which file to annotate — variants differ."""
+    _, _, config = _write_fixture(tmp_path)
+    assert stats_filename_from_config(yaml.safe_load(config.read_text())) == "stats.yaml"
+    assert stats_filename_from_config({"merged_graph": {"operations": []}}) is None
+    assert count_raw_predicates(tmp_path / "merged-kg_edges.tsv")["METPO:2000517"] == 2
+
+
+def test_the_real_canonical_config_names_a_stats_file():
+    """merge.yaml's summarize operation is what the hook reads; keep them in step."""
+    config = yaml.safe_load(Path("merge.yaml").read_text(encoding="utf-8"))
+    assert stats_filename_from_config(config) == "merged_graph_stats.yaml"
+
+
+def test_the_stats_file_itself_never_makes_the_commit_dirty():
+    """KGX rewrites the stats file right before annotation; that must not read as a dirty tree."""
+    from kg_microbe.merge_utils.stats_provenance import git_commit
+
+    repo = Path(".").resolve()
+    stats = repo / "merged_graph_stats.yaml"
+    commit = git_commit(repo, ignore=(stats,))
+    assert commit != "unknown"
+    assert len(commit.split("-")[0]) >= 7
+    # Ignoring the stats file can only make the verdict cleaner, never dirtier.
+    assert not (commit.endswith("-dirty") and not git_commit(repo).endswith("-dirty"))
+
+
+def test_a_directory_that_is_not_a_checkout_records_unknown(tmp_path):
+    """No git, no repo: the field says so rather than raising."""
+    from kg_microbe.merge_utils.stats_provenance import git_commit
+
+    assert git_commit(tmp_path) == "unknown"


### PR DESCRIPTION
Closes #1013. Closes #993.

## Change

`kg_microbe/merge_utils/stats_provenance.py`, hooked into `_cleanup_merged_outputs` right after the invariants check (same isolation: a failure prints and the archive still ships):

- **`provenance`** block: `generated_at`, `commit` (short HEAD; `-dirty` only when a *tracked file other than the stats file* differs — KGX has just rewritten the stats file, so `git describe --dirty` would always say dirty), `merge_config`, `edges_file`, `python`, `kgx`, and per-source `source_fingerprint.json` digests (`no marker in <dir>` when absent).
- **`edge_stats.count_by_raw_predicate`**: the predicate column counted as written, no Biolink resolution, so `METPO:*` predicates sit next to `biolink:*`. Refuses to write if its total ≠ KGX's `total_edges`.
- The stats filename is read from the config's `generate_graph_stats` operation, so every generated variant (`merged_graph_stats_no_prego.yaml`, …) is annotated the same way.
- CLAUDE.md: one paragraph under Data flow.

## Canary (real archive, scratch copy of the stats)

15,392,517 edges: raw total == KGX `total_edges`; `METPO:2000511` = 706,765; 67 METPO predicates carrying 7,656,831 edges; 88 predicates in all; 166 s.

The tracked `merged_graph_stats.yaml` is **not** rewritten in this PR: recording today's HEAD against an archive that was merged on `4fcea53b1` would be the false provenance the issue is about. The block lands with the next canonical merge (scheduled at the end of this batch).

## Tests

`tests/test_merge_stats_provenance.py` — 8 tests: raw counts include METPO and sum to the total; KGX's block kept; provenance fields and source markers; idempotent re-annotation; mismatched edges file refused; filename from config (incl. the real `merge.yaml`); stats file never makes the commit dirty; non-checkout records `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuYY9wZKmXeNJ8rrQ2psqt
