### PR TITLE
Growth-media edges: docs and query match what the transforms emit (#539)

### DIFF
--- a/.claude/skills/kg-query/SKILL.md
+++ b/.claude/skills/kg-query/SKILL.md
@@ -31,13 +31,12 @@ poetry run kg query-organism "Corynebacterium glutamicum" -o report.md
 1. **Name Resolution**: Fuzzy matching on organism names and synonyms
 2. **Taxonomy**: Species classification hierarchy
 3. **Phenotypic Traits**: Oxygen preference, metabolism, morphology, Gram stain
-4. **Media Preferences**: Growth media edges use a Biolink predicate (e.g. `biolink:located_in`) and carry the METPO semantics in the `relation` column — `METPO:2000517` (grows in) and `METPO:2000518` (doesn't grow in). Filter on `relation` when querying.
+4. **Media Preferences**: Growth media edges carry the METPO term as the **predicate** — `METPO:2000517` (grows in) and `METPO:2000518` (does not grow in) — with the same term repeated in `relation`; there is no `biolink:located_in` on these edges (measured 2026-09-10: 36,596 BacDive + 55,251 MediaDive edges, all `predicate == relation`). Filter on `predicate`; `get_media_preferences()` also accepts the term in `relation` so a graph built before the METPO predicate still answers. See #539.
 5. **Media Composition**: 2-hop traversal (organism → media → solutions → chemicals)
 6. **Strain Information**: All strain records linked to species
 
 ## Data Sources
-- Nodes: 1.5M entries (883K organism taxa)
-- Edges: 6.1M relationships
+- Nodes: 3.38M entries; Edges: 15.39M relationships (canonical `merge.yaml`, 2026-09-10 — see `merged_graph_stats.yaml`, whose `provenance` block names the merge that produced it)
 - Primary sources: BacDive, MediaDive, MadinEtal, BactoTraits, GTDB, UniProt
 
 ## Example Organisms

--- a/kg_microbe/query_utils/organism_queries.py
+++ b/kg_microbe/query_utils/organism_queries.py
@@ -93,11 +93,14 @@ def get_media_preferences(conn: duckdb.DuckDBPyConnection, taxon_id: str) -> Dic
     """
     Get growth media preferences (grows in / doesn't grow in).
 
-    Growth media edges use Biolink predicates (e.g. ``biolink:located_in``) and
-    encode the METPO "grows in" / "does not grow in" semantics in the
-    ``relation`` column (``METPO:2000517`` / ``METPO:2000518``), matching the
-    transform output produced by BacDive and MediaDive. Filtering on
-    ``relation`` keeps the query aligned with that KGX encoding.
+    BacDive and MediaDive emit growth-media edges with the METPO term in the
+    ``predicate`` column *and* the ``relation`` column: ``METPO:2000517``
+    (grows in) / ``METPO:2000518`` (does not grow in). Measured on the
+    2026-09-10 outputs: 36,596 + 55,251 edges, every one ``predicate ==
+    relation``; none carry ``biolink:located_in`` (the docs here and in the
+    kg-query skill said otherwise, #539). The predicate is matched first;
+    ``relation`` is a fallback for a graph built before the METPO predicate
+    replaced ``biolink:located_in``, so an older release still answers.
 
     :param conn: DuckDB connection
     :param taxon_id: NCBITaxon ID
@@ -105,15 +108,16 @@ def get_media_preferences(conn: duckdb.DuckDBPyConnection, taxon_id: str) -> Dic
     """
     query = """
     SELECT
-        e.relation,
+        CASE WHEN e.predicate IN ('METPO:2000517', 'METPO:2000518') THEN e.predicate ELSE e.relation END AS growth,
         e.object AS medium_id,
         n.name AS medium_name,
         e.primary_knowledge_source
     FROM edges e
     JOIN nodes n ON e.object = n.id
     WHERE e.subject = ?
-      AND e.relation IN ('METPO:2000517', 'METPO:2000518')
-    ORDER BY e.relation, n.name;
+      AND (e.predicate IN ('METPO:2000517', 'METPO:2000518')
+           OR e.relation IN ('METPO:2000517', 'METPO:2000518'))
+    ORDER BY growth, n.name;
     """
 
     result = conn.execute(query, [taxon_id]).fetchall()
@@ -121,16 +125,16 @@ def get_media_preferences(conn: duckdb.DuckDBPyConnection, taxon_id: str) -> Dic
     grows_in = []
     no_growth = []
 
-    for relation, medium_id, medium_name, source in result:
+    for growth, medium_id, medium_name, source in result:
         media_entry = {
             "medium_id": medium_id,
             "medium_name": medium_name,
             "source": source,
         }
 
-        if relation == "METPO:2000517":  # grows in
+        if growth == "METPO:2000517":  # grows in
             grows_in.append(media_entry)
-        elif relation == "METPO:2000518":  # doesn't grow in
+        elif growth == "METPO:2000518":  # doesn't grow in
             no_growth.append(media_entry)
 
     return {"grows_in": grows_in, "no_growth": no_growth}

--- a/tests/test_duckdb_query_cli.py
+++ b/tests/test_duckdb_query_cli.py
@@ -27,7 +27,8 @@ def _write_graph(tmp_path: Path, newline: str = "\n") -> tuple[Path, Path]:
     ]
     edge_rows = [
         "NCBITaxon:562\tbiolink:has_phenotype\tMETPO:1000699\tRO:0002200\tinfores:test",
-        "NCBITaxon:562\tbiolink:located_in\tmediadive.medium:1\tMETPO:2000517\tinfores:test",
+        # The shape the transforms emit: the METPO term is the predicate and the relation (#539).
+        "NCBITaxon:562\tMETPO:2000517\tmediadive.medium:1\tMETPO:2000517\tinfores:test",
     ]
     nodes.write_bytes((NODE_HEADER.rstrip("\n") + newline + newline.join(node_rows) + newline).encode())
     edges.write_bytes((EDGE_HEADER.rstrip("\n") + newline + newline.join(edge_rows) + newline).encode())
@@ -163,3 +164,29 @@ def test_holdouts_is_not_advertised_until_implemented() -> None:
     result = CliRunner().invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "holdouts" not in result.output
+
+
+def test_media_preferences_match_the_shape_the_transforms_emit(tmp_path: Path) -> None:
+    """
+    #539: the query filtered on ``relation`` while the docs promised ``biolink:located_in``.
+
+    Both BacDive and MediaDive put the METPO term in ``predicate`` and ``relation``.
+    The predicate is matched first; an edge that only carries the term in
+    ``relation`` (a graph built before the METPO predicate) still answers.
+    """
+    from kg_microbe.query_utils.organism_queries import get_media_preferences
+
+    nodes, edges = _write_graph(tmp_path)
+    with nodes.open("a", encoding="utf-8") as handle:
+        handle.write("mediadive.medium:2\tMETPO:1004005\tNo-growth medium\t\n")
+        handle.write("mediadive.medium:3\tMETPO:1004005\tLegacy medium\t\n")
+    with edges.open("a", encoding="utf-8") as handle:
+        handle.write("NCBITaxon:562\tMETPO:2000518\tmediadive.medium:2\tMETPO:2000518\tinfores:test\n")
+        handle.write("NCBITaxon:562\tbiolink:located_in\tmediadive.medium:3\tMETPO:2000517\tinfores:old\n")
+    conn = get_or_create_database(nodes, edges, tmp_path / "graph.duckdb")
+    try:
+        prefs = get_media_preferences(conn, "NCBITaxon:562")
+    finally:
+        conn.close()
+    assert [m["medium_id"] for m in prefs["grows_in"]] == ["mediadive.medium:3", "mediadive.medium:1"]
+    assert [m["medium_id"] for m in prefs["no_growth"]] == ["mediadive.medium:2"]

--- a/tests/test_duckdb_query_cli.py
+++ b/tests/test_duckdb_query_cli.py
@@ -73,16 +73,17 @@ def test_same_size_same_mtime_content_change_rebuilds_database(tmp_path: Path) -
     db_path = tmp_path / "graph.duckdb"
     get_or_create_database(nodes, edges, db_path).close()
     original_stat = edges.stat()
-    changed = edges.read_text(encoding="utf-8").replace("located_in", "related_to")
+    # Same byte length: "grows in" becomes "does not grow in" by one digit.
+    changed = edges.read_text(encoding="utf-8").replace("METPO:2000517\tinfores", "METPO:2000518\tinfores")
     assert len(changed.encode()) == edges.stat().st_size
     edges.write_text(changed, encoding="utf-8")
     os.utime(edges, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
 
     conn = get_or_create_database(nodes, edges, db_path)
     try:
-        predicates = {row[0] for row in conn.execute("SELECT predicate FROM edges").fetchall()}
-        assert "biolink:related_to" in predicates
-        assert "biolink:located_in" not in predicates
+        relations = {row[0] for row in conn.execute("SELECT relation FROM edges").fetchall()}
+        assert "METPO:2000518" in relations
+        assert "METPO:2000517" not in relations
     finally:
         conn.close()
 


### PR DESCRIPTION
Closes #539.

## Measured, not assumed

On the FRESH 2026-09-10 outputs, growth-media edges look like this in **both** sources:

| source | predicate | relation | edges |
|---|---|---|---:|
| bacdive | `METPO:2000517` | `METPO:2000517` | 36,596 |
| mediadive | `METPO:2000517` | `METPO:2000517` | 55,251 |
| mediadive | `METPO:2000518` | `METPO:2000518` | 3 |

No edge carries `biolink:located_in`. The docs (`kg-query/SKILL.md`, the `get_media_preferences` docstring) described a Biolink-predicate encoding that does not exist, and `tests/test_duckdb_query_cli.py`'s fixture encoded that fiction too — so the docs, the fixture and the graph disagreed while the query, filtering on `relation`, happened to work.

## Change

- `get_media_preferences`: match `predicate` first, fall back to `relation` (so a graph built before the METPO predicate still answers); classify by whichever carried the term. Docstring states the measured shape.
- `.claude/skills/kg-query/SKILL.md`: the encoding paragraph, and the node/edge counts (1.5M / 6.1M were from an old graph → 3.38M / 15.39M with a pointer to `merged_graph_stats.yaml`'s new `provenance` block).
- Fixture uses the real shape; new test covers grows-in, does-not-grow-in, and the legacy relation-only edge.

No rerun needed — query and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuYY9wZKmXeNJ8rrQ2psqt
