### PR TITLE
mediadive: own the API fallback's HTTP cache instead of patching requests.Session process-wide (#624)

### DIFF
--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -19,6 +19,7 @@ import csv
 import json
 import math
 import os
+import shutil
 import time
 from pathlib import Path
 from typing import Dict, Optional, Union
@@ -26,8 +27,9 @@ from urllib.parse import urlparse
 
 import pandas as pd
 import requests
-import requests_cache
 import yaml
+from requests_cache import CachedSession
+from requests_cache.backends.sqlite import SQLiteCache
 from tqdm import tqdm
 
 from kg_microbe.transform_utils.constants import (
@@ -124,6 +126,12 @@ from kg_microbe.utils.pandas_utils import (
     drop_duplicates,
 )
 
+#: HTTP response cache for the API fallback, kept beside the bulk JSONs. The
+#: old name is the file `requests_cache.install_cache("mediadive_cache")` left
+#: in the working directory; it is adopted on first use so nothing re-downloads.
+HTTP_CACHE_FILENAME = "mediadive_transform_cache.sqlite"
+LEGACY_HTTP_CACHE_FILENAME = "mediadive_cache.sqlite"
+
 
 class MediaDiveTransform(Transform):
     """Template for how the transform class would be designed."""
@@ -138,7 +146,12 @@ class MediaDiveTransform(Transform):
         # can carry the recipe's amount + unit (g/l, mmol/l, ml/l, ...).
         # Other edge sites in this transform leave both columns empty.
         self.edge_header = self.edge_header + ["value", "unit"]
-        requests_cache.install_cache("mediadive_cache")
+        # No `requests_cache.install_cache()` here: that monkeypatched
+        # `requests.Session` for the whole process from a constructor, so every
+        # HTTP client in the run became a CachedSession and a test that merely
+        # built this transform changed the outcome of unrelated tests (#624).
+        # The cache is a session this transform owns, opened on first API call.
+        self._http: Optional[requests.Session] = None
         self.translation_table = str.maketrans(TRANSLATION_TABLE_FOR_LABELS)
 
         # Load ChEBI role relationships from ontologies transform output (fast TSV lookup).
@@ -471,7 +484,7 @@ class MediaDiveTransform(Transform):
         """
         for attempt in range(retry_count):
             try:
-                r = requests.get(url, timeout=30)
+                r = self._http_session().get(url, timeout=30)
                 r.raise_for_status()
                 data_json = r.json()
                 return data_json.get(DATA_KEY, {})
@@ -482,6 +495,43 @@ class MediaDiveTransform(Transform):
                 else:
                     print(f"  Failed after {retry_count} attempts: {e} (URL: {url})")
                     return {}
+
+    def _http_cache_path(self) -> Path:
+        """
+        Return the API fallback's cache file, adopting the legacy one if present.
+
+        Older code cached in the working directory (usually the repo root).
+        Moving that file, rather than ignoring it, keeps its responses; it is
+        an optimisation, so a failed move is reported and a fresh cache used.
+        """
+        cache_path = self.bulk_data_dir / HTTP_CACHE_FILENAME
+        legacy = Path.cwd() / LEGACY_HTTP_CACHE_FILENAME
+        if not cache_path.exists() and legacy.is_file():
+            try:
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(legacy), str(cache_path))
+                print(f"  Adopted legacy HTTP cache {legacy} -> {cache_path}")
+            except OSError as e:
+                print(f"  Could not adopt {legacy} ({e}); using a fresh HTTP cache")
+        return cache_path
+
+    def _http_session(self) -> requests.Session:
+        """Return this transform's cached HTTP session, opening it on first use."""
+        if self._http is None:
+            cache_path = self._http_cache_path()
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            self._http = CachedSession(backend=SQLiteCache(str(cache_path)))
+        return self._http
+
+    def _close_http(self) -> None:
+        """Close the HTTP session so its SQLite connection does not linger."""
+        # getattr: tests build the transform with __new__ and no __init__.
+        session = getattr(self, "_http", None)
+        if session is not None:
+            try:
+                session.close()
+            finally:
+                self._http = None
 
     def _get_chebi_label(self, curie: str) -> str:
         """
@@ -796,7 +846,7 @@ class MediaDiveTransform(Transform):
         Refuse to transform when the bulk MediaDive download is missing.
 
         Without it the medium/solution lookups fall back to the YAML cache
-        under ``tmp/medium_yaml`` and to ``requests_cache``, neither of
+        under ``tmp/medium_yaml`` and to this transform's HTTP cache, neither of
         which carries an expiry. Those caches hold responses from 2023 and
         2025 that predate MediaDive restructuring solutions, so the run
         succeeds with exit code 0 while emitting a graph built from years-old
@@ -821,6 +871,13 @@ class MediaDiveTransform(Transform):
         )
 
     def run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True):
+        """Run the transformation, closing the API session afterwards."""
+        try:
+            self._run(data_file, show_status)
+        finally:
+            self._close_http()
+
+    def _run(self, data_file: Union[Optional[Path], Optional[str]] = None, show_status: bool = True):
         """Run the transformation."""
         self._assert_bulk_data_available()
         # replace with downloaded data filename for this source

--- a/tests/test_mediadive_http_cache.py
+++ b/tests/test_mediadive_http_cache.py
@@ -1,0 +1,88 @@
+"""The MediaDive transform's HTTP cache is a session it owns, not a process-wide patch (#624)."""
+
+from pathlib import Path
+from unittest import mock
+
+import requests
+from requests_cache import CachedSession
+
+from kg_microbe.transform_utils.mediadive import mediadive as mod
+from kg_microbe.transform_utils.mediadive.mediadive import MediaDiveTransform
+
+
+def _bare_transform(tmp_path: Path) -> MediaDiveTransform:
+    """Build a transform with __init__ skipped: the cache must not need any of the heavy loading."""
+    xform = MediaDiveTransform.__new__(MediaDiveTransform)
+    xform._http = None
+    xform.bulk_data_dir = tmp_path / "raw" / "mediadive"
+    return xform
+
+
+def test_constructing_the_transform_leaves_requests_session_alone(tmp_path, monkeypatch):
+    """The bug: install_cache() in __init__ made every requests.Session in the process a CachedSession."""
+    monkeypatch.chdir(tmp_path)
+    before = requests.Session
+    with (
+        mock.patch.object(MediaDiveTransform, "_load_chebi_roles"),
+        mock.patch.object(MediaDiveTransform, "_load_chebi_categories"),
+        mock.patch.object(MediaDiveTransform, "_load_micromediaparam_mappings"),
+        mock.patch.object(MediaDiveTransform, "_load_bulk_data"),
+        mock.patch.object(mod, "ChemicalMappingLoader"),
+    ):
+        xform = MediaDiveTransform(input_dir=tmp_path / "raw", output_dir=tmp_path / "out")
+    assert requests.Session is before
+    assert type(requests.Session()) is requests.Session
+    assert not hasattr(requests.Session(), "cache")
+    assert xform._http is None, "no session until the first API call"
+
+
+def test_the_session_is_cached_beside_the_bulk_data_and_closed_after_run(tmp_path, monkeypatch):
+    """One CachedSession per transform, backed by a file under the bulk data dir, closed by run()."""
+    monkeypatch.chdir(tmp_path)
+    xform = _bare_transform(tmp_path)
+    session = xform._http_session()
+    assert isinstance(session, CachedSession)
+    assert xform._http_session() is session
+    assert (tmp_path / "raw" / "mediadive" / mod.HTTP_CACHE_FILENAME).exists()
+    assert type(requests.Session()) is requests.Session
+    xform._close_http()
+    assert xform._http is None
+
+
+def test_the_api_helper_uses_the_owned_session(tmp_path, monkeypatch):
+    """_get_mediadive_json goes through the transform's session, never module-level requests.get."""
+    monkeypatch.chdir(tmp_path)
+    xform = _bare_transform(tmp_path)
+    fake = mock.Mock()
+    fake.get.return_value.json.return_value = {mod.DATA_KEY: {"id": 1}}
+    xform._http = fake
+    with mock.patch.object(mod.requests, "get", side_effect=AssertionError("module-level requests.get used")):
+        assert xform._get_mediadive_json("https://example/api") == {"id": 1}
+    fake.get.assert_called_once_with("https://example/api", timeout=30)
+
+
+def test_a_legacy_cache_in_the_working_directory_is_adopted(tmp_path, monkeypatch):
+    """The old install_cache() file in the CWD is moved, so its responses are not re-downloaded."""
+    monkeypatch.chdir(tmp_path)
+    legacy = tmp_path / mod.LEGACY_HTTP_CACHE_FILENAME
+    legacy.write_bytes(b"not really sqlite")
+    xform = _bare_transform(tmp_path)
+    path = xform._http_cache_path()
+    assert path == tmp_path / "raw" / "mediadive" / mod.HTTP_CACHE_FILENAME
+    assert path.read_bytes() == b"not really sqlite"
+    assert not legacy.exists()
+
+
+def test_run_closes_the_session_even_when_the_transform_fails(tmp_path, monkeypatch):
+    """A crash mid-run must not leave the SQLite connection open."""
+    monkeypatch.chdir(tmp_path)
+    xform = _bare_transform(tmp_path)
+    xform._http = mock.Mock()
+    with mock.patch.object(MediaDiveTransform, "_run", side_effect=RuntimeError("boom")):
+        try:
+            xform.run()
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("expected the failure to propagate")
+    assert xform._http is None


### PR DESCRIPTION
Closes #624.

`MediaDiveTransform.__init__` called `requests_cache.install_cache("mediadive_cache")`, which monkeypatches `requests.Session` for the whole process from a constructor. #612 removed the same call from the download path; this does it for the transform.

## Change

- `__init__` no longer touches `requests`. The transform opens **one `CachedSession` it owns** on the first API call (`_http_session`), backed by `<bulk_data_dir>/mediadive_transform_cache.sqlite`; `run()` closes it in a `finally` (`_close_http`).
- The legacy `mediadive_cache.sqlite` the old code left in the working directory is adopted (moved) on first use so cached responses are not re-downloaded; a failed move is reported and a fresh cache used.
- `_get_mediadive_json` uses the owned session; module-level `requests.get` is gone from the transform.
- The stale-cache guard's docstring now names the transform's cache rather than `requests_cache`.

The transform does not thread, so one session is the right scope; the downloader's per-thread sessions stay as they are.

## Tests

`tests/test_mediadive_http_cache.py` — 5 tests: constructing the transform leaves `requests.Session` untouched and opens no session; the session is a `CachedSession` beside the bulk data and is closed; the API helper never calls `requests.get`; the legacy CWD cache is adopted; `run()` closes the session even when the transform raises.

The issue's order-dependent repro passes in the failing order: `pytest tests/test_transform_category_alignment.py tests/test_mediadive_bulk_download.py` → 34 passed, 4 skipped.

No rerun needed: the bulk data path is unchanged; the API fallback only runs for media the bulk JSONs lack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuYY9wZKmXeNJ8rrQ2psqt
