### PR TITLE
bacdive: publish nodes.tsv/edges.tsv atomically (#1036)

### DIFF
--- a/kg_microbe/transform_utils/bacdive/bacdive.py
+++ b/kg_microbe/transform_utils/bacdive/bacdive.py
@@ -222,6 +222,7 @@ from kg_microbe.utils.ontology_utils import (
 # Note: get_label and search_by_label are imported lazily in fallback methods
 from kg_microbe.utils.pandas_utils import drop_duplicates
 from kg_microbe.utils.string_coding import remove_nextlines
+from kg_microbe.utils.tsv_io import tsv_writer
 
 # Anitibiotic resistance
 if Path(METABOLITE_MAPPING_FILE).is_file():
@@ -1006,7 +1007,7 @@ class BacDiveTransform(Transform):
         if not missing:
             return 0
         with open(self.output_node_file, "a", encoding="utf-8", newline="") as handle:
-            writer = csv.writer(handle, delimiter="\t")
+            writer = tsv_writer(handle)
             for curie in missing:
                 label = self._get_ncbitaxon_label(curie)
                 writer.writerow(
@@ -1839,19 +1840,25 @@ class BacDiveTransform(Transform):
             open(str(BACDIVE_TMP_DIR / "bacdive_physiology_metabolism.tsv"), "w") as tsvfile_2,
             open(str(BACDIVE_TMP_DIR / BACDIVE_MAPPING_FILE), "r") as tsvfile_3,
             open(str(BACDIVE_TMP_DIR / "bacdive_name_tax_classification.tsv"), "w") as tsvfile_4,
-            open(self.output_node_file, "w") as node,
-            open(self.output_edge_file, "w") as edge,
+            # Atomic: a run that dies here used to leave a truncated pair on
+            # disk with nothing marking it partial -- a SIGTERM during the
+            # 2026-09-10 rebuild left 173 MB of a 633 MB build, which the merge
+            # would have read as complete (#1036). The later
+            # `drop_duplicates` rewrite is already atomic; this was the gap
+            # before it. Same rule as lpsn (#820) and lpsn_api (#985).
+            atomic_write(self.output_node_file, newline="") as node,
+            atomic_write(self.output_edge_file, newline="") as edge,
             open(CUSTOM_CURIES_YAML_FILE, "r") as cc_file,
         ):
-            writer = csv.writer(tsvfile_1, delimiter="\t")
+            writer = tsv_writer(tsvfile_1)
             # Write the column names to the output file
             writer.writerow(COLUMN_NAMES)
-            writer_2 = csv.writer(tsvfile_2, delimiter="\t")
+            writer_2 = tsv_writer(tsvfile_2)
             writer_2.writerow(PHYS_AND_META_COL_NAMES)
-            writer_3 = csv.writer(tsvfile_4, delimiter="\t")
+            writer_3 = tsv_writer(tsvfile_4)
             writer_3.writerow(NAME_TAX_CLASSIFICATION_COL_NAMES)
 
-            node_writer = csv.writer(node, delimiter="\t")
+            node_writer = tsv_writer(node)
             node_writer.writerow(self.node_header)
             # Wrap edge_writer so every infores:bacdive-sourced edge that
             # involves a kgmicrobe.strain:bacdive_NNN node (subject or object)
@@ -1860,7 +1867,7 @@ class BacDiveTransform(Transform):
             # so downstream merge collapses these rows with their mediadive-
             # sourced twins (which carry just "bacdive:NNN") into a single
             # multi-provenance row instead of leaving them as two singletons.
-            raw_edge_writer = csv.writer(edge, delimiter="\t")
+            raw_edge_writer = tsv_writer(edge)
             raw_edge_writer.writerow(self.edge_header)
             edge_writer = _StrainProvenanceWriter(
                 raw_edge_writer,
@@ -3611,7 +3618,7 @@ class BacDiveTransform(Transform):
         # prevent (#903).
         claims_file = os.path.join(self.output_dir, BACDIVE_DEPOSIT_CLAIMS_FILE)
         with atomic_write(claims_file, newline="") as f:
-            claims_writer = csv.writer(f, delimiter="\t")
+            claims_writer = tsv_writer(f)
             claims_writer.writerow(DEPOSIT_CONFLICT_HEADER)
             claims_writer.writerows(deposit_conflict_rows(contested_deposits))
         resolution_counts = Counter(resolution for _, _, resolution, _ in contested_deposits)

--- a/tests/test_bacdive_atomic_outputs.py
+++ b/tests/test_bacdive_atomic_outputs.py
@@ -1,0 +1,55 @@
+"""bacdive publishes nodes.tsv/edges.tsv atomically, or not at all (#1036)."""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACDIVE = REPO_ROOT / "kg_microbe" / "transform_utils" / "bacdive" / "bacdive.py"
+
+
+def _write_opens_of(attr: str):
+    """Return line numbers where ``self.<attr>`` is opened for writing with the builtin ``open``."""
+    found = []
+    for node in ast.walk(ast.parse(BACDIVE.read_text(encoding="utf-8"))):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name) or node.func.id != "open":
+            continue
+        if not node.args:
+            continue
+        target = node.args[0]
+        if not (isinstance(target, ast.Attribute) and target.attr == attr):
+            continue
+        mode = node.args[1].value if len(node.args) > 1 and isinstance(node.args[1], ast.Constant) else ""
+        if "w" in str(mode):
+            found.append(node.lineno)
+    return found
+
+
+def test_the_graph_outputs_are_not_opened_for_truncating_writes():
+    """
+    A SIGTERM during the 2026-09-10 rebuild left 173 MB of a 633 MB build.
+
+    Nothing marked it partial, and the merge reads whatever pair is on disk.
+    The later `drop_duplicates` rewrite was already atomic; the big csv.writer
+    block before it was the gap.
+    """
+    for attr in ("output_node_file", "output_edge_file"):
+        bare = _write_opens_of(attr)
+        assert not bare, f"self.{attr} is opened with a truncating open() at line(s) {bare}; use atomic_write"
+
+
+def test_both_outputs_go_through_atomic_write():
+    """Pin the positive, so deleting the writes entirely would not pass the check above."""
+    source = BACDIVE.read_text(encoding="utf-8")
+    assert 'atomic_write(self.output_node_file, newline="")' in source
+    assert 'atomic_write(self.output_edge_file, newline="")' in source
+
+
+def test_appending_stubs_is_still_allowed():
+    """
+    The stub pass appends to a file the atomic write has already published.
+
+    That is deliberate and must not be mistaken for the defect: it runs after
+    the context manager closes, so it never sees a partial file.
+    """
+    source = BACDIVE.read_text(encoding="utf-8")
+    assert 'open(self.output_node_file, "a"' in source

--- a/tests/test_tsv_line_endings.py
+++ b/tests/test_tsv_line_endings.py
@@ -19,6 +19,7 @@ GRAPH_WRITERS = (
     "kg_microbe/transform_utils/lpsn/lpsn.py",
     "kg_microbe/transform_utils/lpsn_api/lpsn_api.py",
     "kg_microbe/transform_utils/gold/gold.py",
+    "kg_microbe/transform_utils/bacdive/bacdive.py",
 )
 
 


### PR DESCRIPTION
Closes #1036.

## The failure, observed

A SIGTERM during the 2026-09-10 rebuild left

```
data/transformed/bacdive/nodes.tsv    71,005,945 bytes
data/transformed/bacdive/edges.tsv   101,895,861 bytes
```

against ~633 MB for a complete run — 27%, with no `.partial` marker and nothing else distinguishing it from a finished build. The merge reads whatever pair is on disk.

## Where the gap actually was

The final `drop_duplicates` rewrite is **already atomic** (`pandas_utils.py` documents it), so my first reading — "bacdive writes non-atomically" — was only half right. The gap is the big `csv.writer` block that runs long before it, opening both graph outputs with a truncating `open()`. That is where the SIGTERM landed.

Both now go through `atomic_write`, the rule lpsn took in #820 and lpsn_api in #985.

The stub pass that appends to `nodes.tsv` is unchanged and still correct — it runs after the context manager closes, so it never sees a partial file. A test pins that, so a later reader does not mistake it for the same defect.

## Also: bacdive joins the CRLF guard (#1041)

Its seven `csv.writer` call sites go through `tsv_writer`. The graph outputs already reached disk as LF, but only because pandas rewrote them at the end; the **intermediates did not**, and `bacdive.tsv` is read by the mediadive transform.

## Guards

- AST test: fails if `self.output_node_file` / `self.output_edge_file` is opened for a truncating write.
- Positive assertion that both go through `atomic_write`, so deleting the writes entirely would not pass vacuously.
- Both **fail on the pre-fix file** (2 failed / 1 passed).

`pytest -k bacdive`: 102 passed, 1 skipped. Full-tree `ruff check` clean.

No rerun needed for the PR — this changes how the file is published, not its contents; bacdive's output is byte-identical modulo the intermediates' line endings, and it is rebuilt with the next batch anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
