### PR TITLE
lpsn_api: publish nodes.tsv/edges.tsv atomically (#985)

### DIFF
--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -75,6 +75,7 @@ from kg_microbe.transform_utils.constants import (
 )
 from kg_microbe.transform_utils.lpsn.lpsn import LPSN_KNOWLEDGE_SOURCE, LPSN_PREFIX
 from kg_microbe.transform_utils.transform import Transform
+from kg_microbe.utils.atomic_io import atomic_write
 
 # JSON keys returned by the LPSN API (documented at
 # https://lpsn.dsmz.de/text/lpsn-api). Kept as module constants so a
@@ -280,9 +281,12 @@ class LPSNAPITransform(Transform):
         self._web_cache_dir.mkdir(parents=True, exist_ok=True)
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        # Atomic: a crash mid-run must leave no nodes.tsv/edges.tsv at all. A
+        # truncated pair reads as complete to the merge, and the lpsn transform
+        # already publishes this way (#820, #981, #985).
         with (
-            open(self.output_node_file, "w", newline="") as node_fh,
-            open(self.output_edge_file, "w", newline="") as edge_fh,
+            atomic_write(self.output_node_file, newline="") as node_fh,
+            atomic_write(self.output_edge_file, newline="") as edge_fh,
         ):
             node_writer = csv.writer(node_fh, delimiter="\t")
             edge_writer = csv.writer(edge_fh, delimiter="\t")

--- a/tests/test_lpsn_api_transform.py
+++ b/tests/test_lpsn_api_transform.py
@@ -452,3 +452,27 @@ def test_an_api_miss_is_counted_apart_from_errors(api_transform):
     api_transform.run()
     assert api_transform._stats["api_misses"] == 2
     assert api_transform._stats["errors"] == 0
+
+
+def test_a_run_that_dies_midway_leaves_no_output_file(api_transform, monkeypatch):
+    """
+    A truncated nodes.tsv is worse than none (#985, same rule as lpsn's #820).
+
+    The merge reads whatever pair is on disk as complete; absence is the state
+    the freshness check and the merge both understand.
+    """
+    calls = {"n": 0}
+    original = api_transform._emit
+
+    def explode(record_no, record, node_writer, edge_writer):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated crash after the first record")
+        return original(record_no, record, node_writer, edge_writer)
+
+    monkeypatch.setattr(api_transform, "_emit", explode)
+    with pytest.raises(RuntimeError):
+        api_transform.run()
+    assert not api_transform.output_node_file.exists()
+    assert not api_transform.output_edge_file.exists()
+    assert not list(Path(api_transform.output_dir).glob("*.partial"))


### PR DESCRIPTION
Closes #985.

`lpsn_api.run()` wrote `nodes.tsv` and `edges.tsv` with plain `open()`; a crash mid-run left a truncated pair the merge reads as complete. This is the same change #981 made in `lpsn.py`: both files go through `atomic_write`, so an exception inside the body unwinds both and neither is published.

The two-file window the issue's last comment describes (inner `os.replace` succeeds, outer fails) remains, as it does for `lpsn` — the repo has no two-file transaction and the issue records that as not worth building for these two transforms.

Test mirrors `test_a_run_that_dies_midway_leaves_no_output_file` from the lpsn suite: a crash after the first record leaves no output file and no `*.partial`. 21 passed.

Rerun: batched with the end-of-batch `lpsn_api` run (13 min); the code path that writes rows is unchanged, so the output is expected byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuYY9wZKmXeNJ8rrQ2psqt
