### PR TITLE
Write LF, not CRLF: csv.writer's default terminator reached the shipped graph (#1041)

### DIFF
--- a/kg_microbe/merge_utils/invariants.py
+++ b/kg_microbe/merge_utils/invariants.py
@@ -26,6 +26,7 @@ from kg_microbe.transform_utils.constants import (
     SUBJECT_COLUMN,
 )
 from kg_microbe.utils.atomic_io import atomic_write
+from kg_microbe.utils.tsv_io import tsv_writer
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +125,7 @@ def check_merged_invariants(
     violations = find_multi_parent_strains(edges_file)
     destination = Path(output_dir or edges_file.parent) / STRAIN_PARENT_REPORT
     with atomic_write(destination, newline="") as handle:
-        writer = csv.writer(handle, delimiter="\t")
+        writer = tsv_writer(handle)
         writer.writerow(STRAIN_PARENT_REPORT_HEADER)
         writer.writerows(strain_parent_rows(violations))
     # Absent is normal: the strain-parent check needs no nodes file, and callers
@@ -139,7 +140,7 @@ def check_merged_invariants(
         stubs = find_stub_nodes(nodes_file)
         stub_destination = Path(output_dir or edges_file.parent) / STUB_NODE_REPORT
         with atomic_write(stub_destination, newline="") as handle:
-            writer = csv.writer(handle, delimiter="\t")
+            writer = tsv_writer(handle)
             writer.writerow(STUB_NODE_REPORT_HEADER)
             writer.writerows(stub_node_rows(stubs))
         unexpected = {p: c for p, c in stubs.items() if p not in EXPECTED_STUB_PREFIXES}

--- a/kg_microbe/merge_utils/merge_kg.py
+++ b/kg_microbe/merge_utils/merge_kg.py
@@ -31,6 +31,7 @@ from kg_microbe.transform_utils.constants import (
     SYNONYM_COLUMN,
     XREF_COLUMN,
 )
+from kg_microbe.utils.tsv_io import tsv_writer
 
 CANONICAL_NODE_HEADER = [
     ID_COLUMN,
@@ -328,7 +329,7 @@ def _normalize_nodes_tsv(path: Path) -> None:
             header, CANONICAL_NODE_HEADER, NODE_COLUMNS_TO_DROP, extension_columns=set()
         )
         _log_schema_diff("nodes", path, header, out_header)
-        writer = csv.writer(tmp, delimiter="\t")
+        writer = tsv_writer(tmp)
         writer.writerow(out_header)
         for row in reader:
             writer.writerow(_project_row(row, keep_indices))
@@ -357,7 +358,7 @@ def _normalize_edges_tsv(path: Path) -> None:
             extension_columns=EDGE_EXTENSION_COLUMNS,
         )
         _log_schema_diff("edges", path, header, out_header)
-        writer = csv.writer(tmp, delimiter="\t")
+        writer = tsv_writer(tmp)
         writer.writerow(out_header)
         for row in reader:
             if ks_idx is not None and pks_idx is not None and pks_idx < len(row):

--- a/kg_microbe/transform_utils/gold/gold.py
+++ b/kg_microbe/transform_utils/gold/gold.py
@@ -124,6 +124,7 @@ from kg_microbe.transform_utils.constants import (
     RDFS_SUBCLASS_OF,
 )
 from kg_microbe.transform_utils.transform import Transform
+from kg_microbe.utils.tsv_io import tsv_writer
 
 #: Upstream filenames inside ``data/raw/gold/``.
 GOLD_NODES_FILE = "GOLD_nodes.tsv"
@@ -825,7 +826,7 @@ class GOLDTransform(Transform):
             self.output_edge_file.open("w", newline="") as out,
         ):
             reader = csv.DictReader(handle, delimiter="\t")
-            writer = csv.writer(out, delimiter="\t")
+            writer = tsv_writer(out)
             # `original_object` is Biolink's slot for what the source said before
             # transformation, so an upward resolution stays auditable and
             # reversible rather than silently rewriting the target.
@@ -1068,7 +1069,7 @@ class GOLDTransform(Transform):
             self.output_node_file.open("w", newline="") as out,
         ):
             reader = csv.DictReader(handle, delimiter="\t")
-            writer = csv.writer(out, delimiter="\t")
+            writer = tsv_writer(out)
             writer.writerow(self.node_header)
             written: set = set()
             for row in reader:

--- a/kg_microbe/transform_utils/gtdb/gtdb.py
+++ b/kg_microbe/transform_utils/gtdb/gtdb.py
@@ -44,6 +44,7 @@ from kg_microbe.transform_utils.gtdb.utils import (
     strip_gtdb_prefix,
 )
 from kg_microbe.transform_utils.transform import Transform
+from kg_microbe.utils.tsv_io import tsv_dict_writer, tsv_writer
 
 
 class GTDBTransform(Transform):
