### PR TITLE
ontologies: shape every UPA node row to the header written above it (#1033)

### DIFF
--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -725,12 +725,19 @@ class OntologiesTransform(Transform):
                 add_lines = []
                 for line in nf:
                     if line.startswith("id"):
+                        # KGX's own header for this file. Kept so each row can be
+                        # projected onto self.node_header by column name: KGX
+                        # leaks subsets/meta/iri onto node rows, and padding
+                        # positionally left those extra fields under a canonical
+                        # 9-column header, producing a file pandas could not read
+                        # (#1033).
+                        source_header = line.strip().split("\t")
                         # get the index for the term 'id'
-                        id_index = line.strip().split("\t").index(ID_COLUMN)
+                        id_index = source_header.index(ID_COLUMN)
                         # get the index for the term 'xref'
-                        xref_index = line.strip().split("\t").index(XREF_COLUMN)
+                        xref_index = source_header.index(XREF_COLUMN)
                         # get the index for the term 'category'
-                        category_index = line.strip().split("\t").index(CATEGORY_COLUMN)
+                        category_index = source_header.index(CATEGORY_COLUMN)
                     else:
                         line = remove_unwanted_prefixes_from_node_xrefs(line, xref_index)
                         # For Reactions only
@@ -744,6 +751,7 @@ class OntologiesTransform(Transform):
                                 category_index,
                                 nodes_dictionary,
                                 self.node_header,
+                                source_header,
                             )
                             for new_line in new_lines:
                                 if len(new_line) > 0:
@@ -754,7 +762,7 @@ class OntologiesTransform(Transform):
                             substring in line for substring in [UNIPATHWAYS_PATHWAY_PREFIX]
                         ):  # ,UNIPATHWAYS_LINEAR_SUB_PATHWAY_PREFIX]):
                             new_line = replace_category_for_unipathways(
-                                line, id_index, category_index, self.node_header
+                                line, id_index, category_index, self.node_header, source_header
                             )
                             if len(new_line) > 0:
                                 add_lines.append(new_line + "\n")

