### PR TITLE
gtdb: a shared NCBI taxon is a broad_match, and every one of them is reported (#883)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,17 @@ traversable; it is not a claim that the isolate is an ontology class. Biolink
 validators will report it; do not silently change the convention. See issue
 #834 and [the 4.4.2 revalidation](docs/BIOLINK_4_4_2_REVALIDATION.md).
 
+Cross-source organism joins use the **GTDB identifier**, not `ncbi_taxon_id`.
+NCBI carries coarse placeholder taxa (`bacterium`, `uncultured bacterium`,
+`Pseudomonadota bacterium`) that park unclassified sequence; GTDB names every
+genome, so the bridge is many-to-one and pathologically concentrated — 0.3% of
+NCBI taxa absorb 42.7% of the links, one of them 3,695 GTDB taxa. Joining
+through NCBI pools unrelated species and produces fan-out that looks like
+signal. A mapping edge onto a shared NCBI taxon is `biolink:broad_match`, not
+`close_match`, and every shared taxon is listed worst-first in
+`data/transformed/gtdb/gtdb_ncbi_pooling_report.tsv` — the deny-list to exclude
+them deliberately rather than discovering them in a result set. See #883.
+
 A `kgmicrobe.strain:<code>` node minted from a culture-collection deposit number
 is shared: several source records can cite the same deposit, and they do not
 always agree on the taxon. Such a node gets the one claimed parent that every

--- a/kg_microbe/transform_utils/constants.py
+++ b/kg_microbe/transform_utils/constants.py
@@ -445,6 +445,9 @@ ASSESSED_ACTIVITY_RELATIONSHIP = "NCIT:C153110"
 CLOSE_MATCH = "skos:closeMatch"
 CLOSE_MATCH_PREDICATE = "biolink:close_match"
 CLOSE_MATCH_RELATION = "skos:closeMatch"
+BROAD_MATCH = "skos:broadMatch"
+BROAD_MATCH_PREDICATE = "biolink:broad_match"
+BROAD_MATCH_RELATION = "skos:broadMatch"
 EXACT_MATCH = "skos:exactMatch"
 EXACT_MATCH_PREDICATE = "biolink:exact_match"
 ASSOCIATED_WITH = "PATO:0001668"
@@ -713,6 +716,9 @@ GTDB_RAW_DIR = RAW_DATA_DIR / GTDB
 GTDB_BAC120_TAXONOMY = "bac120_taxonomy.tsv"
 GTDB_AR53_TAXONOMY = "ar53_taxonomy.tsv"
 GTDB_BAC120_METADATA = "bac120_metadata.tsv.gz"
+#: Report of NCBI taxa that several GTDB taxa map onto (#883). Written on
+#: every gtdb run, empty or not.
+GTDB_NCBI_POOLING_REPORT = "gtdb_ncbi_pooling_report.tsv"
 GTDB_AR53_METADATA = "ar53_metadata.tsv.gz"
 
 # Metatraits-specific paths

--- a/kg_microbe/transform_utils/gtdb/gtdb.py
+++ b/kg_microbe/transform_utils/gtdb/gtdb.py
@@ -2,10 +2,13 @@
 
 import csv
 import gzip
+from collections import Counter
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 from kg_microbe.transform_utils.constants import (
+    BROAD_MATCH_PREDICATE,
+    BROAD_MATCH_RELATION,
     CATEGORY_COLUMN,
     CLOSE_MATCH_PREDICATE,
     CLOSE_MATCH_RELATION,
@@ -16,6 +19,7 @@ from kg_microbe.transform_utils.constants import (
     GTDB_AR53_TAXONOMY,
     GTDB_BAC120_METADATA,
     GTDB_BAC120_TAXONOMY,
+    GTDB_NCBI_POOLING_REPORT,
     GTDB_PREFIX,
     GTDB_RAW_DIR,
     ID_COLUMN,
@@ -66,6 +70,11 @@ class GTDBTransform(Transform):
         # ID allocator. Example: "d__Bacteria" -> "GTDB:d__Bacteria".
         self.taxon_to_id = {}
         self._created_mappings = set()  # Track GTDB->NCBI mappings to avoid duplicates
+        # GTDB->NCBI pairs, held until every metadata row is read: the right
+        # predicate for one of these edges depends on how many *other* GTDB
+        # taxa land on the same NCBI taxon, which is not knowable row by row
+        # (#883).
+        self._ncbi_mappings: List[Tuple[str, str]] = []
 
         # Resolve input directory: prefer CLI-provided base dir, fall back to global default
         if self.input_base_dir:
@@ -118,6 +127,15 @@ class GTDBTransform(Transform):
         else:
             print("Archaeal metadata not found, creating genomes without NCBI mappings...")
             self._create_genomes_from_taxonomy(ar_taxa)
+
+        # After every metadata row: the predicate depends on the whole set (#883).
+        mapping_counts = self._emit_ncbi_mapping_edges()
+        pooled = self._write_ncbi_pooling_report()
+        print(
+            f"  GTDB->NCBITaxon mappings: {mapping_counts[CLOSE_MATCH_PREDICATE]:,} close_match (1:1), "
+            f"{mapping_counts[BROAD_MATCH_PREDICATE]:,} broad_match onto {pooled:,} shared NCBI taxa; "
+            f"see {GTDB_NCBI_POOLING_REPORT}"
+        )
 
         print(f"  Total nodes: {len(self.nodes)}")
         print(f"  Total edges: {len(self.edges)}")
@@ -354,19 +372,70 @@ class GTDBTransform(Transform):
                 relation=RDFS_SUBCLASS_OF,
             )
 
-        # Create GTDB -> NCBI mapping edge (if available)
+        # Record the GTDB -> NCBI mapping; the edges are emitted once every
+        # row has been read (see _emit_ncbi_mapping_edges).
         # Dedup on (gtdb_taxon_id, ncbi_taxid) to allow multiple NCBI IDs per GTDB taxon
         if ncbi_taxid and gtdb_taxon_id:
             mapping_key = (gtdb_taxon_id, ncbi_taxid)
             if mapping_key not in self._created_mappings:
-                ncbi_id = f"{NCBITAXON_PREFIX}{ncbi_taxid}"
-                self._add_edge(
-                    subject=gtdb_taxon_id,
-                    predicate=CLOSE_MATCH_PREDICATE,
-                    obj=ncbi_id,
-                    relation=CLOSE_MATCH_RELATION,
-                )
+                self._ncbi_mappings.append((gtdb_taxon_id, f"{NCBITAXON_PREFIX}{ncbi_taxid}"))
                 self._created_mappings.add(mapping_key)
+
+    def _emit_ncbi_mapping_edges(self) -> Dict[str, int]:
+        """
+        Emit the GTDB->NCBITaxon mapping edges, choosing the predicate by fan-in.
+
+        NCBI carries coarse placeholder taxa -- ``bacterium``, ``uncultured
+        bacterium``, ``Pseudomonadota bacterium`` -- that park unclassified
+        sequence; GTDB names every genome, so the bridge between them is
+        many-to-one and severely so at the top: 0.3% of NCBI taxa absorb 42.7%
+        of the links, one of them 3,492 GTDB taxa (#883).
+
+        ``close_match`` is defined as "semantically similar but not strictly
+        equivalent, **broader**, or narrower", so it is the wrong predicate the
+        moment two GTDB taxa share an NCBI taxon: that NCBI taxon is broader.
+        A 1:1 mapping keeps ``close_match``; anything many-to-one becomes
+        ``broad_match`` (``skos:broadMatch``, i.e. the object is the broader
+        term), which is what the data supports. No threshold is chosen -- the
+        line is exactly "is this NCBI taxon shared".
+
+        :return: Counts of the edges emitted, by predicate.
+        """
+        fan_in: Counter = Counter(ncbi_id for _, ncbi_id in self._ncbi_mappings)
+        counts = {CLOSE_MATCH_PREDICATE: 0, BROAD_MATCH_PREDICATE: 0}
+        for gtdb_taxon_id, ncbi_id in self._ncbi_mappings:
+            shared = fan_in[ncbi_id] > 1
+            predicate = BROAD_MATCH_PREDICATE if shared else CLOSE_MATCH_PREDICATE
+            relation = BROAD_MATCH_RELATION if shared else CLOSE_MATCH_RELATION
+            self._add_edge(subject=gtdb_taxon_id, predicate=predicate, obj=ncbi_id, relation=relation)
+            counts[predicate] += 1
+        return counts
+
+    def _write_ncbi_pooling_report(self) -> int:
+        """
+        Write the NCBI taxa that several GTDB taxa map onto.
+
+        Written on every run, empty or not: an absent report cannot be told
+        from a check that never ran. It is the deny-list a query needs to
+        exclude the grab-bags deliberately rather than discovering them in a
+        result set (#883).
+
+        :return: Number of pooled NCBI taxa reported.
+        """
+        pooled: Dict[str, list] = {}
+        for gtdb_taxon_id, ncbi_id in self._ncbi_mappings:
+            pooled.setdefault(ncbi_id, []).append(gtdb_taxon_id)
+        rows = sorted(
+            ((ncbi_id, taxa) for ncbi_id, taxa in pooled.items() if len(taxa) > 1),
+            key=lambda item: (-len(item[1]), item[0]),
+        )
+        report = self.output_dir / GTDB_NCBI_POOLING_REPORT
+        with open(report, "w", newline="") as handle:
+            writer = csv.writer(handle, delimiter="\t")
+            writer.writerow(["ncbi_taxon", "gtdb_taxa", "predicate", "examples"])
+            for ncbi_id, taxa in rows:
+                writer.writerow([ncbi_id, len(taxa), BROAD_MATCH_PREDICATE, "|".join(sorted(taxa)[:3])])
+        return len(rows)
 
     def _add_node(self, node_id: str, category: str, name: str, description: str = "", same_as: str = ""):
         """Add node to internal list."""

--- a/tests/test_gtdb.py
+++ b/tests/test_gtdb.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from kg_microbe.transform_utils.constants import GTDB_BAC120_METADATA
+from kg_microbe.transform_utils.constants import GTDB_BAC120_METADATA, GTDB_NCBI_POOLING_REPORT
 from kg_microbe.transform_utils.gtdb.gtdb import GTDBTransform
 from kg_microbe.transform_utils.gtdb.utils import (
     assembly_archive,
@@ -230,15 +230,16 @@ class TestGTDBTransform(unittest.TestCase):
         self.assertEqual(genome_node["description"], "RefSeq assembly GCF_000005845.2")
         self.assertEqual(genome_node["same_as"], "")
 
-        # Should have 2 edges: genome->taxon and taxon->NCBITaxon
-        self.assertEqual(len(self.transform.edges), 2)
-
-        # Check genome->taxon edge
-        genome_edge = [e for e in self.transform.edges if e["subject"].startswith("ncbi.assembly:")][0]
+        # genome->taxon is emitted inline; the NCBI mapping waits for the whole
+        # file, because its predicate depends on the fan-in (#883).
+        self.assertEqual(len(self.transform.edges), 1)
+        genome_edge = self.transform.edges[0]
+        self.assertEqual(genome_edge["subject"], "ncbi.assembly:GCF_000005845.2")
         self.assertEqual(genome_edge["predicate"], "biolink:subclass_of")
         self.assertEqual(genome_edge["object"], "GTDB:s__Escherichia_coli")
 
-        # Check taxon->NCBI edge
+        # Check taxon->NCBI edge once the deferred pass runs
+        self.transform._emit_ncbi_mapping_edges()
         ncbi_edge = [e for e in self.transform.edges if e["object"].startswith("NCBITaxon:")][0]
         self.assertEqual(ncbi_edge["predicate"], "biolink:close_match")
         self.assertEqual(ncbi_edge["object"], "NCBITaxon:562")
@@ -255,6 +256,7 @@ class TestGTDBTransform(unittest.TestCase):
         )
 
         # Should only have 1 edge: genome->taxon (no NCBI mapping)
+        self.transform._emit_ncbi_mapping_edges()
         self.assertEqual(len(self.transform.edges), 1)
         self.assertEqual(self.transform.edges[0]["predicate"], "biolink:subclass_of")
 
@@ -379,3 +381,102 @@ class TestAssemblyAccessionIdentity(unittest.TestCase):
         by_id = {n["id"]: n for n in self.transform.nodes}
         self.assertEqual(by_id["ncbi.assembly:GCF_000005845.2"]["same_as"], "ncbi.assembly:GCA_000005845.2")
         self.assertEqual(by_id["ncbi.assembly:GCF_000009999.1"]["same_as"], "")
+
+
+class TestNCBIPooling(unittest.TestCase):
+    """#883: 0.3% of NCBI taxa absorb 42.7% of the GTDB mapping; close_match overstates that."""
+
+    def setUp(self):
+        """Build a transform writing to a scratch directory."""
+        self.tmp = tempfile.TemporaryDirectory()
+        self.transform = GTDBTransform(input_dir=Path(self.tmp.name), output_dir=Path(self.tmp.name))
+
+    def tearDown(self):
+        """Drop the scratch directory."""
+        self.tmp.cleanup()
+
+    def _map(self, pairs):
+        for gtdb_name, taxid in pairs:
+            self.transform._get_or_create_taxon_id(gtdb_name)
+            self.transform._create_genome_node(
+                accession=f"GCA_{abs(hash((gtdb_name, taxid))) % 10**9:09d}.1",
+                gtdb_taxon=gtdb_name,
+                ncbi_taxid=taxid,
+            )
+
+    def test_a_shared_ncbi_taxon_gets_broad_match_and_a_solo_one_keeps_close_match(self):
+        """
+        close_match is defined as "not strictly equivalent, broader, or narrower".
+
+        The moment two GTDB taxa share an NCBI taxon, that taxon is broader, so
+        close_match asserts more than the data supports.
+        """
+        self._map(
+            [
+                ("s__Escherichia_coli", "562"),
+                ("s__Grabbag_one", "1869227"),
+                ("s__Grabbag_two", "1869227"),
+                ("s__Grabbag_three", "1869227"),
+            ]
+        )
+        self.transform._emit_ncbi_mapping_edges()
+        by_object = {}
+        for e in self.transform.edges:
+            if e["object"].startswith("NCBITaxon:"):
+                by_object.setdefault(e["object"], []).append((e["predicate"], e["relation"]))
+        self.assertEqual(by_object["NCBITaxon:562"], [("biolink:close_match", "skos:closeMatch")])
+        self.assertEqual(
+            by_object["NCBITaxon:1869227"],
+            [("biolink:broad_match", "skos:broadMatch")] * 3,
+        )
+
+    def test_the_predicate_cannot_be_decided_row_by_row(self):
+        """The first of three rows onto one taxon looks 1:1 until the third arrives."""
+        self._map([("s__A", "1869227")])
+        self.assertEqual([e for e in self.transform.edges if e["object"].startswith("NCBITaxon:")], [])
+        self._map([("s__B", "1869227")])
+        counts = self.transform._emit_ncbi_mapping_edges()
+        self.assertEqual(counts["biolink:close_match"], 0)
+        self.assertEqual(counts["biolink:broad_match"], 2)
+
+    def test_the_pooling_report_is_written_even_when_empty(self):
+        """An absent report cannot be told from a check that never ran."""
+        self._map([("s__Escherichia_coli", "562")])
+        self.assertEqual(self.transform._write_ncbi_pooling_report(), 0)
+        report = self.transform.output_dir / GTDB_NCBI_POOLING_REPORT
+        self.assertTrue(report.exists())
+        with open(report) as handle:
+            rows = list(csv.DictReader(handle, delimiter="\t"))
+        self.assertEqual(rows, [])
+
+    def test_the_pooling_report_names_the_grab_bags_worst_first(self):
+        """The report is the deny-list a query needs to exclude them deliberately."""
+        self._map(
+            [
+                ("s__A", "1869227"),
+                ("s__B", "1869227"),
+                ("s__C", "1869227"),
+                ("s__D", "77133"),
+                ("s__E", "77133"),
+                ("s__Solo", "562"),
+            ]
+        )
+        self.assertEqual(self.transform._write_ncbi_pooling_report(), 2)
+        with open(self.transform.output_dir / GTDB_NCBI_POOLING_REPORT) as handle:
+            rows = list(csv.DictReader(handle, delimiter="\t"))
+        self.assertEqual([r["ncbi_taxon"] for r in rows], ["NCBITaxon:1869227", "NCBITaxon:77133"])
+        self.assertEqual([r["gtdb_taxa"] for r in rows], ["3", "2"])
+        self.assertEqual(rows[0]["predicate"], "biolink:broad_match")
+        self.assertIn("GTDB:s__A", rows[0]["examples"])
+        self.assertNotIn("NCBITaxon:562", [r["ncbi_taxon"] for r in rows])
+
+    def test_a_duplicate_pair_is_still_counted_once(self):
+        """Two genomes of one GTDB species pointing at one NCBI taxon is 1:1, not pooling."""
+        self._map([("s__Escherichia_coli", "562")])
+        self.transform._create_genome_node(
+            accession="GCA_000000002.1", gtdb_taxon="s__Escherichia_coli", ncbi_taxid="562"
+        )
+        counts = self.transform._emit_ncbi_mapping_edges()
+        self.assertEqual(counts["biolink:close_match"], 1)
+        self.assertEqual(counts["biolink:broad_match"], 0)
+        self.assertEqual(self.transform._write_ncbi_pooling_report(), 0)


### PR DESCRIPTION
Closes #883. Implements all three suggested actions.

## Re-measured on the freshly rebuilt output

The issue asked for re-confirmation after the next `kg transform -s gtdb` (which #1031 just did). Every figure reproduces exactly:

| | issue | now |
|---|---:|---:|
| GTDB→NCBITaxon `close_match` edges | 322,327 | 322,327 |
| distinct GTDB subjects / NCBI objects | 199,923 / 118,521 | 199,923 / 118,521 |
| NCBI taxa receiving exactly 1 | 109,895 (92.7%) | 109,895 (92.7%) |
| NCBI taxa receiving ≥100 | 334 (0.3%) absorbing 137,497 (42.7%) | identical |

## 3 — the predicate

Biolink defines `close_match` as *"semantically similar but not strictly equivalent, **broader**, or narrower"* — so it is wrong the moment two GTDB taxa share an NCBI taxon, because that taxon *is* broader. 1:1 keeps `close_match`; many-to-one becomes `broad_match` / `skos:broadMatch` (the object is the broader term, per SKOS). **No threshold is invented** — the line is exactly "is this NCBI taxon shared", which needs no magic number and is defensible per-edge.

Because the fan-in is not knowable row by row, the mapping pairs are now held and emitted in one pass after the last metadata row. A test pins that: the first of two rows onto one taxon looks 1:1 until the second arrives.

## 2 — the grab-bags, in a file

The same pass writes `data/transformed/gtdb/gtdb_ncbi_pooling_report.tsv` (gitignored, worst-first, `ncbi_taxon / gtdb_taxa / predicate / examples`), on every run whether or not anything pooled. 8,626 rows on real data; top three are `NCBITaxon:244328` (3,695), `1869227` (3,492), `77133` (3,450) — the issue's table.

Chose a report over a node property or a curated deny-list: the set is derived, changes with every GTDB release, and a curated file would drift. It follows `merged_strain_parent_violations.tsv`'s convention.

## 1 — the join key

`CLAUDE.md` states it next to the taxon-convention section, with the concentration figure and a pointer to the report.

## Canary — real `kg transform -s gtdb` (41 s)

| check | before | after |
|---|---:|---:|
| nodes / edges | 1,148,709 / 1,471,034 | **identical** |
| GTDB→NCBI `close_match` | 322,327 | 109,895 |
| GTDB→NCBI `broad_match` | 0 | 212,432 |
| shared NCBI taxa reported | — | 8,626 |

A pure predicate reassignment: same edges, same endpoints, 322,327 either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
