### PR TITLE
Declare the three ontologies dependencies the guard could not see (#1035)

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -237,6 +237,11 @@ logger = logging.getLogger(__name__)
 class BacDiveTransform(Transform):
     """Template for how the transform class would be designed."""
 
+    #: Reads ``ontologies/ncbitaxon_nodes.tsv`` and ``ontologies/chebi_nodes.tsv``
+    #: via NCBITAXON_NODES_FILE / CHEBI_NODES_FILE. Undeclared until #1035: the
+    #: path lives in constants.py, so the cross-transform guard never saw it.
+    TRANSFORM_INPUTS = ("ontologies",)
+
     DATA_INPUTS = (
         "mappings/isolation_source_to_ontology.tsv",
         "mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",

--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -136,6 +136,11 @@ LEGACY_HTTP_CACHE_FILENAME = "mediadive_cache.sqlite"
 class MediaDiveTransform(Transform):
     """Template for how the transform class would be designed."""
 
+    #: Reads ``ontologies/chebi_nodes.tsv`` (ChEBI roles and categories) via
+    #: CHEBI_NODES_FILE; the path lives in constants.py, which is why this went
+    #: undeclared (#1035).
+    TRANSFORM_INPUTS = ("ontologies",)
+
     DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
 
     def __init__(self, input_dir: Optional[Path] = None, output_dir: Optional[Path] = None):

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -253,6 +253,11 @@ def _process_file_worker(args: Tuple[Path, Path, Dict[str, Any], bool]) -> Dict[
 class MetaTraitsTransform(Transform):
     """Transform metatraits summary JSONL files into KGX nodes and edges."""
 
+    #: Reads ``ontologies/ncbitaxon_nodes.tsv`` via NCBITAXON_NODES_FILE in
+    #: _load_ncbitaxon_labels. metatraits_gtdb inherits this. Undeclared until
+    #: #1035, because the path lives in constants.py rather than here.
+    TRANSFORM_INPUTS = ("ontologies",)
+
     DATA_INPUTS = ("mappings/kgmicrobe_unified_entity_mappings.sssom.tsv.gz",)
 
     # Measurement traits that should be excluded from unmapped_traits.tsv

--- a/kg_microbe/transform_utils/transform.py
+++ b/kg_microbe/transform_utils/transform.py
@@ -58,11 +58,16 @@ class Transform:
     #: Registered source names whose **output** this transform reads.
     #:
     #: `DATA_INPUTS` covers curation files under ``mappings/``. It does not
-    #: cover a dependency on another transform's output, and five exist: gold
-    #: reads ``ontologies/ncbitaxon_nodes.tsv`` (and refuses to run without it)
-    #: plus ``ontologies_stubs/po_nodes.tsv``, lpsn reads ``gtdb/nodes.tsv``,
-    #: lpsn_api and microbedecoder read ``lpsn/nodes.tsv``, and prego reads
-    #: ``ontologies/``.
+    #: cover a dependency on another transform's output, and eight sources have
+    #: one: gold reads ``ontologies/ncbitaxon_nodes.tsv`` (and refuses to run
+    #: without it) plus ``ontologies_stubs/po_nodes.tsv``, lpsn reads
+    #: ``gtdb/nodes.tsv``, lpsn_api and microbedecoder read ``lpsn/nodes.tsv``,
+    #: prego reads ``ontologies/``, and bacdive, mediadive and metatraits reach
+    #: ``ontologies/`` through the ``NCBITAXON_NODES_FILE`` /
+    #: ``CHEBI_NODES_FILE`` constants (metatraits_gtdb inherits metatraits').
+    #: Those last three went undeclared for months precisely because the path
+    #: is spelled in ``constants.py`` rather than in the transform, which the
+    #: guard below could not see until #1035.
     #:
     #: Undeclared, re-running an upstream leaves every downstream genuinely
     #: stale while all three freshness signals report fresh — the #812 shape,

--- a/tests/test_cross_transform_inputs.py
+++ b/tests/test_cross_transform_inputs.py
@@ -19,6 +19,45 @@ _UPSTREAM_PATTERNS = re.compile(
     r'|output_dir\.parent\s*/\s*["\']([a-z_]+)["\']'
 )
 
+#: `constants.py` defines module-level paths into another transform's output
+#: directory, e.g.
+#:
+#:     ONTOLOGIES_TRANSFORMED_DIR = TRANSFORMED_DATA_DIR / ONTOLOGIES
+#:     NCBITAXON_NODES_FILE = ONTOLOGIES_TRANSFORMED_DIR / "ncbitaxon_nodes.tsv"
+#:
+#: A transform that imports `NCBITAXON_NODES_FILE` writes no path of its own, so
+#: the scan above cannot see the dependency: bacdive, mediadive and metatraits
+#: each read `ontologies/` this way and the guard passed for months (#1035).
+#: Resolve the constants first, then look for their *names* in each transform.
+_CONSTANTS_FILE = TRANSFORM_ROOT / "constants.py"
+_DIR_CONSTANT = re.compile(
+    r"^([A-Z][A-Z0-9_]*) *= *TRANSFORMED_DATA_DIR *(?:/ *([A-Z][A-Z0-9_]*)|/ *[\"\']([a-z_]+)[\"\'])", re.M
+)
+_FILE_CONSTANT = re.compile(r"^([A-Z][A-Z0-9_]*) *= *([A-Z][A-Z0-9_]*) *//? *[\"\']", re.M)
+
+
+def _constants_naming_a_transform_output():
+    """
+    Map every constant in ``constants.py`` that points into a transform's output.
+
+    :return: ``{constant name: source name}``.
+    """
+    text = _CONSTANTS_FILE.read_text(encoding="utf-8")
+    # Which source each *directory* constant names. The source may be spelled as
+    # a literal or as the SOURCE-name constant (ONTOLOGIES = "ontologies").
+    literals = dict(re.findall(r"^([A-Z][A-Z0-9_]*) *= *[\"\']([a-z_]+)[\"\'] *(?:#.*)?$", text, re.M))
+    dirs = {}
+    for name, via_constant, via_literal in _DIR_CONSTANT.findall(text):
+        source = via_literal or literals.get(via_constant)
+        if source in DATA_SOURCES:
+            dirs[name] = source
+    # Then every file constant built on one of those directories.
+    resolved = dict(dirs)
+    for name, parent in _FILE_CONSTANT.findall(text):
+        if parent in resolved:
+            resolved[name] = resolved[parent]
+    return resolved
+
 
 def _observed_dependencies():
     """
@@ -26,6 +65,7 @@ def _observed_dependencies():
 
     :return: ``{source: {upstream, ...}}`` for sources with any dependency.
     """
+    constants = _constants_naming_a_transform_output()
     observed = {}
     for source in DATA_SOURCES:
         code_dir = TRANSFORM_ROOT / source
@@ -33,10 +73,14 @@ def _observed_dependencies():
             continue
         found = set()
         for path in code_dir.rglob("*.py"):
-            for match in _UPSTREAM_PATTERNS.finditer(path.read_text(encoding="utf-8")):
+            text = path.read_text(encoding="utf-8")
+            for match in _UPSTREAM_PATTERNS.finditer(text):
                 name = next(group for group in match.groups() if group)
                 if name != source and name in DATA_SOURCES:
                     found.add(name)
+            for constant, upstream in constants.items():
+                if upstream != source and re.search(rf"\b{constant}\b", text):
+                    found.add(upstream)
         if found:
             observed[source] = found
     return observed
@@ -76,6 +120,17 @@ class CrossTransformDeclarationTest(TestCase):
         self.assertIn("ontologies", observed.get("gold", set()))
         self.assertIn("gtdb", observed.get("lpsn", set()))
         self.assertIn("lpsn", observed.get("microbedecoder", set()))
+        # Reached only through a constants.py path; see _constants_naming_a_transform_output (#1035).
+        self.assertIn("ontologies", observed.get("bacdive", set()))
+        self.assertIn("ontologies", observed.get("mediadive", set()))
+        self.assertIn("ontologies", observed.get("metatraits", set()))
+
+    def test_a_constant_pointing_into_a_transform_output_is_resolved(self):
+        """The premise of the constants scan, pinned so a refactor cannot quietly empty it."""
+        resolved = _constants_naming_a_transform_output()
+        self.assertEqual(resolved.get("NCBITAXON_NODES_FILE"), "ontologies")
+        self.assertEqual(resolved.get("CHEBI_NODES_FILE"), "ontologies")
+        self.assertEqual(resolved.get("ONTOLOGIES_TRANSFORMED_DIR"), "ontologies")
 
     def test_no_transform_declares_an_unregistered_upstream(self):
         """A typo would fold an always-absent marker in and never clear."""


### PR DESCRIPTION
Closes #1035. Found during the full rebuild, working out why `mediadive` and `metatraits` were being run against a half-updated `data/transformed/ontologies/`.

## The hole

`tests/test_cross_transform_inputs.py` exists to make an undeclared cross-transform dependency impossible — its docstring says three prior versions of this contract were opt-in and each was forgotten, "This one is caught by the suite." It wasn't:

| transform | reads | declared |
|---|---|---|
| `bacdive` | `ontologies/ncbitaxon_nodes.tsv`, `ontologies/chebi_nodes.tsv` | `()` |
| `mediadive` | `ontologies/chebi_nodes.tsv` | `()` |
| `metatraits` | `ontologies/ncbitaxon_nodes.tsv` | `()` |

The scan regexes path idioms **only within `kg_microbe/transform_utils/<source>/`**. These three never write a path — they import `NCBITAXON_NODES_FILE` / `CHEBI_NODES_FILE`, defined in `constants.py`, outside the scanned tree.

## Fix

The scan resolves `constants.py` first — directory constants rooted at `TRANSFORMED_DATA_DIR` (via literal or via the source-name constant), then file constants built on those — and looks for the constant *names* in each transform. Then the three declarations.

**The new guard fails on the code as it stood before this commit**, which is precisely what the old one could not do:

```
FAILED CrossTransformDeclarationTest::test_every_observed_dependency_is_declared
  'ontologies' : bacdive reads ['ontologies'] but does not declare it in TRANSFORM_INPUTS
```

Two new pins so a refactor cannot silently empty the scan: the three constant-mediated dependencies are asserted present, and `_constants_naming_a_transform_output()` is asserted to resolve `NCBITAXON_NODES_FILE`/`CHEBI_NODES_FILE`/`ONTOLOGIES_TRANSFORMED_DIR` → `ontologies`.

## What this closes, both observed today

1. **Freshness lied.** Re-running `ontologies` left these three genuinely stale while every signal reported `FRESH` — the #812 shape #845 was meant to close.
2. **#685's skip logic could not protect them.** When `ontologies` failed mid-rebuild, `gold` and `prego` were correctly skipped; `bacdive`, `mediadive` and `metatraits` ran against a directory holding five ontologies from that run and eight from 2026-09-04.

Declarations go from five to nine (`metatraits_gtdb` inherits metatraits'). The `TRANSFORM_INPUTS` docstring, which asserted "five exist", is updated.

Rerun: these three are now correctly `STALE_VS_UPSTREAM` after the `ontologies` rerun that follows — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
