### PR TITLE
ontologies: an ontology's annotation vocabulary is not one of its classes (#1023)

### DIFF
--- a/kg_microbe/transform_utils/ontologies/ontologies_transform.py
+++ b/kg_microbe/transform_utils/ontologies/ontologies_transform.py
@@ -118,6 +118,18 @@ ONTOLOGIES_MAP = {
 # RDF/OWL predicate CURIEs — not biolink entity relationships — so they clutter
 # the merged KG (kgxval flags them as non-biolink) without carrying queryable
 # entity data. Dropped from the edge output; nodes are left untouched.
+#: Prefixes of the annotation and metadata vocabulary an OWL file annotates
+#: *with* -- never anything it defines. KGX's OBO-JSON loader emits a node for
+#: each one it encounters, so `rdfs:label`, `owl:deprecated`, `dc:title` and
+#: `dcterms:license` arrived as biolink:OntologyClass nodes connected to
+#: nothing: 55 distinct ids, 172 rows across ten ontologies, 0 edges, 36 of
+#: them in the shipped graph (#1023). Matching on the id column of a *nodes*
+#: file only -- `skos:closeMatch` as a relation value is legitimate and lives
+#: in a different column of a different file.
+METAMODEL_NODE_PREFIXES = frozenset(
+    {"dc", "dct", "dcterms", "terms", "doap", "foaf", "oio", "owl", "pav", "rdf", "rdfs", "skos"}
+)
+
 METAMODEL_EDGE_PREDICATES = frozenset(
     {
         "rdfs:subPropertyOf",
@@ -459,6 +471,23 @@ class OntologiesTransform(Transform):
             return df, 0
         before = len(df)
         df = df[~df[PREDICATE_COLUMN].isin(METAMODEL_EDGE_PREDICATES)]
+        return df, before - len(df)
+
+    def _drop_metamodel_nodes(self, df: pd.DataFrame) -> tuple:
+        """
+        Return ``(filtered_df, dropped_count)`` with annotation-property nodes removed.
+
+        Drops rows whose ``id`` prefix is in :data:`METAMODEL_NODE_PREFIXES` --
+        the vocabulary an ontology annotates with rather than anything it
+        defines. Pure DataFrame transform (no I/O), mirroring
+        :meth:`_drop_metamodel_edges`; returns the frame unchanged when the id
+        column is absent.
+        """
+        if ID_COLUMN not in df.columns:
+            return df, 0
+        before = len(df)
+        prefixes = df[ID_COLUMN].astype(str).str.split(":", n=1).str[0]
+        df = df[~prefixes.isin(METAMODEL_NODE_PREFIXES)]
         return df, before - len(df)
 
     def _add_kgx_metadata_to_edges(self, edges_file_path: Path):
@@ -1015,7 +1044,13 @@ class OntologiesTransform(Transform):
             for col in added_node_cols:
                 df[col] = ""
             df = df[self.node_header]
+            df, dropped_metamodel_nodes = self._drop_metamodel_nodes(df)
             df.to_csv(nodes_file, sep="\t", index=False)
+            if dropped_metamodel_nodes:
+                print(
+                    f"  [_normalize_schema] {nodes_file.name}: dropped "
+                    f"{dropped_metamodel_nodes} annotation-property node(s) (#1023)"
+                )
             if dropped_node_cols or added_node_cols:
                 print(f"  [_normalize_schema] {nodes_file.name}: dropped={dropped_node_cols} added={added_node_cols}")
 

--- a/tests/test_ontology_metamodel_nodes.py
+++ b/tests/test_ontology_metamodel_nodes.py
@@ -1,0 +1,76 @@
+"""An ontology's annotation vocabulary is not one of its classes (#1023)."""
+
+import pandas as pd
+import pytest
+
+from kg_microbe.transform_utils.ontologies.ontologies_transform import (
+    METAMODEL_NODE_PREFIXES,
+    OntologiesTransform,
+)
+
+
+@pytest.fixture()
+def transform():
+    """Build a transform instance; the dropper is a pure DataFrame method needing no I/O."""
+    return OntologiesTransform.__new__(OntologiesTransform)
+
+
+def _nodes(*ids):
+    return pd.DataFrame({"id": list(ids), "category": ["biolink:OntologyClass"] * len(ids)})
+
+
+def test_annotation_properties_are_dropped(transform):
+    """
+    rdfs:label was a node in the knowledge graph, asserted to be an ontology class.
+
+    55 distinct such ids, 172 rows across ten ontologies, 0 edges touching any
+    of them, 36 in the shipped graph.
+    """
+    df, dropped = transform._drop_metamodel_nodes(
+        _nodes("rdfs:label", "owl:deprecated", "dcterms:license", "dc:title", "skos:closeMatch", "CHEBI:1")
+    )
+    assert dropped == 5
+    assert df["id"].tolist() == ["CHEBI:1"]
+
+
+def test_real_ontology_terms_are_kept(transform):
+    """The filter must key on the prefix, not on anything fuzzier."""
+    keep = _nodes("CHEBI:15377", "GO:0008150", "UPA:UCR00014", "NCBITaxon:562", "FOODON:03301710", "PATO:0001421")
+    df, dropped = transform._drop_metamodel_nodes(keep)
+    assert dropped == 0
+    assert len(df) == 6
+
+
+def test_both_dcterms_spellings_go(transform):
+    """
+    The same IRI arrived as `dcterms:license` or `dct:license` depending on the run.
+
+    Dropping the row removes the nondeterminism without having to pick a winner
+    between two prefixes for one namespace.
+    """
+    df, dropped = transform._drop_metamodel_nodes(_nodes("dcterms:license", "dct:license", "EC:1.1.1.1"))
+    assert dropped == 2
+    assert df["id"].tolist() == ["EC:1.1.1.1"]
+
+
+def test_a_frame_without_an_id_column_is_returned_unchanged(transform):
+    """Mirrors _drop_metamodel_edges: no column, no opinion."""
+    df = pd.DataFrame({"category": ["biolink:OntologyClass"]})
+    out, dropped = transform._drop_metamodel_nodes(df)
+    assert dropped == 0
+    assert out.equals(df)
+
+
+def test_a_bare_id_without_a_prefix_is_kept(transform):
+    """`split(":")[0]` on an id with no colon yields the whole id; it must not match by accident."""
+    df, dropped = transform._drop_metamodel_nodes(_nodes("owl", "rdfs", "CHEBI:1"))
+    # "owl" and "rdfs" have no colon, so they are not prefixed CURIEs -- but they
+    # would collide with the prefix set. Documenting the behaviour deliberately.
+    assert dropped == 2, "a bare token equal to a metamodel prefix is treated as one"
+    assert df["id"].tolist() == ["CHEBI:1"]
+
+
+def test_the_prefix_set_covers_what_was_measured():
+    """The ten prefixes actually seen in the 2026-09-10 ontology outputs."""
+    for prefix in ("dc", "dct", "dcterms", "oio", "owl", "rdfs", "skos"):
+        assert prefix in METAMODEL_NODE_PREFIXES


### PR DESCRIPTION
Closes #1023.

## Scope, measured

`rdfs:label` was a node in the knowledge graph, typed `biolink:OntologyClass`, connected to nothing. So were `owl:deprecated`, `dc:title`, `dcterms:license` and 51 others:

| | |
|---|---:|
| distinct annotation-property ids as nodes | **55** |
| rows across the ten ontology outputs | 172 |
| **edges touching any of them** | **0** |
| reaching the shipped merged graph | 36 |

They are the vocabulary an OWL file annotates *with*, which KGX's OBO-JSON loader emits a node for whenever it encounters one.

## Fix

`_drop_metamodel_nodes` mirrors the existing `_drop_metamodel_edges` — a pure DataFrame filter, called from `_normalize_schema` where the leaked `subsets`/`meta`/`iri` columns are already stripped, keyed on the id prefix.

**This subsumes the defect the issue was opened for.** `dcterms:license` vs `dct:license` alternated between runs because the converter's prefix map carries both for one namespace and the winner depended on iteration order. Dropping the row removes the nondeterminism without needing to pick a winner.

Deliberately narrow: it matches the `id` column of a **nodes** file only. `skos:closeMatch` as a *relation value* is legitimate, lives in a different column of a different file, and is untouched — a test pins that distinction.

## Canary — `kg transform -s pato` (12 s)

| | before | after |
|---|---:|---:|
| annotation-property nodes | 14 | **0** |
| rows | 7,978 | 7,964 (−14 exactly) |
| real `PATO:` terms | 1,887 | 1,887 |
| edges | 18,910 | 18,910 |

An `ec` run (the issue's original example) is in flight; result posted as a comment.

## One documented sharp edge

A bare token equal to a metamodel prefix (`owl` with no colon) is treated as one. No ontology mints such an id, and the alternative — requiring a colon — would let a malformed row through. Pinned by a test that says so explicitly rather than left as a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
