### PR TITLE
lpsn_api: count an empty API result as a miss, not an error (#1020)

### DIFF
--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -234,6 +234,7 @@ class LPSNAPITransform(Transform):
             "fetched": 0,
             "from_cache": 0,
             "errors": 0,
+            "api_misses": 0,
             "linked_declared": 0,
             "linked_from_web": 0,
             "linked_stubbed": 0,
@@ -306,6 +307,7 @@ class LPSNAPITransform(Transform):
             f"[lpsn_api] fetched={self._stats['fetched']:,} "
             f"cached={self._stats['from_cache']:,} "
             f"errors={self._stats['errors']:,} "
+            f"api_misses={self._stats.get('api_misses', 0):,} "
             f"linked_records_declared={self._stats.get('linked_declared', 0):,} "
             f"linked_records_from_web={self._stats.get('linked_from_web', 0):,} "
             f"linked_records_stubbed={self._stats.get('linked_stubbed', 0):,}"
@@ -402,7 +404,11 @@ class LPSNAPITransform(Transform):
             return None
 
         if not records:
-            self._stats["errors"] += 1
+            # Not an error: the API answered and has no record. Counted apart
+            # from transport/parse failures, because 665 of these are expected
+            # (pre-Approved-Lists basonyms) and are then labelled from the web
+            # page; reading them as errors next to 665 successes misled (#1020).
+            self._stats["api_misses"] = self._stats.get("api_misses", 0) + 1
             print(f"[lpsn_api] no record returned for {record_no}")
             return None
         record = records[0] if isinstance(records[0], dict) else records[0].__dict__

--- a/tests/test_lpsn_api_transform.py
+++ b/tests/test_lpsn_api_transform.py
@@ -439,3 +439,16 @@ def test_a_linked_record_is_declared_once(api_transform):
     api_transform.run()
     ids = [n["id"] for n in _read_tsv(api_transform.output_node_file)]
     assert ids.count(f"{LPSN_PREFIX}1001") == 1
+
+
+def test_an_api_miss_is_counted_apart_from_errors(api_transform):
+    """
+    #1020: the summary line read errors=665 beside linked_records_from_web=665.
+
+    An empty result set is the API answering "no such record"; a transport or
+    parse failure is an error. The fixture has two misses (999, 1004) and no
+    failures.
+    """
+    api_transform.run()
+    assert api_transform._stats["api_misses"] == 2
+    assert api_transform._stats["errors"] == 0


### PR DESCRIPTION
Closes #1020.

After #1019 the summary read `errors=665 … linked_records_from_web=665` — the same 665 records counted as failures and then as successes. `_fetch` incremented `errors` on an empty result set before the web fallback ran.

## Change

- An empty result set increments a new `api_misses` counter; `errors` is left for transport and parse failures (the `except` branch is unchanged).
- The summary line prints `api_misses=` beside `errors=`.
- Test: the fixture's two API-less records (999, 1004) give `api_misses == 2`, `errors == 0`.

No rerun needed — counters and the printed summary only; the next `lpsn_api` run (batched at the end) should read `errors=0 api_misses=665 linked_records_from_web=665`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuYY9wZKmXeNJ8rrQ2psqt