@@ -431,7 +432,7 @@ class GTDBTransform(Transform):
         )
         report = self.output_dir / GTDB_NCBI_POOLING_REPORT
         with open(report, "w", newline="") as handle:
-            writer = csv.writer(handle, delimiter="\t")
+            writer = tsv_writer(handle)
             writer.writerow(["ncbi_taxon", "gtdb_taxa", "predicate", "examples"])
             for ncbi_id, taxa in rows:
                 writer.writerow([ncbi_id, len(taxa), BROAD_MATCH_PREDICATE, "|".join(sorted(taxa)[:3])])
@@ -478,12 +479,12 @@ class GTDBTransform(Transform):
 
         # Write nodes
         with open(self.output_node_file, "w") as nf:
-            writer = csv.DictWriter(nf, fieldnames=node_fields, delimiter="\t")
+            writer = tsv_dict_writer(nf, fieldnames=node_fields)
             writer.writeheader()
             writer.writerows(self.nodes)
 
         # Write edges
         with open(self.output_edge_file, "w") as ef:
-            writer = csv.DictWriter(ef, fieldnames=self.edge_header, delimiter="\t")
+            writer = tsv_dict_writer(ef, fieldnames=self.edge_header)
             writer.writeheader()
             writer.writerows(self.edges)

--- a/kg_microbe/transform_utils/lpsn/lpsn.py
+++ b/kg_microbe/transform_utils/lpsn/lpsn.py
@@ -60,6 +60,7 @@ from kg_microbe.transform_utils.constants import (
 )
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.atomic_io import atomic_write
+from kg_microbe.utils.tsv_io import tsv_writer
 
 LPSN_PREFIX = "lpsn:"
 LPSN_KNOWLEDGE_SOURCE = "infores:lpsn"
@@ -435,8 +436,8 @@ class LPSNTransform(Transform):
             atomic_write(self.output_node_file, newline="") as node_fh,
             atomic_write(self.output_edge_file, newline="") as edge_fh,
         ):
-            node_writer = csv.writer(node_fh, delimiter="\t")
-            edge_writer = csv.writer(edge_fh, delimiter="\t")
+            node_writer = tsv_writer(node_fh)
+            edge_writer = tsv_writer(edge_fh)
 
             node_writer.writerow(self.node_header)
             edge_writer.writerow(self.edge_header)

--- a/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
+++ b/kg_microbe/transform_utils/lpsn_api/lpsn_api.py
@@ -76,6 +76,7 @@ from kg_microbe.transform_utils.constants import (
 from kg_microbe.transform_utils.lpsn.lpsn import LPSN_KNOWLEDGE_SOURCE, LPSN_PREFIX
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.atomic_io import atomic_write
+from kg_microbe.utils.tsv_io import tsv_writer
 
 # JSON keys returned by the LPSN API (documented at
 # https://lpsn.dsmz.de/text/lpsn-api). Kept as module constants so a
@@ -288,8 +289,8 @@ class LPSNAPITransform(Transform):
             atomic_write(self.output_node_file, newline="") as node_fh,
             atomic_write(self.output_edge_file, newline="") as edge_fh,
         ):
-            node_writer = csv.writer(node_fh, delimiter="\t")
-            edge_writer = csv.writer(edge_fh, delimiter="\t")
+            node_writer = tsv_writer(node_fh)
+            edge_writer = tsv_writer(edge_fh)
             node_writer.writerow(self.node_header)
             edge_writer.writerow(self.edge_header)
 

--- a/kg_microbe/utils/tsv_io.py
+++ b/kg_microbe/utils/tsv_io.py
@@ -1,4 +1,4 @@
-"""
+r"""
 One place that decides how KG-Microbe writes a TSV.
 
 ``csv.writer``'s default ``lineterminator`` is ``"\r\n"`` on every platform,
@@ -22,7 +22,7 @@ LINE_TERMINATOR = "\n"
 
 
 def tsv_writer(handle: Any, **kwargs: Any):
