### PR TITLE
Finish the CRLF fix, and make the guard one that cannot drift (#1041)

### DIFF
--- a/kg_microbe/transform_utils/bactotraits/bactotraits.py
+++ b/kg_microbe/transform_utils/bactotraits/bactotraits.py
@@ -44,6 +44,7 @@ from kg_microbe.utils.mapping_file_utils import load_metpo_mappings, uri_to_curi
 from kg_microbe.utils.oak_utils import get_label
 from kg_microbe.utils.ontology_utils import get_ncbitaxon_adapter, resolve_adapter
 from kg_microbe.utils.pandas_utils import drop_duplicates
+from kg_microbe.utils.tsv_io import tsv_writer
 
 
 class BactoTraitsTransform(Transform):
@@ -257,7 +258,7 @@ class BactoTraitsTransform(Transform):
             ):
                 # get 3 columns from bacdive.tsv: ['bacdive_id', 'culture_collection_number', 'ncbitaxon_id']
                 bacdive_reader = csv.DictReader(bacdive_file, delimiter="\t")
-                mapping_writer = csv.writer(mapping_handle, delimiter="\t")
+                mapping_writer = tsv_writer(mapping_handle)
                 mapping_writer.writerow(["Bacdive_ID", BACDIVE_CULTURE_COLLECTION_NUMBER_COLUMN, NCBITAXON_ID_COLUMN])
                 for row in bacdive_reader:
                     collection_number_list = row[BACDIVE_CULTURE_COLLECTION_NUMBER_COLUMN]
@@ -307,10 +308,10 @@ class BactoTraitsTransform(Transform):
             open(self.output_edge_file, "w") as edge,
         ):
             reader = csv.reader(infile, delimiter=";")
-            writer = csv.writer(outfile, delimiter="\t")
-            node_writer = csv.writer(node, delimiter="\t")
+            writer = tsv_writer(outfile)
+            node_writer = tsv_writer(node)
             node_writer.writerow(self.node_header)
-            edge_writer = csv.writer(edge, delimiter="\t")
+            edge_writer = tsv_writer(edge)
             edge_writer.writerow(self.edge_header)
 
             # Load custom YAML mappings for terms not in METPO

--- a/kg_microbe/transform_utils/bakta/create_samn_mapping.py
+++ b/kg_microbe/transform_utils/bakta/create_samn_mapping.py
@@ -24,6 +24,8 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, Optional
 
+from kg_microbe.utils.tsv_io import tsv_writer
+
 try:
     from Bio import Entrez
 except ImportError:
