### PR TITLE
Stop stamping every merge -dirty: porcelain output must not be stripped (#1038)

### DIFF
--- a/kg_microbe/merge_utils/stats_provenance.py
+++ b/kg_microbe/merge_utils/stats_provenance.py
@@ -84,24 +84,56 @@ def git_commit(repo_root: Path, ignore: Iterable[Path] = ()) -> str:
     if git is None:
         return "unknown"
     try:
-        head = _git(git, repo_root, "rev-parse", "--short", "HEAD")
+        head = _git(git, repo_root, "rev-parse", "--short", "HEAD").strip()
+        # Not stripped: `git status --porcelain` emits "XY PATH", two status
+        # columns then a space, so an unstaged change reads " M path". Stripping
+        # the leading space shifted every column and the path parsed one
+        # character short, which made `ignore` a no-op and stamped -dirty on
+        # every merge (#1038).
         status = _git(git, repo_root, "status", "--porcelain", "--untracked-files=no")
     except (OSError, subprocess.SubprocessError):
         return "unknown"
     if not head:
         return "unknown"
     ignored = {_relative(Path(path), repo_root) for path in ignore}
-    changed = [line[3:] for line in status.splitlines() if line.strip()]
-    dirty = any(path not in ignored for path in changed)
+    dirty = any(path not in ignored for path in _porcelain_paths(status))
     return f"{head}-dirty" if dirty else head
 
 
 def _git(git: str, repo_root: Path, *args: str) -> str:
-    """Run one git command in the checkout and return stripped stdout."""
+    """
+    Run one git command in the checkout and return stdout verbatim.
+
+    Deliberately unstripped: porcelain output is column-oriented and a caller
+    that strips it before slicing loses a character off every path (#1038).
+    Callers wanting a bare value strip it themselves.
+    """
     result = subprocess.run(  # noqa: S603 - fixed argv, no shell
         [git, *args], cwd=repo_root, capture_output=True, text=True, check=False, timeout=30
     )
-    return result.stdout.strip() if result.returncode == 0 else ""
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _porcelain_paths(status: str) -> list:
+    """
+    Return the paths named by ``git status --porcelain`` output.
+
+    Each line is ``XY PATH``: two status columns, a space, then the path. A
+    rename reads ``R  old -> new``; the destination is what changed, so that is
+    what is returned.
+
+    :param status: Raw stdout of ``git status --porcelain``, unmodified.
+    :return: One path per changed file.
+    """
+    paths = []
+    for line in status.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        paths.append(path.strip('"'))
+    return paths
 
 
 def _relative(path: Path, repo_root: Path) -> str:

--- a/tests/test_merge_stats_provenance.py
+++ b/tests/test_merge_stats_provenance.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 import yaml
 
 from kg_microbe.merge_utils.stats_provenance import (
@@ -124,6 +125,73 @@ def test_the_real_canonical_config_names_a_stats_file():
     """merge.yaml's summarize operation is what the hook reads; keep them in step."""
     config = yaml.safe_load(Path("merge.yaml").read_text(encoding="utf-8"))
     assert stats_filename_from_config(config) == "merged_graph_stats.yaml"
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Build a real git checkout with one commit, so git_commit has something to read."""
+    import os
+    import shutil
+    import subprocess
+
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git is not on PATH")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+    }
+    subprocess.run([git, "init", "-q"], cwd=repo, check=True, env=env)  # noqa: S603 - resolved path
+    (repo / "stats.yaml").write_text("a: 1\n", encoding="utf-8")
+    (repo / "other.txt").write_text("x\n", encoding="utf-8")
+    subprocess.run([git, "add", "."], cwd=repo, check=True, env=env)  # noqa: S603 - resolved path
+    subprocess.run([git, "commit", "-qm", "init"], cwd=repo, check=True, env=env)  # noqa: S603 - resolved path
+    return repo
+
+
+def test_the_ignored_stats_file_alone_does_not_make_the_tree_dirty(tmp_path):
+    """
+    #1038: `_git` stripped the leading space off `git status --porcelain`.
+
+    Porcelain emits "XY PATH", so " M stats.yaml" became "M stats.yaml" and the
+    `line[3:]` slice produced "tats.yaml" — which never matched the ignore set,
+    so every merge stamped -dirty regardless of the tree. The old assertions
+    passed against that constant answer; this constructs the exact state.
+    """
+    from kg_microbe.merge_utils.stats_provenance import git_commit
+
+    repo = _init_repo(tmp_path)
+    stats = repo / "stats.yaml"
+    stats.write_text("a: 2\n", encoding="utf-8")
+
+    clean = git_commit(repo, ignore=(stats,))
+    self_dirty = git_commit(repo)
+    assert not clean.endswith("-dirty"), f"only the ignored file changed, got {clean!r}"
+    assert self_dirty.endswith("-dirty"), "without the ignore it must still report dirty"
+    assert clean == self_dirty[: -len("-dirty")]
+
+
+def test_a_second_modified_file_still_reports_dirty(tmp_path):
+    """Ignoring the stats file must not blind the flag to everything else."""
+    from kg_microbe.merge_utils.stats_provenance import git_commit
+
+    repo = _init_repo(tmp_path)
+    (repo / "stats.yaml").write_text("a: 2\n", encoding="utf-8")
+    (repo / "other.txt").write_text("changed\n", encoding="utf-8")
+    assert git_commit(repo, ignore=(repo / "stats.yaml",)).endswith("-dirty")
+
+
+def test_porcelain_paths_parses_the_column_format(tmp_path):
+    """Status columns, renames and quoted paths all have to yield the path itself."""
+    from kg_microbe.merge_utils.stats_provenance import _porcelain_paths
+
+    status = " M merged_graph_stats.yaml\n?? untracked.txt\nR  old.py -> new.py\nMM both.py\n"
+    assert _porcelain_paths(status) == ["merged_graph_stats.yaml", "untracked.txt", "new.py", "both.py"]
+    assert _porcelain_paths("") == []
 
 
 def test_the_stats_file_itself_never_makes_the_commit_dirty():


### PR DESCRIPTION
Closes #1038. Found on the **first production run** of the #1013/#993 stats hook.

## What it wrote

```yaml
provenance:
  commit: acff35880-dirty
```

The only tracked modification in the tree was `merged_graph_stats.yaml` — the one file `git_commit(repo_root, ignore=(stats_file,))` exists to exclude, since KGX rewrites it moments before the hook runs.

## Cause

`_git()` ended with `result.stdout.strip()`. Porcelain is column-oriented (`XY PATH`), so an unstaged change is `" M merged_graph_stats.yaml"` and stripping the leading space shifts every column:

```
raw stdout       : ' M merged_graph_stats.yaml\n'
_git() returned  : 'M merged_graph_stats.yaml'
line[3:] on that : ['erged_graph_stats.yaml']
```

That never matches the ignore set. **`ignore` has never had any effect**, and `-dirty` was a constant — carrying no information about the checkout, which is the same class of false provenance claim #1013 was filed about.

## Fix

`_git()` returns stdout verbatim (`rev-parse` strips at its call site, where a bare value is wanted); `_porcelain_paths()` parses the column format and handles renames (`R  old -> new` → `new`) and quoted paths.

## The old tests passed against the bug

They asserted the commit was not `"unknown"` and that ignoring "can only make the verdict cleaner" — both true of a permanently dirty answer. The new tests construct the exact state: a real git checkout (`git init`, one commit) whose only modified tracked file is the ignored one.

**Falsified against the pre-fix code** — restoring `HEAD`'s `stats_provenance.py` and re-running:

```
FAILED test_the_ignored_stats_file_alone_does_not_make_the_tree_dirty
FAILED test_porcelain_paths_parses_the_column_format
2 failed, 1 passed
```

and 11 passed on the fix. A third test pins that ignoring the stats file does not blind the flag to a *second* modified file.

## Follow-through

The stats file produced by today's merge carries the wrong `-dirty`. Rather than re-run the 2½-hour merge, I re-run the annotation step alone against the same archive — it is idempotent by design and tested as such — so the committed block states the checkout truthfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