--- a/kg_microbe/utils/unipathways_utils.py
+++ b/kg_microbe/utils/unipathways_utils.py
@@ -3,7 +3,9 @@
 import re
 
 from kg_microbe.transform_utils.constants import (
+    CATEGORY_COLUMN,
     GO_PREFIX,
+    ID_COLUMN,
     OBJECT_COLUMN,
     RHEA_CATEGORY,
     RHEA_NEW_PREFIX,
@@ -17,7 +19,34 @@ from kg_microbe.transform_utils.constants import (
 )
 
 
-def replace_id_with_xref(line, xref_index, id_index, category_index, nodes_dictionary, node_header):
+def project_onto_header(parts, source_header, node_header):
+    """
+    Reshape one row onto ``node_header``, matching columns by name.
+
+    The caller writes ``node_header`` as the file's header, so every row has to
+    be exactly that wide. Padding positionally is not enough: KGX leaks
+    ``subsets``, ``meta`` and ``iri`` onto node rows (the columns
+    ``_normalize_schema`` strips), and a row wider than the header made
+    ``[""] * (len(node_header) - len(parts))`` evaluate to ``[]`` -- so the
+    extra fields survived and the file became unreadable (#1033). Matching by
+    name rather than truncating also means an extra, missing or reordered
+    upstream column cannot shift a value into the wrong field.
+
+    :param parts: The row's fields.
+    :param source_header: Column names of the row, in order. ``None`` falls
+        back to positional pad-or-truncate, for callers that never saw a header.
+    :param node_header: Canonical column names to emit.
+    :return: Exactly ``len(node_header)`` fields.
+    """
+    if source_header is None:
+        return (parts + [""] * len(node_header))[: len(node_header)]
+    # strict=False on purpose: a row may be short (KGX omits trailing empties)
+    # or long (leaked columns); both are handled by name lookup below.
+    by_name = dict(zip(source_header, parts, strict=False))
+    return [by_name.get(column, "") for column in node_header]
+
+
+def replace_id_with_xref(line, xref_index, id_index, category_index, nodes_dictionary, node_header, source_header=None):
     """
     Replace node ID with corresponding xref.
 
@@ -31,6 +60,9 @@ def replace_id_with_xref(line, xref_index, id_index, category_index, nodes_dicti
     :type category_index: int
     :param node_header: List of all values in nodes file header.
     :type node_header: list
+    :param source_header: Column names of ``line``, so fields are matched by
+        name rather than by position (#1033).
+    :type source_header: list
     """
     parts = line.strip().split("\t")
     xrefs = parts[xref_index].split("|") if parts[xref_index] != "" else None
@@ -44,18 +76,23 @@ def replace_id_with_xref(line, xref_index, id_index, category_index, nodes_dicti
             # category-aware consumers (and validators) don't see an empty
             # category column (biolink:MolecularActivity matches the
             # rhea_mappings transform's own RHEA category).
-            l_parts = [xref] + ([""] * (len(node_header) - 1))
+            stub = {ID_COLUMN: xref}
             if xref.startswith(RHEA_NEW_PREFIX):
-                l_parts[category_index] = RHEA_CATEGORY
+                # Set category on Rhea stubs so downstream category-aware
+                # consumers (and validators) don't see an empty category
+                # column. Keyed by name: category_index is an index into the
+                # *source* header and only matched by luck (#1033).
+                stub[CATEGORY_COLUMN] = RHEA_CATEGORY
+            l_parts = [stub.get(column, "") for column in node_header]
             nodes_dictionary[parts[id_index]].append(xref)
             l_joined = "\t".join(l_parts)
             new_lines.append(l_joined)
     else:
-        new_lines.append(replace_category_for_unipathways(line, id_index, category_index, node_header))
+        new_lines.append(replace_category_for_unipathways(line, id_index, category_index, node_header, source_header))
     return new_lines, nodes_dictionary
 
 
-def replace_category_for_unipathways(line, id_index, category_index, node_header):
+def replace_category_for_unipathways(line, id_index, category_index, node_header, source_header=None):
     """
     Replace category of a given node.
 
@@ -65,13 +102,16 @@ def replace_category_for_unipathways(line, id_index, category_index, node_header
     :type id_index: int
     :param category_index: The index of the tab delimited line with the node category.
     :type category_index: int
+    :param source_header: Column names of ``line``, so fields are matched by
+        name rather than by position (#1033).
+    :type source_header: list
     """
     parts = line.strip().split("\t")
     id_substring = get_unipathways_prefix(parts[id_index])
     # Get defined category
     category = UNIPATHWAYS_CATEGORIES_DICT[id_substring]
     parts[category_index] = category
-    complete_parts = parts + ([""] * (len(node_header) - len(parts)))
+    complete_parts = project_onto_header(parts, source_header, node_header)
     # Join the parts back together with a tab separator
     new_line = "\t".join(complete_parts)
     return new_line

--- a/tests/test_unipathways_row_shape.py
+++ b/tests/test_unipathways_row_shape.py
@@ -1,0 +1,106 @@
+"""Every UPA node row must be exactly as wide as the header written above it (#1033)."""
+
+from collections import defaultdict
+
+import pytest
+
+from kg_microbe.utils.unipathways_utils import (
+    project_onto_header,
+    replace_category_for_unipathways,
+    replace_id_with_xref,
+)
+
+NODE_HEADER = [
+    "id",
+    "category",
+    "name",
+    "description",
+    "xref",
+    "provided_by",
+    "synonym",
+    "deprecated",
+    "same_as",
+]
+# What KGX actually writes for an ontology: the canonical columns plus the
+# obograph/RDF leftovers that _normalize_schema strips later.
+KGX_HEADER = NODE_HEADER + ["subsets", "meta", "iri"]
+
+
+def _row(**values):
+    return "\t".join(values.get(column, "") for column in KGX_HEADER)
+
+
+def test_a_row_wider_than_the_header_is_truncated_not_kept():
+    """
+    The bug: `parts + [""] * (len(node_header) - len(parts))`.
+
+    With 12 fields and a 9-column header the multiplier is negative, `[""] * -3`
+    is `[]`, and all 12 fields survived — so pandas could not read the file the
+    transform had just written.
+    """
+    line = _row(
+        id="OBO:UPa_UCR00014",
+        category="biolink:NamedThing",
+        name="pyruvate + thiamine diphosphate = 2-hydroxyethyl-ThPP + CO(2)",
+        provided_by="upa.json",
+        iri="http://purl.obolibrary.org/obo/UPa_UCR00014",
+    )
+    out = replace_category_for_unipathways(line, 0, 1, NODE_HEADER, KGX_HEADER)
+    fields = out.split("\t")
+    assert len(fields) == len(NODE_HEADER)
+    assert fields[0] == "OBO:UPa_UCR00014"
+    assert fields[2] == "pyruvate + thiamine diphosphate = 2-hydroxyethyl-ThPP + CO(2)"
+    assert fields[5] == "upa.json"
+    assert "purl.obolibrary.org" not in out
+
+
+def test_a_short_row_is_padded():
+    """KGX omits trailing empty columns for some rows; those must still be header-width."""
+    out = replace_category_for_unipathways(
+        "OBO:UPa_UCR00014\tbiolink:NamedThing", 0, 1, NODE_HEADER, ["id", "category"]
+    )
+    assert len(out.split("\t")) == len(NODE_HEADER)
+
+
+def test_columns_are_matched_by_name_not_position():
+    """A reordered upstream column must not shift a value into the wrong field."""
+    reordered = ["category", "id", "iri", "name", "provided_by"]
+    line = "\t".join(["biolink:NamedThing", "OBO:UPa_UCR00014", "http://x", "a name", "upa.json"])
+    out = replace_category_for_unipathways(line, 1, 0, NODE_HEADER, reordered).split("\t")
+    assert out[NODE_HEADER.index("id")] == "OBO:UPa_UCR00014"
+    assert out[NODE_HEADER.index("name")] == "a name"
+    assert out[NODE_HEADER.index("provided_by")] == "upa.json"
+    assert "http://x" not in out
+
+
+def test_a_rhea_stub_is_header_width_and_carries_its_category():
+    """The RHEA half was already well-formed; keep it that way, and key it by name."""
+    line = _row(id="OBO:UPa_UCR00014", category="biolink:NamedThing", xref="RHEA:19032|GO:0004739")
+    new_lines, mapping = replace_id_with_xref(line, 4, 0, 1, defaultdict(list), NODE_HEADER, KGX_HEADER)
+    assert len(new_lines) == 1, "GO xrefs are dropped in favour of the Unipathways prefix"
+    fields = new_lines[0].split("\t")
+    assert len(fields) == len(NODE_HEADER)
+    assert fields[NODE_HEADER.index("id")] == "RHEA:19032"
+    assert fields[NODE_HEADER.index("category")] == "biolink:MolecularActivity"
+    assert mapping["OBO:UPa_UCR00014"] == ["RHEA:19032"]
+
+
+def test_a_stub_category_lands_by_name_even_when_the_headers_disagree():
+    """category_index indexes the source header; using it on the output row was luck."""
+    reordered_node_header = ["id", "name", "category", "description", "xref"]
+    line = "\t".join(["OBO:UPa_UCR00014", "biolink:NamedThing", "RHEA:19032"])
+    new_lines, _ = replace_id_with_xref(
+        line, 2, 0, 1, defaultdict(list), reordered_node_header, ["id", "category", "xref"]
+    )
+    fields = new_lines[0].split("\t")
+    assert fields[reordered_node_header.index("category")] == "biolink:MolecularActivity"
+    assert fields[reordered_node_header.index("id")] == "RHEA:19032"
+
+
+@pytest.mark.parametrize(
+    ("parts", "expected"),
+    [(["a", "b", "c", "d"], ["a", "b", "c"]), (["a"], ["a", "", ""])],
+)
+def test_without_a_source_header_it_falls_back_to_pad_or_truncate(parts, expected):
+    """Callers that never saw a header still get exactly header-width rows."""
+    assert project_onto_header(parts, None, ["x", "y", "z"]) == expected


### PR DESCRIPTION
Closes #1033. Found by the full rebuild: `kg transform -s ontologies` dies on `upa`, 6th of 14.

## The bug

`ontologies_transform.py:764` writes the canonical 9-column header; the rows come back from `replace_category_for_unipathways`, ending in

```python
complete_parts = parts + ([""] * (len(node_header) - len(parts)))
```

which **pads and never truncates**. KGX leaks `subsets`, `meta` and `iri` onto node rows — precisely the columns `_normalize_schema` exists to strip — so on a 12-field row the multiplier goes negative, `[""] * -3` is `[]`, and all 12 fields survive under a 9-field header:

| shape | rows | |
|---|---:|---|
| 9 fields | 963 | `RHEA:*` stubs — built at `len(node_header)`, always fine |
| **12 fields** | **1,086** | `UPA:UCR*` rows, trailing `…\t\t\thttp://purl.obolibrary.org/obo/UPa_UCR00014` |

Pandas tolerates short rows and raises on long ones, which is why only the UPA half killed `_remove_iri_column`.

## The fix

Project each row onto the canonical header **by column name** (`project_onto_header`), passing KGX's own header down from the caller. Positional truncation would work *today* only because the canonical header happens to be a prefix of KGX's column order; matching by name means an extra, missing or reordered upstream column cannot shift a value into the wrong field.

The same change fixes the RHEA stub builder, which was writing `l_parts[category_index]` — `category_index` is an index into the **source** header, correct only while the two headers agreed in position.

## Canary — real `kg transform -s upa`

| | before | after |
|---|---:|---:|
| exit | **1** (`ParserError`) | **0** (10.9 s) |
| malformed rows | 1,086 of 2,049 | **0** |
| UPA / RHEA nodes | 1,086 / 963 | 1,086 / 963 — unchanged |
| `purl.obolibrary.org` in the file | present | 0 |

Two consecutive runs give identical sorted-row md5s for nodes (`b0087c06…`) and edges (`8990047a…`).

7 new tests: wide row truncated, short row padded, columns matched by name under a reordered header, RHEA stub width + category by name, and the no-source-header fallback.

## Note

Two more instances of the same pad-without-truncate pattern live in `kg_microbe/utils/uniprot_utils.py:563,572`. Those transforms are `MISSING_OUTPUT`, so the defect is latent; left in #1033's description rather than changed blind here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