@@ -116,7 +118,7 @@ def create_mapping_file(samn_ids: list, output_file: Path, email: str, delay: fl
 
     # Create output file with header
     with open(output_file, "w", newline="") as f:
-        writer = csv.writer(f, delimiter="\t")
+        writer = tsv_writer(f)
         writer.writerow(["samn_id", "ncbitaxon_id"])
 
         # Query each SAMN ID

--- a/kg_microbe/transform_utils/ctd/ctd.py
+++ b/kg_microbe/transform_utils/ctd/ctd.py
@@ -30,6 +30,7 @@ from kg_microbe.transform_utils.constants import (
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.chemical_mapping_utils import ChemicalMappingLoader
 from kg_microbe.utils.pandas_utils import drop_duplicates
+from kg_microbe.utils.tsv_io import tsv_writer
 
 RELATIONS_DICT = {
     CHEMICAL_TO_DISEASE_EDGE: ASSOCIATED_WITH,
@@ -78,8 +79,8 @@ class CTDTransform(Transform):
         edge_filename = self.output_edge_file
 
         with open(node_filename, "w") as nf, open(edge_filename, "w") as ef:
-            nodes_file_writer = csv.writer(nf, delimiter="\t")
-            edges_file_writer = csv.writer(ef, delimiter="\t")
+            nodes_file_writer = tsv_writer(nf)
+            edges_file_writer = tsv_writer(ef)
 
             nodes_file_writer.writerow(self.node_header)
             edges_file_writer.writerow(self.edge_header)

--- a/kg_microbe/transform_utils/disbiome/disbiome.py
+++ b/kg_microbe/transform_utils/disbiome/disbiome.py
@@ -29,6 +29,7 @@ from kg_microbe.transform_utils.constants import (
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.transform_utils.wallen_etal.wallen_etal import MICROBE_NOT_FOUND_STR
 from kg_microbe.utils.pandas_utils import drop_duplicates
+from kg_microbe.utils.tsv_io import tsv_writer
 
 
 class DisbiomeTransform(Transform):
@@ -139,14 +140,14 @@ class DisbiomeTransform(Transform):
         # Write to tmp file
         os.makedirs(DISBIOME_TMP_DIR, exist_ok=True)
         with open(DISBIOME_TMP_FILEPATH, mode="w", newline="") as file:
-            tmp_writer = csv.writer(file, delimiter="\t")
+            tmp_writer = tsv_writer(file)
             tmp_writer.writerow(["orig_node", "entity_uri"])
             for key, value in self.microbe_labels_dict.items():
                 tmp_writer.writerow([key, value])
 
         with open(node_filename, "w") as nf, open(edge_filename, "w") as ef:
-            nodes_file_writer = csv.writer(nf, delimiter="\t")
-            edges_file_writer = csv.writer(ef, delimiter="\t")
+            nodes_file_writer = tsv_writer(nf)
+            edges_file_writer = tsv_writer(ef)
 
             nodes_file_writer.writerow(self.node_header)
             edges_file_writer.writerow(self.edge_header)

--- a/kg_microbe/transform_utils/madin_etal/madin_etal.py
+++ b/kg_microbe/transform_utils/madin_etal/madin_etal.py
@@ -77,6 +77,7 @@ from kg_microbe.utils.mapping_file_utils import load_metpo_mappings, uri_to_curi
 from kg_microbe.utils.ner_utils import annotate
 from kg_microbe.utils.ontology_utils import get_chebi_adapter
 from kg_microbe.utils.pandas_utils import drop_duplicates
+from kg_microbe.utils.tsv_io import tsv_writer
 
 OUTPUT_FILE_SUFFIX = "_ner.tsv"
 STOPWORDS_FN = "stopwords.txt"
@@ -378,10 +379,10 @@ class MadinEtAlTransform(Transform):
             open(self.output_edge_file, "w") as edge,
         ):
             reader = csv.DictReader(f)
-            node_writer = csv.writer(node, delimiter="\t")
+            node_writer = tsv_writer(node)
             node_writer.writerow(self.node_header)
             node_writer.writerows(role_nodes)
-            edge_writer = csv.writer(edge, delimiter="\t")
+            edge_writer = tsv_writer(edge)
             edge_writer.writerow(self.edge_header)
             edge_writer.writerows(role_edges)
 

--- a/kg_microbe/transform_utils/mediadive/mediadive.py
+++ b/kg_microbe/transform_utils/mediadive/mediadive.py
@@ -15,7 +15,6 @@ Output these two files:
 - edges.tsv
 """
 
-import csv
 import json
 import math
 import os
@@ -125,6 +124,7 @@ from kg_microbe.utils.dummy_tqdm import DummyTqdm
 from kg_microbe.utils.pandas_utils import (
     drop_duplicates,
 )
+from kg_microbe.utils.tsv_io import tsv_writer
 
 #: HTTP response cache for the API fallback, kept beside the bulk JSONs. The
 #: old name is the file `requests_cache.install_cache("mediadive_cache")` left
@@ -920,13 +920,13 @@ class MediaDiveTransform(Transform):
             open(self.output_node_file, "w") as node,
             open(self.output_edge_file, "w") as edge,
         ):
-            writer = csv.writer(tsvfile, delimiter="\t")
+            writer = tsv_writer(tsvfile)
             # Write the column names to the output file
             writer.writerow(COLUMN_NAMES)
 
-            node_writer = csv.writer(node, delimiter="\t")
+            node_writer = tsv_writer(node)
             node_writer.writerow(self.node_header)
-            edge_writer = csv.writer(edge, delimiter="\t")
+            edge_writer = tsv_writer(edge)
             edge_writer.writerow(self.edge_header)
 
             # Choose the appropriate context manager based on the flag

--- a/kg_microbe/transform_utils/metatraits/io.py
+++ b/kg_microbe/transform_utils/metatraits/io.py
@@ -1,9 +1,10 @@
 """File I/O primitives for the MetaTraits transform."""
 
-import csv
 import gzip
 from pathlib import Path
 from typing import IO, List
+
+from kg_microbe.utils.tsv_io import tsv_writer
 
 
 def open_maybe_gzipped(path: Path) -> IO[str]:
@@ -41,7 +42,7 @@ class StreamingRowWriter:
         """Open the output and write its header."""
         self.output_file.parent.mkdir(exist_ok=True, parents=True)
         self.file_handle = self.output_file.open("w", newline="", encoding="utf-8")
-        self.writer = csv.writer(self.file_handle, delimiter="\t")
+        self.writer = tsv_writer(self.file_handle)
         self.writer.writerow(self.header)
         return self
 

--- a/kg_microbe/transform_utils/metatraits/metatraits.py
+++ b/kg_microbe/transform_utils/metatraits/metatraits.py
@@ -62,6 +62,7 @@ from kg_microbe.utils.ontology_utils import (  # noqa: E402
     _db_is_for_ontology,
 )
 from kg_microbe.utils.pandas_utils import drop_duplicates  # noqa: E402
+from kg_microbe.utils.tsv_io import tsv_writer  # noqa: E402
 
 # Input file names (transform accepts either ncbi_* or metatraits_* convention)
 # NOTE: Only process species-level files, not genus or family summaries
@@ -3029,19 +3030,19 @@ class MetaTraitsTransform(Transform):
 
         # Write unmapped traits
         with open(self.unmapped_traits_file, "w", newline="") as uf:
-            uw = csv.writer(uf, delimiter="\t")
+            uw = tsv_writer(uf)
             uw.writerow(["trait_name", "tax_name", "majority_label", "num_observations"])
             uw.writerows(all_unmapped)
 
         # Write measurement traits
         with open(self.measurement_traits_file, "w", newline="") as mf:
-            mw = csv.writer(mf, delimiter="\t")
+            mw = tsv_writer(mf)
             mw.writerow(["trait_name", "tax_name", "majority_label", "num_observations"])
             mw.writerows(all_measurements)
 
         # Write unresolved taxa
         with open(self.unresolved_taxa_file, "w", newline="") as rf:
-            rw = csv.writer(rf, delimiter="\t")
+            rw = tsv_writer(rf)
             rw.writerow(["tax_name"])
             for t in sorted(all_unresolved):
                 rw.writerow([t])
@@ -3574,17 +3575,17 @@ class MetaTraitsTransform(Transform):
 
         # Write unmapped traits, measurement traits, and unresolved taxa
         with open(self.unmapped_traits_file, "w", newline="") as uf:
-            uw = csv.writer(uf, delimiter="\t")
+            uw = tsv_writer(uf)
             uw.writerow(["trait_name", "tax_name", "majority_label", "num_observations"])
             uw.writerows(unmapped_traits)
 
         with open(self.measurement_traits_file, "w", newline="") as mf:
-            mw = csv.writer(mf, delimiter="\t")
+            mw = tsv_writer(mf)
             mw.writerow(["trait_name", "tax_name", "majority_label", "num_observations"])
             mw.writerows(measurement_traits)
 
         with open(self.unresolved_taxa_file, "w", newline="") as rf:
-            rw = csv.writer(rf, delimiter="\t")
+            rw = tsv_writer(rf)
             rw.writerow(["tax_name"])
             for t in sorted(set(unresolved_taxa)):
                 rw.writerow([t])

--- a/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
+++ b/kg_microbe/transform_utils/metatraits_gtdb/metatraits_gtdb.py
@@ -17,6 +17,7 @@ from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.chemical_mapping_utils import ChemicalMappingLoader
 from kg_microbe.utils.mapping_file_utils import load_metpo_mappings
 from kg_microbe.utils.microbial_trait_mappings import load_microbial_trait_mappings
+from kg_microbe.utils.tsv_io import tsv_dict_writer
 
 # Input file names for GTDB metatraits (species-level only)
 METATRAITS_GTDB_INPUT_FILES = [
@@ -474,7 +475,7 @@ class MetaTraitsGTDBTransform(MetaTraitsTransform):
         # Append to existing edge file
         if hierarchical_edges:
             with open(self.output_edge_file, "a") as f:
-                writer = csv.DictWriter(f, fieldnames=self.edge_header, delimiter="\t")
+                writer = tsv_dict_writer(f, fieldnames=self.edge_header)
                 for edge in hierarchical_edges:
                     # Fill in missing columns with empty strings
                     for col in self.edge_header:

--- a/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
+++ b/kg_microbe/transform_utils/microbedecoder/microbedecoder.py
@@ -107,6 +107,7 @@ from kg_microbe.transform_utils.microbedecoder.utils import (
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.lpsn_utils import resolve_accepted_records
 from kg_microbe.utils.pandas_utils import drop_duplicates
+from kg_microbe.utils.tsv_io import tsv_dict_writer, tsv_writer
 
 logger = logging.getLogger(__name__)
 
@@ -251,8 +252,8 @@ class MicrobeDecoderTransform(Transform):
             open(self.output_node_file, "w", newline="") as node_fh,
             open(self.output_edge_file, "w", newline="") as edge_fh,
         ):
-            node_writer = csv.writer(node_fh, delimiter="\t")
-            edge_writer = csv.writer(edge_fh, delimiter="\t")
+            node_writer = tsv_writer(node_fh)
+            edge_writer = tsv_writer(edge_fh)
             node_writer.writerow(self.node_header)
             edge_writer.writerow(self.edge_header)
 
@@ -790,10 +791,9 @@ class MicrobeDecoderTransform(Transform):
         # Sort by count desc, then CURIE asc for stable output.
         rows.sort(key=lambda r: (-int(r["occurrences"]), r["placeholder_curie"]))
         with open(target, "w", newline="") as fh:
-            writer = csv.DictWriter(
+            writer = tsv_dict_writer(
                 fh,
                 fieldnames=["placeholder_curie", "category", "label", "source_columns", "occurrences"],
-                delimiter="\t",
             )
             writer.writeheader()
             writer.writerows(rows)

--- a/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
+++ b/kg_microbe/transform_utils/ontologies_stubs/ontologies_stubs_transform.py
@@ -52,7 +52,6 @@ fuller record.
 
 from __future__ import annotations
 
-import csv
 import gzip
 import json
 import re
@@ -76,6 +75,7 @@ from kg_microbe.utils.stub_curie_collection import (
 from kg_microbe.utils.stub_curie_collection import (
     REPO_ROOT as _STUB_REPO_ROOT,
 )
+from kg_microbe.utils.tsv_io import tsv_writer
 
 # Stub ontologies handled by this transform. Each entry maps the canonical
 # CURIE prefix (case-sensitive — must match how the prefix appears in
@@ -904,7 +904,7 @@ class OntologiesStubsTransform(Transform):
         """Write ``rows`` to ``path`` using the canonical Transform node header."""
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", newline="", encoding="utf-8") as fh:
-            writer = csv.writer(fh, delimiter="\t", lineterminator="\n")
+            writer = tsv_writer(fh)
             writer.writerow(self.node_header)
             for row in rows:
                 writer.writerow(["" if cell is None else cell for cell in row])
@@ -913,7 +913,7 @@ class OntologiesStubsTransform(Transform):
         """Write ``rows`` to ``path`` using the canonical Transform edge header."""
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", newline="", encoding="utf-8") as fh:
-            writer = csv.writer(fh, delimiter="\t", lineterminator="\n")
+            writer = tsv_writer(fh)
             writer.writerow(self.edge_header)
             for row in rows:
                 writer.writerow(["" if cell is None else cell for cell in row])

--- a/kg_microbe/transform_utils/prego/prego.py
+++ b/kg_microbe/transform_utils/prego/prego.py
@@ -27,7 +27,6 @@ threshold on confidence.
 
 from __future__ import annotations
 
-import csv
 import os
 import pickle
 import tarfile
@@ -93,6 +92,7 @@ from kg_microbe.transform_utils.prego.utils import (
 )
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.atomic_io import atomic_write
+from kg_microbe.utils.tsv_io import tsv_writer
 
 # ---------------------------------------------------------------------------
 # Edge predicates and relations. PREGO uses only biolink predicates; the
@@ -362,8 +362,8 @@ class PregoTransform(Transform):
             self.output_node_file.open("w", newline="") as node_fh,
             self.output_edge_file.open("w", newline="") as edge_fh,
         ):
-            node_writer = csv.writer(node_fh, delimiter="\t")
-            edge_writer = csv.writer(edge_fh, delimiter="\t")
+            node_writer = tsv_writer(node_fh)
+            edge_writer = tsv_writer(edge_fh)
             node_writer.writerow(self.node_header)
             edge_writer.writerow(self.edge_header)
 
@@ -1111,7 +1111,7 @@ class PregoTransform(Transform):
         first.
         """
         with self.unmapped_report_file.open("w", newline="") as fh:
-            writer = csv.writer(fh, delimiter="\t")
+            writer = tsv_writer(fh)
             writer.writerow(["reason", "exemplar_row", "occurrences", "reason_total"])
             for reason in sorted(self._drop_examples):
                 total = self._stats["rows_dropped_by_reason"][reason]

--- a/kg_microbe/transform_utils/rhea_mappings/rhea_mappings.py
+++ b/kg_microbe/transform_utils/rhea_mappings/rhea_mappings.py
@@ -79,6 +79,7 @@ from kg_microbe.utils.ontology_utils import (
     get_go_adapter,
     resolve_adapter,
 )
+from kg_microbe.utils.tsv_io import tsv_writer
 
 logger = logging.getLogger(__name__)
 
@@ -259,9 +260,9 @@ class RheaMappingsTransform(Transform):
             open(self.output_dir / "nodes.tsv", "w") as nodes_file,
             open(self.output_dir / "edges.tsv", "w") as edges_file,
         ):
-            tmp_file_writer = csv.writer(tmp_file, delimiter="\t")
-            nodes_file_writer = csv.writer(nodes_file, delimiter="\t")
-            edges_file_writer = csv.writer(edges_file, delimiter="\t")
+            tmp_file_writer = tsv_writer(tmp_file)
+            nodes_file_writer = tsv_writer(nodes_file)
+            edges_file_writer = tsv_writer(edges_file)
 
             tmp_file_writer.writerow([RHEA_ID_COLUMN, RHEA_CATEGORY_COLUMN, RHEA_NAME_COLUMN, RHEA_DIRECTION_COLUMN])
             nodes_file_writer.writerow(self.node_header)
@@ -353,7 +354,7 @@ class RheaMappingsTransform(Transform):
                                 )
 
                     with open(RHEAMAPPINGS_TMP_DIR / "all_terms.tsv", "w", newline="") as tsvfile:
-                        all_terms_writer = csv.writer(tsvfile, delimiter="\t")
+                        all_terms_writer = tsv_writer(tsvfile)
                         # Write headers
                         all_terms_writer.writerow(
                             [

--- a/kg_microbe/transform_utils/wallen_etal/wallen_etal.py
+++ b/kg_microbe/transform_utils/wallen_etal/wallen_etal.py
@@ -21,6 +21,7 @@ from kg_microbe.transform_utils.constants import (
 from kg_microbe.transform_utils.transform import Transform
 from kg_microbe.utils.atomic_io import atomic_write, cache_is_complete
 from kg_microbe.utils.pandas_utils import drop_duplicates
+from kg_microbe.utils.tsv_io import tsv_writer
 
 # Constants
 WALLEN_ETAL_TAB_NAME = "Supplementary Data 1"
@@ -113,14 +114,14 @@ class WallenEtAlTransform(Transform):
             # Atomic: guarded only by the .exists() above, so a truncated write
             # would be treated as a complete label cache on every later run.
             with atomic_write(WALLEN_ETAL_TMP_FILEPATH, mode="w", mark_complete=True, newline="") as file:
-                tmp_writer = csv.writer(file, delimiter="\t")
+                tmp_writer = tsv_writer(file)
                 tmp_writer.writerow(["orig_node", "entity_uri"])
                 for key, value in self.microbe_labels_dict.items():
                     tmp_writer.writerow([key, value])
 
         with open(node_filename, "w") as nf, open(edge_filename, "w") as ef:
-            nodes_file_writer = csv.writer(nf, delimiter="\t")
-            edges_file_writer = csv.writer(ef, delimiter="\t")
+            nodes_file_writer = tsv_writer(nf)
+            edges_file_writer = tsv_writer(ef)
 
             nodes_file_writer.writerow(self.node_header)
             edges_file_writer.writerow(self.edge_header)

--- a/tests/test_tsv_line_endings.py
+++ b/tests/test_tsv_line_endings.py
@@ -1,4 +1,4 @@
-"""KG-Microbe writes LF, not CRLF, in every TSV another tool parses (#1041)."""
+r"""KG-Microbe writes LF, not CRLF, in every TSV another tool parses (#1041)."""
 
 import ast
 import io
@@ -9,22 +9,25 @@ import pytest
 from kg_microbe.utils.tsv_io import tsv_dict_writer, tsv_writer
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+TRANSFORMED = REPO_ROOT / "data" / "transformed"
 
-#: Modules that write a nodes/edges TSV or a report beside one. A bare
-#: ``csv.writer`` here reintroduces CRLF into the shipped graph.
-GRAPH_WRITERS = (
-    "kg_microbe/merge_utils/merge_kg.py",
-    "kg_microbe/merge_utils/invariants.py",
-    "kg_microbe/transform_utils/gtdb/gtdb.py",
-    "kg_microbe/transform_utils/lpsn/lpsn.py",
-    "kg_microbe/transform_utils/lpsn_api/lpsn_api.py",
-    "kg_microbe/transform_utils/gold/gold.py",
-    "kg_microbe/transform_utils/bacdive/bacdive.py",
-)
+#: Every module that can write a graph TSV, enumerated rather than listed.
+#: The first version of this guard carried a hand-written list of seven files
+#: and silently missed `prego`, `rhea_mappings`, `metatraits`,
+#: `metatraits_gtdb` and `microbedecoder` -- 11 CRLF files still shipped. A
+#: list someone has to remember to extend is the same failure mode #1035 was
+#: about, so the scan now walks the trees.
+SCANNED_TREES = ("kg_microbe/transform_utils", "kg_microbe/merge_utils")
+
+
+def _modules():
+    """Yield every Python module under the scanned trees."""
+    for tree in SCANNED_TREES:
+        yield from sorted((REPO_ROOT / tree).rglob("*.py"))
 
 
 def _bare_csv_writers(path: Path):
-    """Return the line numbers of ``csv.writer``/``csv.DictWriter`` calls without an explicit terminator."""
+    """Return line numbers of ``csv.writer``/``csv.DictWriter`` calls without an explicit terminator."""
     found = []
     for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
         if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
@@ -39,24 +42,53 @@ def _bare_csv_writers(path: Path):
     return found
 
 
-@pytest.mark.parametrize("relpath", GRAPH_WRITERS)
-def test_graph_writers_do_not_use_a_bare_csv_writer(relpath):
+@pytest.mark.parametrize("module", list(_modules()), ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_no_module_uses_a_bare_csv_writer(module):
     r"""
-    csv.writer defaults to lineterminator="\\r\\n" on every platform.
+    csv.writer defaults to lineterminator="\r\n" on every platform.
 
     `newline=""` does not change it -- gold, lpsn and lpsn_api all passed
     `newline=""` and still emitted CRLF, which is how every line of the shipped
     merged graph ended with a carriage return.
     """
-    bare = _bare_csv_writers(REPO_ROOT / relpath)
+    bare = _bare_csv_writers(module)
     assert not bare, (
-        f"{relpath} constructs csv.writer/DictWriter without lineterminator at line(s) {bare}; "
-        "use kg_microbe.utils.tsv_io.tsv_writer / tsv_dict_writer"
+        f"{module.relative_to(REPO_ROOT)} constructs csv.writer/DictWriter without lineterminator "
+        f"at line(s) {bare}; use kg_microbe.utils.tsv_io.tsv_writer / tsv_dict_writer"
     )
 
 
+def test_the_scan_actually_covers_the_transforms():
+    """A glob that silently matches nothing would make every check above vacuous."""
+    modules = list(_modules())
+    assert len(modules) > 30, f"only {len(modules)} modules scanned"
+    names = {m.name for m in modules}
+    for expected in ("prego.py", "rhea_mappings.py", "metatraits.py", "merge_kg.py", "gtdb.py"):
+        assert expected in names, f"{expected} is not being scanned"
+
+
+@pytest.mark.skipif(not TRANSFORMED.is_dir(), reason="no transform output on this checkout")
+def test_no_transform_output_on_disk_has_crlf():
+    r"""
+    Enumerate the files; never guess their paths.
+
+    Both misses in the first pass came from guessing: the survey looked for
+    `data/transformed/prego/nodes.tsv` when PREGO writes to `prego_habitat`
+    (`PREGO_SHAPES=habitat` changes the output directory, #885), and it tested
+    only `nodes.tsv` for sources whose `edges.tsv` was the CRLF one. A
+    `find`-shaped check cannot make either mistake.
+    """
+    offenders = []
+    for tsv in sorted(TRANSFORMED.rglob("*.tsv")):
+        with tsv.open("rb") as handle:
+            chunk = handle.read(200_000)
+        if b"\r\n" in chunk:
+            offenders.append(str(tsv.relative_to(REPO_ROOT)))
+    assert not offenders, "CRLF in transform output (rerun these sources): " + ", ".join(offenders)
+
+
 def test_the_helper_writes_lf_where_a_bare_writer_writes_crlf():
-    """The premise, pinned: this is the difference the whole change rests on."""
+    r"""The premise, pinned: this is the difference the whole change rests on."""
     import csv
 
     bare = io.StringIO()
@@ -81,7 +113,7 @@ def test_an_empty_last_field_is_empty_not_a_carriage_return():
     r"""
     The corruption this prevents: a trailing CR lands in the last column.
 
-    An "empty" last field then holds "\\r", so a truthiness test on it inverts --
+    An "empty" last field then holds "\r", so a truthiness test on it inverts --
     which is how a count of gtdb nodes carrying a `same_as` read 901,341 instead
     of 447,137.
     """


### PR DESCRIPTION
Reopens and completes #1041. **#1042 was incomplete and I called it done.**

## What was still shipping CRLF

11 files, five sources — found only by enumerating every TSV instead of looping over guessed names:

| file | why the first pass missed it |
|---|---|
| `prego_habitat/nodes.tsv`, `edges.tsv`, `unmapped_associations.tsv` | the survey looked in `data/transformed/prego/` — PREGO writes to `prego_habitat` (`PREGO_SHAPES=habitat` changes the output dir, #885's exact confusion), so the source was skipped entirely |
| `rhea_mappings/edges.tsv` | the loop tested `nodes.tsv` and stopped; that one happens to be LF |
| `metatraits/`, `metatraits_gtdb/` × 3 reports, `microbedecoder/unmapped_labels.tsv` | never in the hand-written module list |

Two of those are **graph files that feed the merge**.

## Fix

**Every** `csv.writer`/`DictWriter` under `transform_utils/` and `merge_utils/` now goes through `tsv_io` — 37 call sites across 14 modules. (`scripts/` is out of scope and untouched.)

## The guard no longer carries a list

That was the real defect. `GRAPH_WRITERS` was seven hand-written paths; a list someone must remember to extend is the failure mode **#1035** was about, and it drifted within a day. It now walks both trees — **68 modules** — with a companion test asserting the walk found >30 and specifically reaches `prego`, `rhea_mappings`, `metatraits`, `merge_kg`, `gtdb`, so a glob that silently matched nothing can't make every check vacuous.

## The acceptance test enumerates too

```python
for tsv in sorted(TRANSFORMED.rglob("*.tsv")):   # not a source-name loop
```

It fails today, naming all 11 offenders — correct behaviour: the code is fixed, the output needs regenerating. It skips where `data/transformed` is absent, so CI is unaffected.

## Verification

- 68/68 modules pass the AST guard; `pytest -k "prego or rhea or metatraits or microbedecoder or mediadive or bactotraits or madin or stubs or gtdb or merge"` → **482 passed, 4 skipped**.
- Not blocking the merged artifact: proven empirically that `_normalize_nodes_tsv` turns a CRLF input into pure LF with no stray `\r` in any field, so `merged-kg.tar.gz` is LF regardless of what transforms hand it.

## Reruns

`prego`, `rhea_mappings`, `metatraits`, `metatraits_gtdb`, `microbedecoder`, `bactotraits`, `madin_etal`, `mediadive` — ~64 min, dominated by `metatraits` at 42. No shared code moved, so nothing else goes stale and no dependents cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPpUDtT57QRMteXw7dLvRo
