### PR TITLE
ontologies: type FOODON terms Food and PATO terms PhenotypicQuality (#1015)

### DIFF
--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -367,6 +367,7 @@ PATHWAY_CATEGORY = "biolink:BiologicalProcess"
 
 # Anatomical and environmental categories
 ANATOMICAL_ENTITY_CATEGORY = "biolink:AnatomicalEntity"  # For UBERON anatomical terms
+FOOD_CATEGORY = "biolink:Food"  # FOODON terms (#1015)
 ENVIRONMENT_CATEGORY = "biolink:EnvironmentalFeature"  # "ENVO:01000254"
 
 # Phenotype and attribute categories

--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -499,8 +499,10 @@ class OntologiesTransform(Transform):
         from kg_microbe.utils.ontology_utils import (
             assert_go_version_alignment,
             get_chebi_category,
+            get_foodon_category,
             get_go_category_by_aspect,
             get_ncbitaxon_category,
+            get_pato_category,
             get_uberon_category,
             replace_deprecated_categories,
         )
@@ -562,6 +564,33 @@ class OntologiesTransform(Transform):
                 return replace_deprecated_categories(str(row["category"]))
 
             df["category"] = df.apply(fix_uberon_category, axis=1)
+
+        elif ontology_name == "foodon":
+            # FOODON terms are foods; the obograph default (OntologyClass)
+            # disagreed with mediadive's biolink:Food for the same ids (#1015).
+            print("  Fixing FOODON categories (all terms → Food)...")
+
+            def fix_foodon_category(row):
+                """Fix FOODON category (all FOODON terms are Food; imports keep theirs)."""
+                foodon_id = row["id"]
+                if pd.notna(foodon_id) and foodon_id.startswith("FOODON:"):
+                    return get_foodon_category(foodon_id)
+                return replace_deprecated_categories(str(row["category"]))
+
+            df["category"] = df.apply(fix_foodon_category, axis=1)
+
+        elif ontology_name == "pato":
+            # PATO terms are qualities; madin_etal types them PhenotypicQuality (#1015).
+            print("  Fixing PATO categories (all terms → PhenotypicQuality)...")
+
+            def fix_pato_category(row):
+                """Fix PATO category (all PATO terms are PhenotypicQuality; imports keep theirs)."""
+                pato_id = row["id"]
+                if pd.notna(pato_id) and pato_id.startswith("PATO:"):
+                    return get_pato_category(pato_id)
+                return replace_deprecated_categories(str(row["category"]))
+
+            df["category"] = df.apply(fix_pato_category, axis=1)
 
         elif ontology_name == "ncbitaxon":
             # Fix NCBITaxon categories: all NCBITaxon terms should be OrganismTaxon

--- a/kg_microbe/utils/ontology_resolution.py
+++ b/kg_microbe/utils/ontology_resolution.py
@@ -8,6 +8,7 @@ from kg_microbe.transform_utils.constants import (
     CELLULAR_COMPONENT_CATEGORY,
     EC_CATEGORY,
     EC_PREFIX,
+    FOOD_CATEGORY,
     GENE_CATEGORY,
     GO_CATEGORY,
     GO_PREFIX,
@@ -15,6 +16,7 @@ from kg_microbe.transform_utils.constants import (
     MACROMOLECULE_CATEGORY,
     MOLECULAR_ACTIVITY_CATEGORY,
     NCBI_CATEGORY,
+    PHENOTYPIC_CATEGORY,
     PROTEIN_CATEGORY,
     RHEA_CATEGORY,
     RHEA_NEW_PREFIX,
@@ -122,6 +124,22 @@ def uberon_category(_term_id: str) -> str:
 def ncbitaxon_category(_term_id: str) -> str:
     """Return the invariant category for an NCBITaxon term."""
     return NCBI_CATEGORY
+
+
+def foodon_category(_term_id: str) -> str:
+    """
+    Return the invariant category for a FOODON term.
+
+    Without this the ontologies transform typed every FOODON term
+    biolink:OntologyClass while mediadive typed the same ids biolink:Food,
+    and the merge turned the disagreement into list-valued categories (#1015).
+    """
+    return FOOD_CATEGORY
+
+
+def pato_category(_term_id: str) -> str:
+    """Return the invariant category for a PATO term (madin_etal's choice, #1015)."""
+    return PHENOTYPIC_CATEGORY
 
 
 def replace_deprecated_category_names(category: str) -> str:

--- a/kg_microbe/utils/ontology_utils.py
+++ b/kg_microbe/utils/ontology_utils.py
@@ -36,8 +36,10 @@ from kg_microbe.transform_utils.constants import (
 )
 from kg_microbe.utils.ontology_resolution import (
     chebi_category,
+    foodon_category,
     go_category_for_namespace,
     ncbitaxon_category,
+    pato_category,
     replace_category_by_prefix,
     replace_deprecated_category_names,
     uberon_category,
@@ -2824,6 +2826,16 @@ def get_ncbitaxon_category(ncbitaxon_id: str) -> str:
 
     """
     return ncbitaxon_category(ncbitaxon_id)
+
+
+def get_foodon_category(foodon_term_id: str) -> str:
+    """Return the Biolink category for a FOODON term: always biolink:Food (#1015)."""
+    return foodon_category(foodon_term_id)
+
+
+def get_pato_category(pato_term_id: str) -> str:
+    """Return the Biolink category for a PATO term: always biolink:PhenotypicQuality (#1015)."""
+    return pato_category(pato_term_id)
 
 
 def replace_deprecated_categories(category_str: str) -> str:

--- a/tests/test_ontology_resolution.py
+++ b/tests/test_ontology_resolution.py
@@ -2,8 +2,10 @@
 
 from kg_microbe.utils.ontology_resolution import (
     chebi_category,
+    foodon_category,
     go_category_for_namespace,
     ncbitaxon_category,
+    pato_category,
     replace_category_by_prefix,
     replace_deprecated_category_names,
     uberon_category,
@@ -52,5 +54,8 @@ def test_simple_category_policies() -> None:
     """Prefix, invariant ontology, and deprecation policies are pure."""
     assert replace_category_by_prefix("GO:1\told", 0, 1) == "GO:1\tbiolink:BiologicalProcess"
     assert uberon_category("UBERON:1") == "biolink:AnatomicalEntity"
+    # #1015: the ontologies transform typed these OntologyClass while sources typed them Food / PhenotypicQuality.
+    assert foodon_category("FOODON:03301710") == "biolink:Food"
+    assert pato_category("PATO:0001421") == "biolink:PhenotypicQuality"
     assert ncbitaxon_category("NCBITaxon:1") == "biolink:OrganismTaxon"
     assert replace_deprecated_category_names("biolink:ChemicalSubstance") == "biolink:ChemicalEntity"


### PR DESCRIPTION
Closes #1015.

After #1010 merged the UBERON/FOODON/PATO files, the ontologies transform's `biolink:OntologyClass` default collided with the categories sources already use for the same ids — mediadive's `biolink:Food` (23 + 5 `ChemicalMixture`) and madin_etal's `biolink:PhenotypicQuality` (6) — and KGX turned each into a list-valued category.

## Change

- `ontology_resolution.py`: `foodon_category()` → `biolink:Food`, `pato_category()` → `biolink:PhenotypicQuality` (invariant per prefix, same shape as `uberon_category`); `constants.py` gains `FOOD_CATEGORY` (`PHENOTYPIC_CATEGORY` already existed).
- `ontology_utils.py`: `get_foodon_category` / `get_pato_category` wrappers.
- `ontologies_transform.py`: `foodon` and `pato` post-fix branches beside the UBERON/NCBITaxon/EC ones — only ids with the ontology's own prefix are retyped; imported terms keep their category.
- Test: the two policies in `tests/test_ontology_resolution.py`.

Not changed: madin's UBERON `EnvironmentalFeature` (its modelling choice, #246); the 5 mediadive FOODON ids typed `ChemicalMixture` will still merge as `[Food, ChemicalMixture]` — that is mediadive's call to make, not the ontology's.

## Rerun

Code-only here. The graph changes when `ontologies` reruns (batched at the end of this series with the canonical merge). Canary before that: `poetry run kg transform -s pato` on this branch — see the follow-up comment for its result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpEain2dcbJTKEKXEUXPnF