-    """
+    r"""
     Return a tab-delimited ``csv.writer`` that terminates lines with ``\n``.
 
     :param handle: A file opened with ``newline=""`` (so the text layer does
@@ -37,7 +37,7 @@ def tsv_writer(handle: Any, **kwargs: Any):
 
 
 def tsv_dict_writer(handle: Any, fieldnames, **kwargs: Any):
-    """
+    r"""
     Return a tab-delimited ``csv.DictWriter`` terminating lines with ``\n``.
 
     :param handle: A file opened with ``newline=""``.

--- a/kg_microbe/utils/tsv_io.py
+++ b/kg_microbe/utils/tsv_io.py
@@ -1,0 +1,53 @@
+"""
+One place that decides how KG-Microbe writes a TSV.
+
+``csv.writer``'s default ``lineterminator`` is ``"\r\n"`` on every platform,
+and it is emitted literally regardless of the ``newline`` argument to
+``open()``. Four transforms and both merge normalizers used that default, so
+every line of the shipped merged graph ended with a carriage return and the
+last column of every row carried it as data -- an "empty" trailing field was
+``"\r"``, which inverts a truthiness test on it (#1041, and the corruption
+open issue #541 describes in the DuckDB loader).
+
+Use :func:`tsv_writer` instead of constructing ``csv.writer`` directly for any
+file another tool will parse. ``tests/test_tsv_line_endings.py`` fails on a
+graph-writing module that goes back to the bare constructor.
+"""
+
+import csv
+from typing import Any
+
+#: The only line terminator KG-Microbe writes.
+LINE_TERMINATOR = "\n"
+
+
+def tsv_writer(handle: Any, **kwargs: Any):
+    """
+    Return a tab-delimited ``csv.writer`` that terminates lines with ``\n``.
+
+    :param handle: A file opened with ``newline=""`` (so the text layer does
+        not translate what the writer emits).
+    :param kwargs: Passed through to ``csv.writer``; ``delimiter`` and
+        ``lineterminator`` default to tab and newline.
+    :return: The configured writer.
+    """
+    kwargs.setdefault("delimiter", "\t")
+    kwargs.setdefault("lineterminator", LINE_TERMINATOR)
+    return csv.writer(handle, **kwargs)
+
+
+def tsv_dict_writer(handle: Any, fieldnames, **kwargs: Any):
+    """
+    Return a tab-delimited ``csv.DictWriter`` terminating lines with ``\n``.
+
+    :param handle: A file opened with ``newline=""``.
+    :param fieldnames: Column names, in order.
+    :param kwargs: Passed through to ``csv.DictWriter``.
+    :return: The configured writer.
+    """
+    kwargs.setdefault("delimiter", "\t")
+    kwargs.setdefault("lineterminator", LINE_TERMINATOR)
+    return csv.DictWriter(handle, fieldnames=fieldnames, **kwargs)
+
+
+__all__ = ["LINE_TERMINATOR", "tsv_dict_writer", "tsv_writer"]

--- a/tests/test_tsv_line_endings.py
+++ b/tests/test_tsv_line_endings.py
@@ -1,0 +1,89 @@
+"""KG-Microbe writes LF, not CRLF, in every TSV another tool parses (#1041)."""
+
+import ast
+import io
+from pathlib import Path
+
+import pytest
+
+from kg_microbe.utils.tsv_io import tsv_dict_writer, tsv_writer
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Modules that write a nodes/edges TSV or a report beside one. A bare
+#: ``csv.writer`` here reintroduces CRLF into the shipped graph.
+GRAPH_WRITERS = (
+    "kg_microbe/merge_utils/merge_kg.py",
+    "kg_microbe/merge_utils/invariants.py",
+    "kg_microbe/transform_utils/gtdb/gtdb.py",
+    "kg_microbe/transform_utils/lpsn/lpsn.py",
+    "kg_microbe/transform_utils/lpsn_api/lpsn_api.py",
+    "kg_microbe/transform_utils/gold/gold.py",
+)
+
+
+def _bare_csv_writers(path: Path):
+    """Return the line numbers of ``csv.writer``/``csv.DictWriter`` calls without an explicit terminator."""
+    found = []
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in {"writer", "DictWriter"}:
+            continue
+        if not (isinstance(node.func.value, ast.Name) and node.func.value.id == "csv"):
+            continue
+        if any(kw.arg == "lineterminator" for kw in node.keywords):
+            continue
+        found.append(node.lineno)
+    return found
+
+
+@pytest.mark.parametrize("relpath", GRAPH_WRITERS)
+def test_graph_writers_do_not_use_a_bare_csv_writer(relpath):
+    """
+    csv.writer defaults to lineterminator="\\r\\n" on every platform.
+
+    `newline=""` does not change it -- gold, lpsn and lpsn_api all passed
+    `newline=""` and still emitted CRLF, which is how every line of the shipped
+    merged graph ended with a carriage return.
+    """
+    bare = _bare_csv_writers(REPO_ROOT / relpath)
+    assert not bare, (
+        f"{relpath} constructs csv.writer/DictWriter without lineterminator at line(s) {bare}; "
+        "use kg_microbe.utils.tsv_io.tsv_writer / tsv_dict_writer"
+    )
+
+
+def test_the_helper_writes_lf_where_a_bare_writer_writes_crlf():
+    """The premise, pinned: this is the difference the whole change rests on."""
+    import csv
+
+    bare = io.StringIO()
+    csv.writer(bare, delimiter="\t").writerow(["a", "b"])
+    assert bare.getvalue() == "a\tb\r\n", "if this ever changes, the guard above is obsolete"
+
+    ours = io.StringIO()
+    tsv_writer(ours).writerow(["a", "b"])
+    assert ours.getvalue() == "a\tb\n"
+
+
+def test_the_dict_helper_writes_lf_too():
+    """Header and rows both, since gtdb writes its nodes file through DictWriter."""
+    buf = io.StringIO()
+    writer = tsv_dict_writer(buf, ["id", "name"])
+    writer.writeheader()
+    writer.writerow({"id": "X:1", "name": "n"})
+    assert buf.getvalue() == "id\tname\nX:1\tn\n"
+
+
+def test_an_empty_last_field_is_empty_not_a_carriage_return():
+    """
+    The corruption this prevents: a trailing CR lands in the last column.
+
+    An "empty" last field then holds "\\r", so a truthiness test on it inverts --
+    which is how a count of gtdb nodes carrying a `same_as` read 901,341 instead
+    of 447,137.
+    """
+    buf = io.StringIO()
+    tsv_writer(buf).writerow(["ncbi.assembly:GCA_1.1", "biolink:Genome", ""])
+    assert buf.getvalue().split("\n")[0].split("\t")[-1] == ""

--- a/tests/test_tsv_line_endings.py
+++ b/tests/test_tsv_line_endings.py
@@ -40,7 +40,7 @@ def _bare_csv_writers(path: Path):
 
 @pytest.mark.parametrize("relpath", GRAPH_WRITERS)
 def test_graph_writers_do_not_use_a_bare_csv_writer(relpath):
-    """
+    r"""
     csv.writer defaults to lineterminator="\\r\\n" on every platform.
 
     `newline=""` does not change it -- gold, lpsn and lpsn_api all passed
@@ -77,7 +77,7 @@ def test_the_dict_helper_writes_lf_too():
 
 
 def test_an_empty_last_field_is_empty_not_a_carriage_return():
-    """
+    r"""
     The corruption this prevents: a trailing CR lands in the last column.
 
     An "empty" last field then holds "\\r", so a truthiness test on it inverts --


### PR DESCRIPTION
Closes #1041. Found while verifying #882's `same_as` pairing survived the merge — it did, as `…GCA_027889305.1\r`.

## What was wrong

Every line of `merged-kg.tar.gz` ended with CR — **3,384,380 node lines and 15,285,904 edge lines**. Splitting a row on tabs leaves the last column carrying it as data (`same_as` for nodes, `agent_type` for edges). An "empty" last field is `"\r"`, so a truthiness test inverts: a count of gtdb nodes with a `same_as` read **901,341** instead of the correct **447,137**.

## Corrected cause

My first analysis on the issue blamed a missing `newline=""` — wrong, and the evidence contradicted it: `gold`, `lpsn` and `lpsn_api` all pass `newline=""` and still emitted CRLF.

```
open(w) + csv default             -> b'a\tb\r\n'
open(w, newline="") + csv default -> b'a\tb\r\n'     <-- newline="" changes nothing
open(w, newline="") + LF          -> b'a\tb\n'
```

`csv.writer`'s default `lineterminator` is `"\r\n"` on every platform and is written literally; `newline=""` only stops the text layer translating it.

## Fix

`kg_microbe/utils/tsv_io.py` owns the decision (`tsv_writer` / `tsv_dict_writer`); the six graph-writing modules go through it.

Four transforms emitted CRLF (`gtdb`, `lpsn`, `lpsn_api`, `gold`) — but the merged file was **100% CRLF regardless of source**, because `merge_kg`'s two normalizers rebuild every row through a default writer, converting the LF majority on the way. Those two call sites are most of the fix.

## Guard

An AST test fails on any of the six modules constructing `csv.writer`/`DictWriter` without an explicit `lineterminator`, **and** pins the premise (`csv.writer` emits `\r\n`) so it cannot become vacuous if the stdlib ever changes. Falsified: it fails on the pre-fix `merge_kg.py`.

## Canaries

| | rows | CR lines |
|---|---:|---:|
| `kg transform -s gtdb` (34 s) — nodes | 1,148,710 | **0** |
| — edges | 1,471,035 | **0** |
| — pooling report | 8,627 | **0** |
| `kg transform -s lpsn` — nodes / edges | 86,667 / 156,205 | **0** |

Row counts unchanged, and the `same_as` count now reads 447,137 directly with no special handling. 124 tests pass across the touched suites.

## Not a regression, and its consequence

The 2026-09-07 archive is CRLF too. But it means open issue **#541** ("duckdb_loader.py silently corrupts the last column on CRLF input files") describes the graph this repo actually ships, not a hypothetical input — so `kg query-organism` and the `kg-query` skill have been loading a corrupt last column.

Correcting the merged artifact needs a re-merge; batching that with the next rebuild rather than spending 2½ hours to change line endings alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
