### PR TITLE
gtdb: give every genome one correct, versioned, resolvable assembly identifier (#882)

### DIFF
--- a/.claude/skills/gtdb-phylo-diagram/SKILL.md
+++ b/.claude/skills/gtdb-phylo-diagram/SKILL.md
@@ -18,7 +18,7 @@ It is intentionally a *tree* view, not a network view — for network views use 
 Every edge in the merged KG is classified by looking at its two endpoints and predicate:
 
 - If **both** endpoints are taxon-prefixed (`NCBITaxon:`, `GTDB:`, `kgmicrobe.strain:`, `kgmicrobe.genus:`) the edge is *structural* — it carries the GTDB hierarchy, GTDB↔NCBITaxon `close_match` links, or strain→species `subclass_of` links. **Excluded** from node sizing.
-- If the predicate is `biolink:subclass_of` (regardless of the other endpoint) the edge is *classification* — most importantly the ~732K `GenBank:<genome> --subclass_of--> GTDB:<species>` edges (one per GTDB genome). **Excluded** from node sizing, otherwise the circles would measure "how many genomes GTDB has for this clade" rather than metadata richness.
+- If the predicate is `biolink:subclass_of` (regardless of the other endpoint) the edge is *classification* — most importantly the ~901K `ncbi.assembly:<accession> --subclass_of--> GTDB:<species>` edges (`GenBank:<genome>` before #882) (one per GTDB genome). **Excluded** from node sizing, otherwise the circles would measure "how many genomes GTDB has for this clade" rather than metadata richness.
 - Otherwise the edge contributes +1 to the count for whichever endpoint is a taxon. These are the biologically interesting edges: `has_phenotype`, `location_of` (isolation source), growth-media (`METPO:2000517`), and the METPO trait predicates.
 
 Counts on NCBITaxon are folded onto their GTDB equivalent via the mapping built in step 1; strain counts are folded onto the NCBITaxon parent and then onto GTDB. Cumulative counts propagate up the tree.

--- a/.claude/skills/gtdb-phylo-diagram/gtdb_phylo_diagram.py
+++ b/.claude/skills/gtdb-phylo-diagram/gtdb_phylo_diagram.py
@@ -189,7 +189,7 @@ def stream_edges(
                 continue
 
             # subclass_of with one taxon endpoint is a classification edge,
-            # not metadata -- e.g. GenBank:<genome> --subclass_of--> GTDB:<species>
+            # not metadata -- e.g. ncbi.assembly:<accession> --subclass_of--> GTDB:<species>
             # (~732K of these, one per GTDB genome). Excluding them keeps the
             # circle size meaning "biologically interesting edges" (phenotype,
             # isolation source, growth media, METPO traits) rather than

--- a/.claude/skills/kg-model-review/kg_model_review.py
+++ b/.claude/skills/kg-model-review/kg_model_review.py
@@ -275,6 +275,9 @@ STANDARD_PREFIXES = {
     "PO",        # Plant Ontology (OBO; reachable via ENVO/FOODON closure)
     "TAXRANK",   # Taxonomic Rank vocabulary (OBO; from NCBITaxon)
     "GenBank",   # GenBank sequence accessions (from NCBITaxon xrefs)
+    # NCBI Assembly accessions (GCA_*/GCF_*) minted by the gtdb transform.
+    # One prefix for both archives; the accession says which one (#882).
+    "ncbi.assembly",
     "chemrof",   # chemical role framework (CHEBI-adjacent)
     "debio",     # domain entity for biology (Rhea-adjacent)
     "kgmicrobe", # KG-Microbe native prefix (bare form; dotted variants also registered)

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -225,6 +225,13 @@ BACDIVE_API_BASE_URL = "https://mediadive.dsmz.de/"
 BIOSAFETY_LEVEL_PREFIX = "BSL:"
 GTDB_PREFIX = "GTDB:"
 GENBANK_PREFIX = "GenBank:"
+# NCBI Assembly accessions (GCA_* from GenBank, GCF_* from RefSeq). One
+# registered prefix covers both archives, and the accession itself says which
+# one it came from; `GenBank:GCF_...` asserted the wrong archive for 447,137
+# nodes and resolved to the nucleotide endpoint rather than the assembly one
+# (#882). Bioregistry `ncbi.assembly` ->
+# https://www.ncbi.nlm.nih.gov/datasets/genome/$1
+NCBI_ASSEMBLY_PREFIX = "ncbi.assembly:"
 # LPSN nomenclature spine (used both by the standalone `lpsn` transform and,
 # for organism identity, by MicrobeDecoder — whose row primary key is LPSN_ID).
 LPSN_PREFIX = "lpsn:"

--- a/kg_microbe/transform_utils/custom_curies.yaml
+++ b/kg_microbe/transform_utils/custom_curies.yaml
@@ -19,6 +19,12 @@
 #           and project IDs surfaced by MicrobeDecoder's pre-joined crosswalk.
 #   IMG   — JGI Integrated Microbial Genomes (https://bioregistry.io/registry/img.genome),
 #           genome IDs from the same MicrobeDecoder crosswalk.
+#   ncbi.assembly — NCBI Assembly accessions (https://bioregistry.io/registry/ncbi.assembly),
+#           minted by the gtdb transform for every classified genome. One prefix covers both
+#           archives: GCA_* comes from GenBank, GCF_* from RefSeq, and the accession says which.
+#           The version suffix is part of the identifier (GCA_000005845.1 and .2 are different
+#           assemblies). A RefSeq-primary genome carries its GenBank twin in `same_as` rather
+#           than getting a second node. See #882.
 #
 # Any kgmicrobe.* CURIE that exists as a placeholder for a proposed METPO term
 # (i.e. one that appears in mappings/metpo_proposal_*.tsv and will be swapped to

--- a/kg_microbe/transform_utils/gtdb/gtdb.py
+++ b/kg_microbe/transform_utils/gtdb/gtdb.py
@@ -10,7 +10,6 @@ from kg_microbe.transform_utils.constants import (
     CLOSE_MATCH_PREDICATE,
     CLOSE_MATCH_RELATION,
     DESCRIPTION_COLUMN,
-    GENBANK_PREFIX,
     GENOME_CATEGORY,
     GTDB,
     GTDB_AR53_METADATA,
@@ -29,13 +28,16 @@ from kg_microbe.transform_utils.constants import (
     PROVIDED_BY_COLUMN,
     RDFS_SUBCLASS_OF,
     RELATION_COLUMN,
+    SAME_AS_COLUMN,
     SUBCLASS_PREDICATE,
     SUBJECT_COLUMN,
 )
 from kg_microbe.transform_utils.gtdb.utils import (
+    assembly_archive,
+    assembly_curie,
     clean_taxon_name,
-    extract_accession_type,
     parse_taxonomy_string,
+    strip_gtdb_prefix,
 )
 from kg_microbe.transform_utils.transform import Transform
 
@@ -211,7 +213,7 @@ class GTDBTransform(Transform):
         Parse GTDB metadata file.
 
         For each genome:
-        1. Create GenBank genome node
+        1. Create the ncbi.assembly genome node
         2. Create subclass_of edge to GTDB taxon
         3. Create skos:closeMatch edge to NCBITaxon (if available)
         """
@@ -230,6 +232,11 @@ class GTDBTransform(Transform):
             for row in reader:
                 accession = row.get("accession", "").strip()
                 ncbi_taxid = row.get("ncbi_taxid", "").strip()
+                # The same physical assembly's GenBank accession; "none" is how
+                # GTDB spells absent here (#882).
+                genbank_accession = row.get("ncbi_genbank_assembly_accession", "").strip()
+                if genbank_accession.lower() in {"", "none", "na"}:
+                    genbank_accession = None
 
                 # Get taxonomy for this accession
                 taxa = accession_to_taxa.get(accession)
@@ -240,7 +247,7 @@ class GTDBTransform(Transform):
                 gtdb_taxon = clean_taxon_name(taxa[-1]) if taxa else None
 
                 # Create genome node and edges
-                self._create_genome_node(accession, gtdb_taxon, ncbi_taxid)
+                self._create_genome_node(accession, gtdb_taxon, ncbi_taxid, genbank_accession)
 
     def _create_genomes_from_taxonomy(self, taxa_list: List[Tuple[str, List[str]]]):
         """
@@ -291,25 +298,50 @@ class GTDBTransform(Transform):
 
         return self.taxon_to_id[cleaned]
 
-    def _create_genome_node(self, accession: str, gtdb_taxon: str, ncbi_taxid: str = None):
+    def _create_genome_node(
+        self,
+        accession: str,
+        gtdb_taxon: str,
+        ncbi_taxid: str = None,
+        genbank_accession: str = None,
+    ):
         """
         Create genome node and associated edges.
 
+        The node id is the ``ncbi.assembly:`` CURIE for the accession GTDB
+        classified, version intact (#882). ``genbank_accession`` is GTDB's
+        ``ncbi_genbank_assembly_accession`` column: for a genome GTDB took from
+        RefSeq it names the *same physical assembly* in GenBank, so it is
+        recorded in ``same_as``. Without it a consumer holding one of an
+        assembly's two accessions found nothing -- measured on the 2026-09-10
+        output, 0 of 901,341 genomes were reachable by both.
+
+        A second node for the paired accession was considered and rejected: one
+        physical assembly is one thing, and declaring both would double the
+        largest node block after NCBITaxon to say nothing new.
+
         Args:
-            accession: "GCF_000005845.2"
+            accession: "RS_GCF_000005845.2" or "GCF_000005845.2"
             gtdb_taxon: "s__Escherichia_coli"
             ncbi_taxid: "562" (optional)
+            genbank_accession: "GCA_000005845.2" (optional; from GTDB metadata)
 
         """
         # Create genome node
-        base_accession, version = extract_accession_type(accession)
-        genome_id = f"{GENBANK_PREFIX}{base_accession}"
+        genome_id = assembly_curie(accession)
+        paired = assembly_curie(genbank_accession) if genbank_accession else ""
+        same_as = paired if paired and paired != genome_id else ""
 
+        # The NCBI accession, not GTDB's RS_/GB_-prefixed key: "RefSeq assembly
+        # RS_GCF_000005845.2" named a string RefSeq does not issue. GTDB's form
+        # is recoverable (RS_ for GCF, GB_ for GCA) and adds nothing here.
+        ncbi_accession = strip_gtdb_prefix(accession)
         self._add_node(
             node_id=genome_id,
             category=GENOME_CATEGORY,
-            name=accession,
-            description=f"GenBank genome {accession}",
+            name=ncbi_accession,
+            description=f"{assembly_archive(accession)} assembly {ncbi_accession}",
+            same_as=same_as,
         )
 
         # Create genome -> GTDB taxon edge
@@ -336,7 +368,7 @@ class GTDBTransform(Transform):
                 )
                 self._created_mappings.add(mapping_key)
 
-    def _add_node(self, node_id: str, category: str, name: str, description: str = ""):
+    def _add_node(self, node_id: str, category: str, name: str, description: str = "", same_as: str = ""):
         """Add node to internal list."""
         if node_id not in self.seen_nodes:
             self.nodes.append(
@@ -345,6 +377,7 @@ class GTDBTransform(Transform):
                     CATEGORY_COLUMN: category,
                     NAME_COLUMN: name,
                     DESCRIPTION_COLUMN: description,
+                    SAME_AS_COLUMN: same_as,
                     PROVIDED_BY_COLUMN: self.knowledge_source,
                 }
             )
@@ -370,6 +403,7 @@ class GTDBTransform(Transform):
             CATEGORY_COLUMN,
             NAME_COLUMN,
             DESCRIPTION_COLUMN,
+            SAME_AS_COLUMN,
             PROVIDED_BY_COLUMN,
         ]
 

--- a/kg_microbe/transform_utils/gtdb/utils.py
+++ b/kg_microbe/transform_utils/gtdb/utils.py
@@ -1,5 +1,7 @@
 """Helper functions for parsing GTDB data."""
 
+from kg_microbe.transform_utils.constants import NCBI_ASSEMBLY_PREFIX
+
 
 def parse_taxonomy_string(taxonomy_str):
     """
@@ -34,6 +36,63 @@ def extract_accession_type(accession):
     base = parts[0]
     version = parts[1] if len(parts) > 1 else "1"
     return base, version
+
+
+def strip_gtdb_prefix(accession):
+    """
+    Return a GTDB accession without its archive prefix, version intact.
+
+    Args:
+        accession: "RS_GCF_000005845.2", "GB_GCA_000008865.2" or "GCF_000005845.2"
+
+    Returns:
+        str: "GCF_000005845.2" / "GCA_000008865.2" / "GCF_000005845.2"
+
+    """
+    if accession.startswith(("RS_", "GB_")):
+        return accession[3:]
+    return accession
+
+
+def assembly_curie(accession):
+    """
+    Return the ``ncbi.assembly:`` CURIE for a GTDB accession.
+
+    The version suffix is kept: ``GCA_000005845.1`` and ``.2`` are different
+    assemblies of the same genome, and no NCBI resolver accepts a version-less
+    accession, so dropping it made the identifier both ambiguous and
+    unresolvable (#882). GTDB's own ``RS_``/``GB_`` prefix is not part of the
+    NCBI identifier and is dropped; ``GCF_`` vs ``GCA_`` already says which
+    archive the accession belongs to.
+
+    Args:
+        accession: "RS_GCF_000005845.2" or "GCA_000008865.2"
+
+    Returns:
+        str: "ncbi.assembly:GCF_000005845.2"
+
+    """
+    return f"{NCBI_ASSEMBLY_PREFIX}{strip_gtdb_prefix(accession)}"
+
+
+def assembly_archive(accession):
+    """
+    Return the archive an assembly accession belongs to.
+
+    Args:
+        accession: "RS_GCF_000005845.2" or "GCA_000008865.2"
+
+    Returns:
+        str: "RefSeq", "GenBank", or "NCBI Assembly" when the accession is
+        neither shape.
+
+    """
+    stripped = strip_gtdb_prefix(accession)
+    if stripped.startswith("GCF_"):
+        return "RefSeq"
+    if stripped.startswith("GCA_"):
+        return "GenBank"
+    return "NCBI Assembly"
 
 
 def clean_taxon_name(taxon_name):

--- a/tests/test_gtdb.py
+++ b/tests/test_gtdb.py
@@ -1,11 +1,15 @@
 """Test GTDB transform."""
 
+import csv
 import tempfile
 import unittest
 from pathlib import Path
 
+from kg_microbe.transform_utils.constants import GTDB_BAC120_METADATA
 from kg_microbe.transform_utils.gtdb.gtdb import GTDBTransform
 from kg_microbe.transform_utils.gtdb.utils import (
+    assembly_archive,
+    assembly_curie,
     clean_taxon_name,
     extract_accession_type,
     parse_taxonomy_string,
@@ -218,16 +222,19 @@ class TestGTDBTransform(unittest.TestCase):
 
         # Should have 2 nodes: taxon + genome
         self.assertEqual(len(self.transform.nodes), 2)
-        genome_node = [n for n in self.transform.nodes if n["id"].startswith("GenBank:")][0]
-        self.assertEqual(genome_node["id"], "GenBank:GCF_000005845")
+        genome_node = [n for n in self.transform.nodes if n["id"].startswith("ncbi.assembly:")][0]
+        # #882: the version is part of the identifier, and GCF_ is a RefSeq accession.
+        self.assertEqual(genome_node["id"], "ncbi.assembly:GCF_000005845.2")
         self.assertEqual(genome_node["category"], "biolink:Genome")
         self.assertEqual(genome_node["name"], "GCF_000005845.2")
+        self.assertEqual(genome_node["description"], "RefSeq assembly GCF_000005845.2")
+        self.assertEqual(genome_node["same_as"], "")
 
         # Should have 2 edges: genome->taxon and taxon->NCBITaxon
         self.assertEqual(len(self.transform.edges), 2)
 
         # Check genome->taxon edge
-        genome_edge = [e for e in self.transform.edges if e["subject"].startswith("GenBank:")][0]
+        genome_edge = [e for e in self.transform.edges if e["subject"].startswith("ncbi.assembly:")][0]
         self.assertEqual(genome_edge["predicate"], "biolink:subclass_of")
         self.assertEqual(genome_edge["object"], "GTDB:s__Escherichia_coli")
 
@@ -275,3 +282,100 @@ class TestGTDBTransform(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAssemblyAccessionIdentity(unittest.TestCase):
+    """#882: one physical assembly, two accessions, one resolvable identifier."""
+
+    def setUp(self):
+        """Build a transform writing to a scratch directory."""
+        self.tmp = tempfile.TemporaryDirectory()
+        self.transform = GTDBTransform(input_dir=Path(self.tmp.name), output_dir=Path(self.tmp.name))
+
+    def tearDown(self):
+        """Drop the scratch directory."""
+        self.tmp.cleanup()
+
+    def test_the_curie_names_the_right_archive_and_keeps_the_version(self):
+        """`GenBank:GCF_...` asserted the wrong archive and dropped the version, twice wrong."""
+        self.assertEqual(assembly_curie("RS_GCF_000005845.2"), "ncbi.assembly:GCF_000005845.2")
+        self.assertEqual(assembly_curie("GB_GCA_000008865.2"), "ncbi.assembly:GCA_000008865.2")
+        self.assertEqual(assembly_archive("RS_GCF_000005845.2"), "RefSeq")
+        self.assertEqual(assembly_archive("GB_GCA_000008865.2"), "GenBank")
+
+    def test_a_missing_version_is_not_invented(self):
+        """extract_accession_type defaults to version 1; an identifier must not guess."""
+        self.assertEqual(assembly_curie("GCF_000005845"), "ncbi.assembly:GCF_000005845")
+
+    def test_a_refseq_genome_records_its_genbank_twin_in_same_as(self):
+        """The pairing GTDB already ships makes the other accession findable without a second node."""
+        self.transform._get_or_create_taxon_id("s__Escherichia_coli")
+        self.transform._create_genome_node(
+            accession="RS_GCF_000005845.2",
+            gtdb_taxon="s__Escherichia_coli",
+            ncbi_taxid="562",
+            genbank_accession="GCA_000005845.2",
+        )
+        genome = [n for n in self.transform.nodes if n["id"].startswith("ncbi.assembly:")][0]
+        self.assertEqual(genome["id"], "ncbi.assembly:GCF_000005845.2")
+        self.assertEqual(genome["same_as"], "ncbi.assembly:GCA_000005845.2")
+        # GTDB's RS_/GB_ key is not an NCBI identifier and must not be presented as one.
+        self.assertEqual(genome["name"], "GCF_000005845.2")
+        self.assertEqual(genome["description"], "RefSeq assembly GCF_000005845.2")
+        # One node for one physical assembly: the twin is not declared separately.
+        self.assertEqual(len([n for n in self.transform.nodes if n["id"].startswith("ncbi.assembly:")]), 1)
+
+    def test_a_genbank_genome_does_not_point_same_as_at_itself(self):
+        """For a GB_GCA_* genome the paired accession IS the accession; same_as must stay empty."""
+        self.transform._get_or_create_taxon_id("s__Escherichia_coli")
+        self.transform._create_genome_node(
+            accession="GB_GCA_000008865.2",
+            gtdb_taxon="s__Escherichia_coli",
+            ncbi_taxid="562",
+            genbank_accession="GCA_000008865.2",
+        )
+        genome = [n for n in self.transform.nodes if n["id"].startswith("ncbi.assembly:")][0]
+        self.assertEqual(genome["same_as"], "")
+
+    def test_the_paired_accession_can_be_at_a_different_version(self):
+        """3,016 GTDB rows pair accessions whose versions differ; the twin keeps its own."""
+        self.transform._get_or_create_taxon_id("s__Escherichia_coli")
+        self.transform._create_genome_node(
+            accession="RS_GCF_000005845.3",
+            gtdb_taxon="s__Escherichia_coli",
+            ncbi_taxid="562",
+            genbank_accession="GCA_000005845.2",
+        )
+        genome = [n for n in self.transform.nodes if n["id"].startswith("ncbi.assembly:")][0]
+        self.assertEqual(genome["id"], "ncbi.assembly:GCF_000005845.3")
+        self.assertEqual(genome["same_as"], "ncbi.assembly:GCA_000005845.2")
+
+    def test_same_as_is_written_to_the_nodes_tsv(self):
+        """A column the writer drops is a column that does not exist."""
+        self.transform._get_or_create_taxon_id("s__Escherichia_coli")
+        self.transform._create_genome_node(
+            accession="RS_GCF_000005845.2",
+            gtdb_taxon="s__Escherichia_coli",
+            ncbi_taxid="562",
+            genbank_accession="GCA_000005845.2",
+        )
+        self.transform._write_tsv_files()
+        with open(self.transform.output_node_file) as handle:
+            rows = list(csv.DictReader(handle, delimiter="\t"))
+        genome = [r for r in rows if r["id"].startswith("ncbi.assembly:")][0]
+        self.assertEqual(genome["same_as"], "ncbi.assembly:GCA_000005845.2")
+
+    def test_metadata_rows_pass_the_pairing_through(self):
+        """GTDB spells an absent pairing "none"; that must not become a CURIE."""
+        self.transform.input_dir.mkdir(parents=True, exist_ok=True)
+        metadata = self.transform.input_dir / GTDB_BAC120_METADATA.replace(".gz", "")
+        header = "accession\tncbi_taxid\tncbi_genbank_assembly_accession\n"
+        metadata.write_text(
+            header + "RS_GCF_000005845.2\t562\tGCA_000005845.2\n" + "RS_GCF_000009999.1\t563\tnone\n",
+            encoding="utf-8",
+        )
+        taxa = [("RS_GCF_000005845.2", ["s__Escherichia_coli"]), ("RS_GCF_000009999.1", ["s__Escherichia_coli"])]
+        self.transform._parse_metadata_file(metadata.name, taxa)
+        by_id = {n["id"]: n for n in self.transform.nodes}
+        self.assertEqual(by_id["ncbi.assembly:GCF_000005845.2"]["same_as"], "ncbi.assembly:GCA_000005845.2")
+        self.assertEqual(by_id["ncbi.assembly:GCF_000009999.1"]["same_as"], "")


### PR DESCRIPTION
Closes #882.

All three defects the issue names share one line (`gtdb.py:306`) and one blast radius — `GenBank:` ids appear **only** in gtdb's own output (901,341 nodes and edges; nothing else in the repo joins on them), so fixing them separately would mean two id-changing PRs and two re-merges for the same set of rows.

## Measured before the change (FRESH 2026-09-10 output)

| | |
|---|---:|
| RefSeq accessions asserted as `GenBank:` | 447,137 |
| ids retaining a version | 0 of 901,341 |
| numeric cores reachable under both accessions | **0** of 901,341 |
| GTDB rows whose paired accessions differ in version | 3,016 |

## Change

- **id**: `ncbi.assembly:<accession>`, version intact. One bioregistry-registered prefix covers both archives, resolves to the assembly datasets page, and its pattern accepts `GCA_*` and `GCF_*` — unlike `refseq`, whose pattern (`NC_`, `NP_`, `NZ_`…) does not match assembly accessions at all, so the obvious genbank:/refseq: split would have produced invalid CURIEs.
- **pairing**: GTDB ships `ncbi_genbank_assembly_accession` for every row (0 missing). A RefSeq-primary genome records its GenBank twin in the standard `same_as` node column. Rejected alternative, recorded in the docstring: declaring a second node per twin — one physical assembly is one thing, and it would double the largest node block after NCBITaxon to say nothing new.
- **name / description**: the NCBI accession, not GTDB's `RS_`/`GB_` key. `"RefSeq assembly RS_GCF_000005845.2"` named a string RefSeq does not issue.
- `ncbi.assembly` registered in `custom_curies.yaml` and `kg_model_review.STANDARD_PREFIXES`; `gtdb-phylo-diagram` prose updated (it filters on the predicate, not the prefix — no behaviour change).

## Canary — real `poetry run kg transform -s gtdb` (35 s)

| check | before | after |
|---|---:|---:|
| nodes / edges | 1,148,709 / 1,471,034 | **identical** |
| assembly nodes | 901,341 | 901,341 |
| …with a version | 0 | 901,341 |
| …GCF / GCA | 447,137 / 454,204 | unchanged split |
| …with `same_as` | — | 447,137 (exactly the RefSeq-primary ones) |
| `GenBank:` occurrences | 901,341 | **0** |
| cores addressable under both accessions | 0 | **447,137** |

Downstream check: `kg transform -s lpsn` (21 s) — it reads gtdb's `nodes.tsv` with `csv.DictReader` and skips every row whose id is not `GTDB:`, so the new column and ids are invisible to it. Output **byte-identical** (sorted md5 match), which is the acceptance test for the header change.

## Rerun

`gtdb` is done (above). `lpsn` → `lpsn_api` → `microbedecoder` need a fingerprint refresh only (~1 min total, verified no content change at the first hop); batched with the canonical merge at the end of this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
